### PR TITLE
fix: install provider as user plugin by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 > **YantrikDB as a memory provider for [Hermes Agent](https://github.com/NousResearch/hermes-agent).** Self-maintaining memory — canonicalizes duplicates, surfaces contradictions, explains recall — in a drop-in plugin. As of **v0.2.0** the default backend is **in-process** (`pip install` and go, no separate server).
 
-This repository **is** the canonical distribution. Per Hermes maintainer guidance, new memory providers aren't being merged upstream — the recommended pattern is standalone plugins that users install via `pip` and copy into their Hermes tree. That keeps the version cadence, CI gating, issue triage, and review cycle on the plugin author's side, so fixes ship the same day they're ready instead of waiting on upstream review bandwidth.
+This repository **is** the canonical distribution. Per Hermes maintainer guidance, new memory providers aren't being merged upstream — the recommended pattern is standalone plugins that users install via `pip` and register with their Hermes home directory. That keeps the version cadence, CI gating, issue triage, and review cycle on the plugin author's side, so fixes ship the same day they're ready instead of waiting on upstream review bandwidth.
 
 ## Install (default — embedded backend)
 
@@ -22,22 +22,22 @@ The v0.2.0 default backend is **in-process**: no separate server, no token, no G
 ```bash
 hermes plugins install yantrikos/yantrikdb-hermes-plugin
 pip install yantrikdb                    # ~10 MB; in the same Python env as Hermes
-hermes config set memory.provider yantrikdb
+hermes memory setup                      # → Select "yantrikdb" and press Enter
 hermes memory status                     # → Provider: yantrikdb  Status: available ✓
 ```
 
 `hermes plugins install` clones the repo into `~/.hermes/plugins/yantrikdb/` based on `plugin.yaml`'s `name:` field. The `pip install yantrikdb` step gets the engine — `hermes plugins install` doesn't auto-install pip dependencies, so this is a separate step. **Crucially: pip-install into the same Python environment Hermes runs from.** If Hermes was installed via `pipx`, use `pipx inject hermes-agent yantrikdb`. If you're using a regular venv, source it first.
 
-### Option B — `pip install yantrikdb-hermes-plugin` (bundled-discovery path)
+### Option B — `pip install yantrikdb-hermes-plugin` (bundled package path)
 
 ```bash
-pip install yantrikdb-hermes-plugin     # pulls yantrikdb engine + the plugin source
-yantrikdb-hermes install ~/.hermes/hermes-agent
-hermes config set memory.provider yantrikdb
-hermes memory status                     # → Provider: yantrikdb  Status: available ✓
+pip install yantrikdb-hermes-plugin     # pulls yantrikdb engine + the provider source
+yantrikdb-hermes install                # registers ~/.hermes/plugins/yantrikdb
+hermes memory setup                     # → Select "yantrikdb" and press Enter
+hermes memory status                    # → Provider: yantrikdb  Status: available ✓
 ```
 
-This drops the plugin source into Hermes' bundled `plugins/memory/yantrikdb/` and pulls all deps in one step. Use this when you want a single `pip install` to handle both the plugin and the engine, or when you don't want to add a user-plugin entry.
+`yantrikdb-hermes install` registers the pip-installed provider with Hermes by creating `~/.hermes/plugins/yantrikdb` (or `$HERMES_HOME/plugins/yantrikdb`) as a symlink to the installed provider package. Use `yantrikdb-hermes install --copy` if your environment prefers physical files instead of a symlink.
 
 ### Same-venv guidance (both options)
 

--- a/tests/test_cli_installer.py
+++ b/tests/test_cli_installer.py
@@ -1,0 +1,73 @@
+"""Tests for the yantrikdb-hermes installer CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+CLI_PATH = Path(__file__).resolve().parents[1] / "yantrikdb" / "cli.py"
+
+
+def _load_cli():
+    spec = importlib.util.spec_from_file_location("yantrikdb_cli_under_test", CLI_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_install_defaults_to_user_plugin_symlink(tmp_path, capsys):
+    cli = _load_cli()
+    hermes_home = tmp_path / "home"
+
+    rc = cli.main(["install", "--hermes-home", str(hermes_home)])
+
+    assert rc == 0
+    target = hermes_home / "plugins" / "yantrikdb"
+    assert target.is_symlink()
+    assert target.resolve() == CLI_PATH.parent.resolve()
+    out = capsys.readouterr().out
+    assert "linked yantrikdb plugin into" in out
+    assert "hermes config set memory.provider yantrikdb" in out
+
+
+def test_install_copy_mode_creates_user_plugin_directory(tmp_path):
+    cli = _load_cli()
+    hermes_home = tmp_path / "home"
+
+    rc = cli.main(["install", "--hermes-home", str(hermes_home), "--copy"])
+
+    assert rc == 0
+    target = hermes_home / "plugins" / "yantrikdb"
+    assert target.is_dir()
+    assert not target.is_symlink()
+    assert (target / "__init__.py").exists()
+    assert (target / "plugin.yaml").exists()
+
+
+def test_install_refuses_existing_target_without_force(tmp_path, capsys):
+    cli = _load_cli()
+    hermes_home = tmp_path / "home"
+    target = hermes_home / "plugins" / "yantrikdb"
+    target.mkdir(parents=True)
+
+    rc = cli.main(["install", "--hermes-home", str(hermes_home)])
+
+    assert rc == 3
+    err = capsys.readouterr().err
+    assert "already exists" in err
+    assert "--force" in err
+
+
+def test_legacy_positional_path_still_installs_into_checkout(tmp_path):
+    cli = _load_cli()
+    hermes_root = tmp_path / "hermes-agent"
+    (hermes_root / "plugins" / "memory").mkdir(parents=True)
+
+    rc = cli.main(["install", str(hermes_root)])
+
+    assert rc == 0
+    target = hermes_root / "plugins" / "memory" / "yantrikdb"
+    assert target.is_dir()
+    assert (target / "__init__.py").exists()
+    assert (target / "plugin.yaml").exists()

--- a/yantrikdb/cli.py
+++ b/yantrikdb/cli.py
@@ -1,44 +1,111 @@
-"""``yantrikdb-hermes`` CLI — copy the plugin source into a Hermes install.
+"""``yantrikdb-hermes`` CLI — expose the pip-installed provider to Hermes.
 
-Hermes loads memory plugins from ``$HERMES_ROOT/plugins/memory/<name>/``.
-Pip alone can't drop files there because Hermes' plugin discovery is
-filesystem-based, not import-path-based. This CLI bridges the gap:
+Hermes discovers user-installed memory providers from
+``$HERMES_HOME/plugins/<name>/``. Pip installs this package on Python's
+import path, but Hermes' memory-provider discovery is filesystem-based, so
+this CLI creates the small bridge:
 
     pip install yantrikdb-hermes-plugin
-    yantrikdb-hermes install ~/hermes-agent
+    yantrikdb-hermes install
 
-After installation, configure Hermes via ``$HERMES_HOME/.env``:
-
-    YANTRIKDB_MODE=embedded
-    YANTRIKDB_DB_PATH=~/.hermes/yantrikdb-memory.db
-    YANTRIKDB_NAMESPACE=hermes
-
-Then ``hermes memory status`` should show the plugin as available.
+By default the bridge is a symlink from ``$HERMES_HOME/plugins/yantrikdb``
+to this pip-installed provider package, so package upgrades are picked up
+without copying files again. Use ``--copy`` on platforms where symlinks are
+not desirable.
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import shutil
 import sys
 from pathlib import Path
+
+DEFAULT_PLUGIN_NAME = "yantrikdb"
 
 
 def _plugin_source_dir() -> Path:
     """Return the directory of the installed yantrikdb_hermes_plugin package.
 
     pyproject.toml maps the on-disk ``yantrikdb/`` directory to the
-    importable package name ``yantrikdb_hermes_plugin``. The plugin
-    source lives in this package's directory; we copy it (renamed to
-    ``yantrikdb``) into the user's Hermes install.
+    importable package name ``yantrikdb_hermes_plugin``. The provider source
+    lives in this package's directory; Hermes should see it as a plugin named
+    ``yantrikdb``.
     """
     return Path(__file__).resolve().parent
 
 
-def cmd_install(args: argparse.Namespace) -> int:
+def _default_hermes_home() -> Path:
+    """Return the Hermes home directory used for user-installed plugins."""
+    return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")).expanduser().resolve()
+
+
+def _copy_provider(src: Path, target: Path) -> None:
+    target.mkdir(parents=True, exist_ok=False)
+    for entry in src.iterdir():
+        if entry.name == "__pycache__":
+            continue
+        if entry.is_dir():
+            shutil.copytree(entry, target / entry.name)
+        else:
+            shutil.copy2(entry, target / entry.name)
+
+
+def _replace_target(target: Path, *, force: bool) -> None:
+    if not target.exists() and not target.is_symlink():
+        return
+    if not force:
+        raise FileExistsError(
+            f"{target} already exists. Re-run with --force to overwrite, "
+            "or remove it first."
+        )
+    if target.is_symlink() or target.is_file():
+        target.unlink()
+    else:
+        shutil.rmtree(target)
+
+
+def _install_user_plugin(args: argparse.Namespace) -> int:
+    hermes_home = Path(args.hermes_home).expanduser().resolve() if args.hermes_home else _default_hermes_home()
+    plugins_dir = hermes_home / "plugins"
+    target = plugins_dir / DEFAULT_PLUGIN_NAME
+    src = _plugin_source_dir()
+
+    plugins_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        _replace_target(target, force=args.force)
+    except FileExistsError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 3
+
+    if args.copy:
+        _copy_provider(src, target)
+        action = "copied"
+    else:
+        target.symlink_to(src, target_is_directory=True)
+        action = "linked"
+
+    print(f"{action} yantrikdb plugin into {target}")
+    print()
+    print("Next steps:")
+    print("  1. hermes config set memory.provider yantrikdb")
+    print(f"  2. configure {hermes_home}/.env if you want to override defaults:")
+    print("       YANTRIKDB_MODE=embedded")
+    print(f"       YANTRIKDB_DB_PATH={hermes_home}/yantrikdb-memory.db")
+    print("       YANTRIKDB_NAMESPACE=hermes")
+    print("  3. hermes memory status     # should show: Status: available [OK]")
+    print()
+    print("Skills (opt-in, v0.3.0+): set YANTRIKDB_SKILLS_ENABLED=true")
+    return 0
+
+
+def _install_legacy_source_tree(args: argparse.Namespace) -> int:
+    """Backward-compatible install path for older Hermes checkouts/docs."""
     hermes_root = Path(args.hermes_root).expanduser().resolve()
     plugins_memory = hermes_root / "plugins" / "memory"
-    target = plugins_memory / "yantrikdb"
+    target = plugins_memory / DEFAULT_PLUGIN_NAME
 
     if not plugins_memory.is_dir():
         print(
@@ -48,50 +115,32 @@ def cmd_install(args: argparse.Namespace) -> int:
         )
         return 2
 
-    if target.exists():
-        if not args.force:
-            print(
-                f"error: {target} already exists. Re-run with --force to overwrite, "
-                "or remove it first.",
-                file=sys.stderr,
-            )
-            return 3
-        shutil.rmtree(target)
+    try:
+        _replace_target(target, force=args.force)
+    except FileExistsError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 3
 
-    src = _plugin_source_dir()
-    target.mkdir(parents=True, exist_ok=False)
-    for entry in src.iterdir():
-        if entry.name == "cli.py":
-            # The CLI is a packaging concern, not part of the plugin Hermes loads.
-            continue
-        if entry.name == "__pycache__":
-            continue
-        if entry.is_dir():
-            shutil.copytree(entry, target / entry.name)
-        else:
-            shutil.copy2(entry, target / entry.name)
-
-    # Use ASCII-only output so Windows cp1252 consoles don't choke.
-    # Hermes' UI handles unicode fine; this is the bare CLI install path.
-    print(f"installed yantrikdb plugin into {target}")
+    _copy_provider(_plugin_source_dir(), target)
+    print(f"copied yantrikdb plugin into {target}")
     print()
     print("Next steps:")
     print("  1. hermes config set memory.provider yantrikdb")
-    print(f"  2. configure {hermes_root}/.env (or $HERMES_HOME/.env):")
-    print("       YANTRIKDB_MODE=embedded")
-    print("       YANTRIKDB_DB_PATH=~/.hermes/yantrikdb-memory.db")
-    print("       YANTRIKDB_NAMESPACE=hermes")
-    print("  3. hermes memory status     # should show: Status: available [OK]")
-    print()
-    print("Skills (opt-in, v0.3.0+): set YANTRIKDB_SKILLS_ENABLED=true")
+    print("  2. hermes memory status     # should show: Status: available [OK]")
     return 0
 
 
-def cmd_path(args: argparse.Namespace) -> int:
-    """Print the on-disk path of the installed plugin source.
+def cmd_install(args: argparse.Namespace) -> int:
+    if args.hermes_root:
+        return _install_legacy_source_tree(args)
+    return _install_user_plugin(args)
 
-    Useful for users who'd rather symlink than copy:
-        ln -s "$(yantrikdb-hermes path)" ~/hermes-agent/plugins/memory/yantrikdb
+
+def cmd_path(args: argparse.Namespace) -> int:
+    """Print the on-disk path of the installed provider source.
+
+    Useful for users who would rather create their own symlink:
+        ln -s "$(yantrikdb-hermes path)" "$HERMES_HOME/plugins/yantrikdb"
     """
     print(_plugin_source_dir())
     return 0
@@ -101,31 +150,47 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="yantrikdb-hermes",
         description=(
-            "Manage the YantrikDB Hermes memory plugin installed via pip. "
-            "Hermes loads plugins from $HERMES_ROOT/plugins/memory/, so this "
-            "CLI bridges the pip → filesystem gap."
+            "Manage the YantrikDB Hermes memory provider installed via pip. "
+            "Hermes loads memory providers from $HERMES_HOME/plugins/, so this "
+            "CLI bridges the pip package to Hermes' filesystem discovery."
         ),
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     p_install = sub.add_parser(
         "install",
-        help="copy the plugin source into a Hermes Agent checkout",
+        help="register the pip-installed provider with Hermes",
     )
     p_install.add_argument(
         "hermes_root",
-        help="path to your hermes-agent checkout (the directory containing 'plugins/')",
+        nargs="?",
+        help=(
+            "deprecated: path to a Hermes Agent checkout. If supplied, the "
+            "provider is copied into <hermes_root>/plugins/memory/yantrikdb. "
+            "Omit this argument to install as a user plugin under $HERMES_HOME/plugins/."
+        ),
+    )
+    p_install.add_argument(
+        "--hermes-home",
+        type=str,
+        default=None,
+        help="Hermes home directory for user-plugin install (default: $HERMES_HOME or ~/.hermes)",
+    )
+    p_install.add_argument(
+        "--copy",
+        action="store_true",
+        help="copy files instead of creating a symlink for the user-plugin install",
     )
     p_install.add_argument(
         "-f", "--force",
         action="store_true",
-        help="overwrite an existing plugins/memory/yantrikdb/ directory",
+        help="overwrite an existing yantrikdb provider directory or symlink",
     )
     p_install.set_defaults(func=cmd_install)
 
     p_path = sub.add_parser(
         "path",
-        help="print the on-disk path of the installed plugin source",
+        help="print the on-disk path of the installed provider source",
     )
     p_path.set_defaults(func=cmd_path)
 


### PR DESCRIPTION
## Summary
- change `yantrikdb-hermes install` to register the provider under `$HERMES_HOME/plugins/yantrikdb` by default
- use a symlink by default so pip package upgrades are picked up without re-copying files; add `--copy` for environments that prefer physical files
- keep the old positional Hermes checkout install path working as a backward-compatible fallback
- update README install instructions to use the pip package + installer flow instead of manual clone/move

## Test Plan
- `python -m pytest tests/test_cli_installer.py -q`
- `python -m pytest tests/test_provider.py tests/test_embedded.py tests/test_client.py tests/test_cli_installer.py -q`
- `python -m ruff check yantrikdb/cli.py tests/test_cli_installer.py`
- `git diff --check`
- smoke-tested `python yantrikdb/cli.py install --hermes-home /tmp/yantrik-hermes-home-test --force`
