### PR TITLE
fix: scope stats to derived namespace

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -271,6 +271,21 @@ class TestRequestFormation:
             "GET", "http://test:7438/v1/stats",
         )
         assert mock_session.request.call_args.kwargs["json"] is None
+        assert mock_session.request.call_args.kwargs["params"] is None
+        assert result == {"active_memories": 42, "open_conflicts": 1}
+
+    def test_stats_with_namespace(self, client, mock_session):
+        mock_session.request.return_value = _make_response(
+            200, {"active_memories": 42, "open_conflicts": 1},
+        )
+        result = client.stats(namespace="hermes:workspace:coder")
+        assert mock_session.request.call_args.args == (
+            "GET", "http://test:7438/v1/stats",
+        )
+        assert mock_session.request.call_args.kwargs["json"] is None
+        assert mock_session.request.call_args.kwargs["params"] == {
+            "namespace": "hermes:workspace:coder",
+        }
         assert result == {"active_memories": 42, "open_conflicts": 1}
 
     def test_resolve_conflict_keep_winner(self, client, mock_session):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -312,7 +312,7 @@ class TestHandleToolCall:
 
     def test_stats_dispatches(self, provider, mock_client):
         out = provider.handle_tool_call("yantrikdb_stats", {})
-        mock_client.stats.assert_called_once()
+        mock_client.stats.assert_called_once_with(namespace="hermes:workspace:coder")
         parsed = json.loads(out)
         assert parsed["active_memories"] == 42
         assert parsed["open_conflicts"] == 1

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -1108,7 +1108,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
         return json.dumps({"edge_id": resp.get("edge_id"), "stored": True})
 
     def _do_stats(self) -> str:
-        resp = self._require_client().stats()
+        resp = self._require_client().stats(namespace=self._namespace)
         self._record_success()
         return json.dumps({
             "active_memories": resp.get("active_memories", 0),

--- a/yantrikdb/client.py
+++ b/yantrikdb/client.py
@@ -298,6 +298,7 @@ class YantrikDBClient:
         method: str,
         path: str,
         body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         url = f"{self.config.url}{path}"
         req_id = uuid.uuid4().hex[:8]
@@ -307,6 +308,7 @@ class YantrikDBClient:
                 method,
                 url,
                 json=body,
+                params=params,
                 headers=self._headers(),
                 timeout=(self.config.connect_timeout, self.config.read_timeout),
             )
@@ -448,8 +450,9 @@ class YantrikDBClient:
             body["weight"] = float(weight)
         return self._request("POST", "/v1/relate", body)
 
-    def stats(self) -> dict[str, Any]:
-        return self._request("GET", "/v1/stats")
+    def stats(self, *, namespace: str | None = None) -> dict[str, Any]:
+        params = {"namespace": namespace} if namespace else None
+        return self._request("GET", "/v1/stats", params=params)
 
     # -- Skills (v0.3.0+) ---------------------------------------------
     #

--- a/yantrikdb/embedded.py
+++ b/yantrikdb/embedded.py
@@ -452,8 +452,8 @@ class EmbeddedYantrikDBClient:
 
     # -- Stats --------------------------------------------------------
 
-    def stats(self) -> dict[str, Any]:
-        out = self._db.stats(namespace=self.config.namespace)
+    def stats(self, *, namespace: str | None = None) -> dict[str, Any]:
+        out = self._db.stats(namespace=namespace or self.config.namespace)
         return out if isinstance(out, dict) else {}
 
     # -- Skills (v0.3.0+) ---------------------------------------------


### PR DESCRIPTION
## Summary
- pass the derived Hermes runtime namespace into `yantrikdb_stats`
- let embedded and HTTP backends accept an optional stats namespace
- add regression coverage for namespaced stats requests

## Test Plan
- `HERMES_HOME="$(mktemp -d)" python -m pytest -q`

## Context
YantrikDB derives runtime namespaces from the configured base namespace plus Hermes workspace/profile identity, e.g. `hermes:hermes:default`. Recall/remember already use this derived namespace, but stats used the base config namespace through the backend, which can report zero active memories even when the derived runtime namespace contains memories.
