### PR TITLE
fix: register pip provider via shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ uv pip install --python ~/.hermes/hermes-agent/venv/bin/python yantrikdb-hermes-
 ~/.hermes/hermes-agent/venv/bin/yantrikdb-hermes install
 ```
 
-`yantrikdb-hermes install` registers the pip-installed provider with Hermes by creating `~/.hermes/plugins/yantrikdb` (or `$HERMES_HOME/plugins/yantrikdb`) as a symlink to the installed provider package. Use `yantrikdb-hermes install --copy` if your environment prefers physical files instead of a symlink.
+`yantrikdb-hermes install` registers the pip-installed provider with Hermes by creating a lightweight shim at `~/.hermes/plugins/yantrikdb` (or `$HERMES_HOME/plugins/yantrikdb`). The shim imports the real provider from the installed `yantrikdb-hermes-plugin` package, so future package upgrades are picked up without copying the whole provider tree. Use `yantrikdb-hermes install --copy` if your environment prefers a physical copy instead of the default shim.
 
 ### Updating
 
@@ -72,7 +72,7 @@ If your Hermes CLI does not have `hermes plugins update`, reinstall the plugin s
 hermes plugins install yantrikos/yantrikdb-hermes-plugin --force
 ```
 
-Option B updates the pip package, then refreshes the registered symlink:
+Option B updates the pip package, then refreshes the registered shim:
 
 ```bash
 source ~/.hermes/hermes-agent/venv/bin/activate
@@ -89,7 +89,36 @@ uv pip install --python ~/.hermes/hermes-agent/venv/bin/python --upgrade yantrik
 uv pip install --python ~/.hermes/hermes-agent/venv/bin/python --upgrade yantrikdb-hermes-plugin
 ```
 
-`--force` replaces the registered plugin directory/symlink. Back up any plugin-local files first if you keep custom files under `~/.hermes/plugins/yantrikdb/`; normal YantrikDB settings belong in `~/.hermes/.env` and are not touched.
+`--force` replaces the registered plugin directory. Back up any plugin-local files first if you keep custom files under `~/.hermes/plugins/yantrikdb/`; normal YantrikDB settings belong in `~/.hermes/.env` and are not touched.
+
+### Uninstalling
+
+Option A uses Hermes' plugin manager for the plugin source, plus pip for the engine dependency:
+
+```bash
+source ~/.hermes/hermes-agent/venv/bin/activate
+hermes plugins remove yantrikdb
+pip uninstall yantrikdb
+hermes memory setup                      # choose another provider, or disable external memory
+hermes gateway restart                   # if Hermes is running as a gateway/service
+```
+
+Option B removes the user-plugin registration, then optionally removes the pip packages:
+
+```bash
+source ~/.hermes/hermes-agent/venv/bin/activate
+yantrikdb-hermes uninstall
+pip uninstall yantrikdb-hermes-plugin yantrikdb
+hermes memory setup                      # choose another provider, or disable external memory
+hermes gateway restart                   # if Hermes is running as a gateway/service
+```
+
+If your installed version does not yet have `yantrikdb-hermes uninstall`, remove the registration manually:
+
+```bash
+rm -rf ~/.hermes/plugins/yantrikdb
+pip uninstall yantrikdb-hermes-plugin yantrikdb
+```
 
 ### Same-venv guidance (both options)
 

--- a/tests/test_cli_installer.py
+++ b/tests/test_cli_installer.py
@@ -3,10 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
-import sys
 from pathlib import Path
-
-import pytest
 
 CLI_PATH = Path(__file__).resolve().parents[1] / "yantrikdb" / "cli.py"
 
@@ -19,11 +16,7 @@ def _load_cli():
     return module
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Windows pathlib symlink_to requires admin/developer-mode; --copy is the documented path on Windows.",
-)
-def test_install_defaults_to_user_plugin_symlink(tmp_path, capsys):
+def test_install_defaults_to_user_plugin_shim(tmp_path, capsys):
     cli = _load_cli()
     hermes_home = tmp_path / "home"
 
@@ -31,10 +24,14 @@ def test_install_defaults_to_user_plugin_symlink(tmp_path, capsys):
 
     assert rc == 0
     target = hermes_home / "plugins" / "yantrikdb"
-    assert target.is_symlink()
-    assert target.resolve() == CLI_PATH.parent.resolve()
+    assert target.is_dir()
+    assert not target.is_symlink()
+    init_text = (target / "__init__.py").read_text(encoding="utf-8")
+    assert "from yantrikdb_hermes_plugin import YantrikDBMemoryProvider" in init_text
+    assert "register_memory_provider(YantrikDBMemoryProvider())" in init_text
+    assert (target / "plugin.yaml").exists()
     out = capsys.readouterr().out
-    assert "linked yantrikdb plugin into" in out
+    assert "registered yantrikdb plugin into" in out
     assert "hermes config set memory.provider yantrikdb" in out
 
 
@@ -78,3 +75,30 @@ def test_legacy_positional_path_still_installs_into_checkout(tmp_path):
     assert target.is_dir()
     assert (target / "__init__.py").exists()
     assert (target / "plugin.yaml").exists()
+
+
+def test_uninstall_removes_user_plugin_registration(tmp_path, capsys):
+    cli = _load_cli()
+    hermes_home = tmp_path / "home"
+    assert cli.main(["install", "--hermes-home", str(hermes_home)]) == 0
+    capsys.readouterr()
+
+    rc = cli.main(["uninstall", "--hermes-home", str(hermes_home)])
+
+    assert rc == 0
+    target = hermes_home / "plugins" / "yantrikdb"
+    assert not target.exists()
+    out = capsys.readouterr().out
+    assert "removed yantrikdb plugin registration" in out
+    assert "pip uninstall yantrikdb-hermes-plugin yantrikdb" in out
+
+
+def test_uninstall_is_idempotent_when_not_installed(tmp_path, capsys):
+    cli = _load_cli()
+    hermes_home = tmp_path / "home"
+
+    rc = cli.main(["uninstall", "--hermes-home", str(hermes_home)])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "not found" in out

--- a/yantrikdb/cli.py
+++ b/yantrikdb/cli.py
@@ -8,10 +8,11 @@ this CLI creates the small bridge:
     pip install yantrikdb-hermes-plugin
     yantrikdb-hermes install
 
-By default the bridge is a symlink from ``$HERMES_HOME/plugins/yantrikdb``
-to this pip-installed provider package, so package upgrades are picked up
-without copying files again. Use ``--copy`` on platforms where symlinks are
-not desirable.
+By default the bridge is a tiny shim directory at
+``$HERMES_HOME/plugins/yantrikdb`` that imports the pip-installed provider
+package. This keeps package upgrades in site-packages while avoiding Hermes'
+user-plugin namespace from breaking package-relative imports. Use ``--copy``
+to install a physical copy instead.
 """
 
 from __future__ import annotations
@@ -52,6 +53,28 @@ def _copy_provider(src: Path, target: Path) -> None:
             shutil.copy2(entry, target / entry.name)
 
 
+def _install_provider_shim(src: Path, target: Path) -> None:
+    """Install a Hermes-discoverable shim for the pip package.
+
+    Hermes loads user memory providers under an internal namespace
+    (``_hermes_user_memory.<name>``). Loading the full pip package directory
+    directly under that namespace breaks package-relative imports in the
+    provider. The shim keeps Hermes discovery filesystem-based while importing
+    the real provider through its normal package name.
+    """
+    target.mkdir(parents=True, exist_ok=False)
+    (target / "__init__.py").write_text(
+        '"""Hermes user-plugin shim for the pip-installed YantrikDB provider."""\n'
+        "from yantrikdb_hermes_plugin import YantrikDBMemoryProvider\n\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_memory_provider(YantrikDBMemoryProvider())\n",
+        encoding="utf-8",
+    )
+    plugin_yaml = src / "plugin.yaml"
+    if plugin_yaml.exists():
+        shutil.copy2(plugin_yaml, target / "plugin.yaml")
+
+
 def _replace_target(target: Path, *, force: bool) -> None:
     if not target.exists() and not target.is_symlink():
         return
@@ -84,23 +107,8 @@ def _install_user_plugin(args: argparse.Namespace) -> int:
         _copy_provider(src, target)
         action = "copied"
     else:
-        try:
-            target.symlink_to(src, target_is_directory=True)
-            action = "linked"
-        except OSError as e:
-            # Windows raises OSError when symlinks require admin or
-            # developer-mode (the default on stock Windows). Give the user
-            # an actionable next step instead of a bare stack trace.
-            if sys.platform == "win32":
-                print(
-                    f"error: could not create symlink at {target}: {e}\n"
-                    "Windows requires admin or developer-mode for symlinks. "
-                    "Re-run with --copy to install a physical copy instead:\n"
-                    f"  yantrikdb-hermes install --hermes-home {hermes_home} --copy",
-                    file=sys.stderr,
-                )
-                return 4
-            raise
+        _install_provider_shim(src, target)
+        action = "registered"
 
     print(f"{action} yantrikdb plugin into {target}")
     print()
@@ -151,6 +159,34 @@ def cmd_install(args: argparse.Namespace) -> int:
     return _install_user_plugin(args)
 
 
+def cmd_uninstall(args: argparse.Namespace) -> int:
+    """Remove the Hermes user-plugin registration created by install."""
+    hermes_home = Path(args.hermes_home).expanduser().resolve() if args.hermes_home else _default_hermes_home()
+    target = hermes_home / "plugins" / DEFAULT_PLUGIN_NAME
+
+    if not target.exists() and not target.is_symlink():
+        print(f"yantrikdb plugin registration not found at {target}")
+        return 0
+
+    if target.is_symlink() or target.is_file():
+        target.unlink()
+    else:
+        shutil.rmtree(target)
+
+    print(f"removed yantrikdb plugin registration from {target}")
+    print()
+    print("Next steps:")
+    print("  1. If YantrikDB is the active provider, choose another provider:")
+    print("       hermes memory setup")
+    print("     or disable the external provider:")
+    print("       hermes config set memory.provider null")
+    print("  2. Optionally uninstall the pip package from the Hermes environment:")
+    print("       pip uninstall yantrikdb-hermes-plugin yantrikdb")
+    print("  3. Restart Hermes if it is running as a gateway/service:")
+    print("       hermes gateway restart")
+    return 0
+
+
 def cmd_path(args: argparse.Namespace) -> int:
     """Print the on-disk path of the installed provider source.
 
@@ -194,7 +230,7 @@ def main(argv: list[str] | None = None) -> int:
     p_install.add_argument(
         "--copy",
         action="store_true",
-        help="copy files instead of creating a symlink for the user-plugin install",
+        help="copy the full provider package instead of creating the default lightweight shim",
     )
     p_install.add_argument(
         "-f", "--force",
@@ -202,6 +238,18 @@ def main(argv: list[str] | None = None) -> int:
         help="overwrite an existing yantrikdb provider directory or symlink",
     )
     p_install.set_defaults(func=cmd_install)
+
+    p_uninstall = sub.add_parser(
+        "uninstall",
+        help="remove the Hermes user-plugin registration",
+    )
+    p_uninstall.add_argument(
+        "--hermes-home",
+        type=str,
+        default=None,
+        help="Hermes home directory for user-plugin uninstall (default: $HERMES_HOME or ~/.hermes)",
+    )
+    p_uninstall.set_defaults(func=cmd_uninstall)
 
     p_path = sub.add_parser(
         "path",


### PR DESCRIPTION
## Summary
- change `yantrikdb-hermes install` default registration from a raw symlink to a lightweight Hermes user-plugin shim
- the shim imports the real provider from the installed `yantrikdb_hermes_plugin` package, avoiding Hermes' `_hermes_user_memory.<name>` namespace from breaking the full package directory's relative imports
- add `yantrikdb-hermes uninstall` to remove the Option B user-plugin registration
- keep `--copy` as the physical-copy fallback and update README wording from symlink to shim
- add README uninstall instructions for both Option A and Option B
- update installer tests for shim and uninstall behavior

## Why
Option B currently creates `~/.hermes/plugins/yantrikdb` as a symlink to the full pip package directory. Hermes then imports that directory as `_hermes_user_memory.yantrikdb`; package-relative imports inside the provider fail in that namespace, so `hermes memory setup` / `hermes memory status` do not show YantrikDB as available.

The shim directory is filesystem-discoverable by Hermes but imports the provider via its normal package name, so the package's relative imports work.

## Test Plan
- `python -m ruff check yantrikdb/cli.py tests/test_cli_installer.py`
- `python -m pytest tests/test_cli_installer.py -q`
- `git diff --check`
- smoke-tested `python yantrikdb/cli.py install --hermes-home /tmp/yantrik-shim-test` and verified it creates a real shim directory, not a symlink
- smoke-tested `python yantrikdb/cli.py uninstall --hermes-home /tmp/yantrik-uninstall-test` and verified it removes the registration
- smoke-tested the same shim shape locally under `~/.hermes/plugins/yantrikdb`; `hermes memory status` now lists `yantrikdb (local)`
