### PR TITLE
fix: harden provider session handling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,8 @@ def _clean_yantrikdb_env(monkeypatch):
         "YANTRIKDB_EMBEDDER_HF",
         "YANTRIKDB_EMBEDDING_DIM",
         "YANTRIKDB_SKILLS_ENABLED",
+        "YANTRIKDB_SYNC_USER_MESSAGES",
+        "YANTRIKDB_AUTO_THINK_ON_SESSION_END",
     ):
         monkeypatch.delenv(var, raising=False)
     yield

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -69,11 +69,15 @@ class TestConfigFromEnv:
         monkeypatch.setenv("YANTRIKDB_TOKEN", "ydb_abc")
         monkeypatch.setenv("YANTRIKDB_NAMESPACE", "myns")
         monkeypatch.setenv("YANTRIKDB_TOP_K", "25")
+        monkeypatch.setenv("YANTRIKDB_SYNC_USER_MESSAGES", "false")
+        monkeypatch.setenv("YANTRIKDB_AUTO_THINK_ON_SESSION_END", "false")
         cfg = client_module.YantrikDBConfig.from_env()
         assert cfg.url == "http://remote:7438"  # trailing slash stripped
         assert cfg.token == "ydb_abc"
         assert cfg.namespace == "myns"
         assert cfg.top_k == 25
+        assert cfg.sync_user_messages is False
+        assert cfg.auto_think_on_session_end is False
 
     def test_bad_top_k_falls_back_to_default(self, client_module, monkeypatch):
         monkeypatch.setenv("YANTRIKDB_TOP_K", "not-a-number")
@@ -230,27 +234,40 @@ class TestRequestFormation:
 
     def test_think_with_pattern_mining(self, client, mock_session):
         mock_session.request.return_value = _make_response(200, {})
-        client.think(run_pattern_mining=True, consolidation_limit=100)
+        client.think(
+            run_pattern_mining=True,
+            consolidation_limit=100,
+            namespace="hermes:workspace:coder",
+        )
         body = mock_session.request.call_args.kwargs["json"]
         assert body["run_pattern_mining"] is True
         assert body["consolidation_limit"] == 100
+        assert body["namespace"] == "hermes:workspace:coder"
 
     def test_conflicts_is_get_with_no_body(self, client, mock_session):
         mock_session.request.return_value = _make_response(200, {"conflicts": []})
-        client.conflicts()
+        client.conflicts(namespace="hermes:workspace:coder")
         assert mock_session.request.call_args.args == (
             "GET", "http://test:7438/v1/conflicts",
         )
         assert mock_session.request.call_args.kwargs["json"] is None
+        assert mock_session.request.call_args.kwargs["params"] == {
+            "namespace": "hermes:workspace:coder",
+        }
 
     def test_relate(self, client, mock_session):
         mock_session.request.return_value = _make_response(200, {"edge_id": "e1"})
-        client.relate("Alice", "Acme", "works_at", weight=0.9)
+        client.relate(
+            "Alice", "Acme", "works_at",
+            weight=0.9,
+            namespace="hermes:workspace:coder",
+        )
         body = mock_session.request.call_args.kwargs["json"]
         assert body == {
             "entity": "Alice",
             "target": "Acme",
             "relationship": "works_at",
+            "namespace": "hermes:workspace:coder",
             "weight": 0.9,
         }
 

--- a/tests/test_embedded.py
+++ b/tests/test_embedded.py
@@ -490,3 +490,25 @@ class TestPathPrecedence:
         instance = mock_engine_class.return_value
         instance.set_embedder_named.assert_not_called()
         instance.set_embedder.assert_called_once()
+class TestEmbeddedErrorMapping:
+    def test_queue_full_maps_to_transient_error(
+        self, embedded_module, client_module, mock_engine_class, make_config,
+    ):
+        engine = mock_engine_class.with_default.return_value
+        engine.record_text.side_effect = RuntimeError(
+            "ingest queue full (256 pending ops, max=256); retry after 50ms"
+        )
+        client = embedded_module.EmbeddedYantrikDBClient(make_config())
+
+        with pytest.raises(client_module.YantrikDBTransientError):
+            client.remember("durable fact")
+
+    def test_unknown_engine_error_maps_to_server_error(
+        self, embedded_module, client_module, mock_engine_class, make_config,
+    ):
+        engine = mock_engine_class.with_default.return_value
+        engine.recall.side_effect = RuntimeError("rust panic: boom")
+        client = embedded_module.EmbeddedYantrikDBClient(make_config())
+
+        with pytest.raises(client_module.YantrikDBServerError):
+            client.recall("durable fact")

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -286,13 +286,14 @@ class TestHandleToolCall:
             "yantrikdb_think", {"run_pattern_mining": True},
         )
         assert mock_client.think.call_args.kwargs["run_pattern_mining"] is True
+        assert mock_client.think.call_args.kwargs["namespace"] == "hermes:workspace:coder"
         parsed = json.loads(out)
         assert parsed["consolidated"] == 2
         assert parsed["conflicts_found"] == 1
 
     def test_conflicts_dispatches(self, provider, mock_client):
         out = provider.handle_tool_call("yantrikdb_conflicts", {})
-        mock_client.conflicts.assert_called_once()
+        mock_client.conflicts.assert_called_once_with(namespace="hermes:workspace:coder")
         assert json.loads(out)["count"] == 0
 
     def test_relate_dispatches(self, provider, mock_client):
@@ -300,7 +301,9 @@ class TestHandleToolCall:
             "yantrikdb_relate",
             {"entity": "Alice", "target": "Acme", "relationship": "works_at"},
         )
-        mock_client.relate.assert_called_once_with("Alice", "Acme", "works_at")
+        mock_client.relate.assert_called_once_with(
+            "Alice", "Acme", "works_at", namespace="hermes:workspace:coder",
+        )
         assert json.loads(out)["edge_id"] == "e1"
 
     def test_relate_requires_all_three_fields(self, provider, mock_client):
@@ -454,6 +457,33 @@ class TestSyncTurn:
 # ---------------------------------------------------------------------------
 # Optional hooks
 # ---------------------------------------------------------------------------
+
+class TestSessionSwitch:
+    def test_updates_cached_session_id(self, provider):
+        assert provider._session_id == "sess-1"
+        provider.on_session_switch("sess-2", parent_session_id="sess-1")
+        assert provider._session_id == "sess-2"
+
+    def test_reset_clears_prefetch_cache(self, provider):
+        with provider._prefetch_lock:
+            provider._prefetch_results["sess-1"] = "old recall"
+        provider.on_session_switch("sess-2", reset=True)
+        assert provider._prefetch_results == {}
+
+
+class TestPrefetch:
+    def test_prefetch_is_scoped_by_session_id(self, provider, mock_client):
+        mock_client.recall.return_value = {
+            "results": [{"text": "alpha memory", "score": 0.9}],
+        }
+
+        provider.queue_prefetch("alpha", session_id="sess-a")
+        _wait_for_thread(provider._prefetch_thread)
+
+        assert provider.prefetch("alpha", session_id="sess-b") == ""
+        block = provider.prefetch("alpha", session_id="sess-a")
+        assert "alpha memory" in block
+
 
 class TestOnSessionEnd:
     def test_triggers_think(self, provider, mock_client):

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -571,7 +571,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
         # it to the model instead of yantrikdb appearing silently absent.
         self._init_error: str | None = None
 
-        self._prefetch_result: str = ""
+        self._prefetch_results: dict[str, str] = {}
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: threading.Thread | None = None
         self._sync_thread: threading.Thread | None = None
@@ -771,10 +771,45 @@ class YantrikDBMemoryProvider(MemoryProvider):
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=_SYNC_JOIN_SECS)
+        with self._prefetch_lock:
+            self._prefetch_results.clear()
         with self._client_lock:
             if self._client is not None:
                 self._client.close()
                 self._client = None
+
+    def on_session_switch(
+        self,
+        new_session_id: str,
+        *,
+        parent_session_id: str = "",
+        reset: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        """Update cached per-session state when Hermes changes session id."""
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=_PREFETCH_JOIN_SECS)
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=_SYNC_JOIN_SECS)
+
+        old_session_id = self._session_id
+        self._session_id = new_session_id or ""
+
+        # A reset/new conversation should not consume stale prefetched recall.
+        # For resume/branch/compression, drop only the session we just left;
+        # the new session has its own cache slot if one was queued explicitly.
+        with self._prefetch_lock:
+            if reset:
+                self._prefetch_results.clear()
+            elif old_session_id:
+                self._prefetch_results.pop(old_session_id, None)
+            if parent_session_id:
+                self._prefetch_results.pop(parent_session_id, None)
+
+        logger.debug(
+            "YantrikDB session switched: %s -> %s (reset=%s)",
+            old_session_id, self._session_id, reset,
+        )
 
     def _require_client(self) -> YantrikDBClient:
         """Return the client or raise — keeps dispatch paths type-clean."""
@@ -825,8 +860,11 @@ class YantrikDBMemoryProvider(MemoryProvider):
             return ""
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=_PREFETCH_JOIN_SECS)
+        key = session_id or self._session_id or "__default__"
         with self._prefetch_lock:
-            result, self._prefetch_result = self._prefetch_result, ""
+            result = self._prefetch_results.pop(key, "")
+            if not result and key != "__default__":
+                result = self._prefetch_results.pop("__default__", "")
         if not result:
             return ""
         return f"## YantrikDB Recall\n{result}"
@@ -839,6 +877,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
 
         client = self._client
         namespace = self._namespace
+        key = session_id or self._session_id or "__default__"
 
         def _run() -> None:
             try:
@@ -846,7 +885,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 block = _format_recall_block(resp.get("results", []), limit=5)
                 if block:
                     with self._prefetch_lock:
-                        self._prefetch_result = block
+                        self._prefetch_results[key] = block
                 self._record_success()
             except YantrikDBClientError as e:
                 logger.debug("YantrikDB prefetch rejected: %s", e)
@@ -1049,6 +1088,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
         resp = self._require_client().think(
             run_pattern_mining=bool(args.get("run_pattern_mining", False)),
             consolidation_limit=args.get("consolidation_limit"),
+            namespace=self._namespace,
         )
         self._record_success()
         return json.dumps({
@@ -1062,7 +1102,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
         })
 
     def _do_conflicts(self) -> str:
-        resp = self._require_client().conflicts()
+        resp = self._require_client().conflicts(namespace=self._namespace)
         self._record_success()
         conflicts = resp.get("conflicts", []) or []
         return json.dumps({"count": len(conflicts), "conflicts": conflicts})
@@ -1103,6 +1143,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
             )
         resp = self._require_client().relate(
             entity, target, relationship,
+            namespace=self._namespace,
         )
         self._record_success()
         return json.dumps({"edge_id": resp.get("edge_id"), "stored": True})
@@ -1205,7 +1246,9 @@ class YantrikDBMemoryProvider(MemoryProvider):
             return
         try:
             stats = self._client.think(
-                run_pattern_mining=False, run_personality=False,
+                run_pattern_mining=False,
+                run_personality=False,
+                namespace=self._namespace,
             )
             logger.info(
                 "YantrikDB session-end think: consolidated=%s conflicts=%s duration_ms=%s",

--- a/yantrikdb/client.py
+++ b/yantrikdb/client.py
@@ -98,6 +98,12 @@ class YantrikDBConfig:
             skills_enabled=_parse_bool(
                 os.environ.get("YANTRIKDB_SKILLS_ENABLED"), default=False,
             ),
+            auto_think_on_session_end=_parse_bool(
+                os.environ.get("YANTRIKDB_AUTO_THINK_ON_SESSION_END"), default=True,
+            ),
+            sync_user_messages=_parse_bool(
+                os.environ.get("YANTRIKDB_SYNC_USER_MESSAGES"), default=True,
+            ),
             namespace=os.environ.get("YANTRIKDB_NAMESPACE", DEFAULT_NAMESPACE),
             top_k=_parse_int(os.environ.get("YANTRIKDB_TOP_K"), DEFAULT_TOP_K),
             connect_timeout=_parse_float(
@@ -399,6 +405,7 @@ class YantrikDBClient:
         run_pattern_mining: bool = False,
         run_personality: bool = False,
         consolidation_limit: int | None = None,
+        namespace: str | None = None,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {
             "run_consolidation": run_consolidation,
@@ -406,12 +413,15 @@ class YantrikDBClient:
             "run_pattern_mining": run_pattern_mining,
             "run_personality": run_personality,
         }
+        if namespace:
+            body["namespace"] = namespace
         if consolidation_limit is not None:
             body["consolidation_limit"] = int(consolidation_limit)
         return self._request("POST", "/v1/think", body)
 
-    def conflicts(self) -> dict[str, Any]:
-        return self._request("GET", "/v1/conflicts")
+    def conflicts(self, *, namespace: str | None = None) -> dict[str, Any]:
+        params = {"namespace": namespace} if namespace else None
+        return self._request("GET", "/v1/conflicts", params=params)
 
     def resolve_conflict(
         self,
@@ -440,12 +450,15 @@ class YantrikDBClient:
         relationship: str,
         *,
         weight: float | None = None,
+        namespace: str | None = None,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {
             "entity": entity,
             "target": target,
             "relationship": relationship,
         }
+        if namespace:
+            body["namespace"] = namespace
         if weight is not None:
             body["weight"] = float(weight)
         return self._request("POST", "/v1/relate", body)

--- a/yantrikdb/embedded.py
+++ b/yantrikdb/embedded.py
@@ -34,10 +34,31 @@ from .client import (
     YantrikDBConfig,
     YantrikDBError,
     YantrikDBServerError,
+    YantrikDBTransientError,
     truncate_text,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _map_engine_error(operation: str, exc: Exception) -> YantrikDBError:
+    """Map embedded-engine exceptions into the plugin's error taxonomy."""
+    if isinstance(exc, YantrikDBError):
+        return exc
+    msg = str(exc)
+    lowered = msg.lower()
+    if (
+        "queue full" in lowered
+        or "retry after" in lowered
+        or "database is locked" in lowered
+        or "database locked" in lowered
+        or "busy" in lowered
+        or "timeout" in lowered
+    ):
+        return YantrikDBTransientError(f"{operation} failed transiently: {msg}")
+    if "invalid" in lowered or "bad rid" in lowered or "not found" in lowered:
+        return YantrikDBClientError(f"{operation} failed: {msg}")
+    return YantrikDBServerError(f"{operation} failed: {msg}")
 
 
 # ---------------------------------------------------------------------------
@@ -344,14 +365,17 @@ class EmbeddedYantrikDBClient:
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         safe_text = truncate_text(text, self.config.max_text_len)
-        rid = self._db.record_text(
-            safe_text,
-            memory_type=memory_type or "semantic",
-            importance=float(importance),
-            namespace=namespace or self.config.namespace,
-            domain=domain or "general",
-            metadata=metadata,
-        )
+        try:
+            rid = self._db.record_text(
+                safe_text,
+                memory_type=memory_type or "semantic",
+                importance=float(importance),
+                namespace=namespace or self.config.namespace,
+                domain=domain or "general",
+                metadata=metadata,
+            )
+        except Exception as e:
+            raise _map_engine_error("remember", e) from e
         return {"rid": rid}
 
     def recall(
@@ -363,13 +387,16 @@ class EmbeddedYantrikDBClient:
         memory_type: str | None = None,
         domain: str | None = None,
     ) -> dict[str, Any]:
-        results = self._db.recall(
-            query=query,
-            top_k=int(top_k or self.config.top_k),
-            namespace=namespace or self.config.namespace,
-            domain=domain,
-            memory_type=memory_type,
-        )
+        try:
+            results = self._db.recall(
+                query=query,
+                top_k=int(top_k or self.config.top_k),
+                namespace=namespace or self.config.namespace,
+                domain=domain,
+                memory_type=memory_type,
+            )
+        except Exception as e:
+            raise _map_engine_error("recall", e) from e
         items = list(results) if results else []
         return {"results": items, "total": len(items)}
 
@@ -401,11 +428,17 @@ class EmbeddedYantrikDBClient:
         }
         if consolidation_limit is not None:
             cfg["consolidation_limit"] = int(consolidation_limit)
-        out = self._db.think(cfg)
+        try:
+            out = self._db.think(cfg)
+        except Exception as e:
+            raise _map_engine_error("think", e) from e
         return out if isinstance(out, dict) else {}
 
-    def conflicts(self) -> dict[str, Any]:
-        out = self._db.get_conflicts(namespace=self.config.namespace)
+    def conflicts(self, *, namespace: str | None = None) -> dict[str, Any]:
+        try:
+            out = self._db.get_conflicts(namespace=namespace or self.config.namespace)
+        except Exception as e:
+            raise _map_engine_error("conflicts", e) from e
         items = list(out) if out else []
         return {"conflicts": items}
 
@@ -428,7 +461,10 @@ class EmbeddedYantrikDBClient:
             kwargs["new_text"] = new_text
         if resolution_note:
             kwargs["resolution_note"] = resolution_note
-        out = self._db.resolve_conflict(**kwargs)
+        try:
+            out = self._db.resolve_conflict(**kwargs)
+        except Exception as e:
+            raise _map_engine_error("resolve_conflict", e) from e
         if isinstance(out, dict):
             return out
         return {"conflict_id": conflict_id, "strategy": strategy}
@@ -443,17 +479,23 @@ class EmbeddedYantrikDBClient:
         *,
         weight: float | None = None,
     ) -> dict[str, Any]:
-        edge_id = self._db.relate(
-            entity, target,
-            rel_type=relationship,
-            weight=float(weight) if weight is not None else 1.0,
-        )
+        try:
+            edge_id = self._db.relate(
+                entity, target,
+                rel_type=relationship,
+                weight=float(weight) if weight is not None else 1.0,
+            )
+        except Exception as e:
+            raise _map_engine_error("relate", e) from e
         return {"edge_id": edge_id}
 
     # -- Stats --------------------------------------------------------
 
     def stats(self, *, namespace: str | None = None) -> dict[str, Any]:
-        out = self._db.stats(namespace=namespace or self.config.namespace)
+        try:
+            out = self._db.stats(namespace=namespace or self.config.namespace)
+        except Exception as e:
+            raise _map_engine_error("stats", e) from e
         return out if isinstance(out, dict) else {}
 
     # -- Skills (v0.3.0+) ---------------------------------------------


### PR DESCRIPTION
## Summary
- Wire `YANTRIKDB_SYNC_USER_MESSAGES` and `YANTRIKDB_AUTO_THINK_ON_SESSION_END` into config loading
- Update cached provider session state via `on_session_switch(...)`
- Scope prefetch results by `session_id` instead of using one global cache slot
- Pass the derived provider namespace through `think`, `conflicts`, `relate`, and session-end maintenance calls
- Normalize embedded-engine runtime errors into the existing client error taxonomy

## Why
The provider already had configuration fields and Hermes lifecycle hooks for these behaviors, but a few paths were not fully connected:

- env vars could not disable ambient user-message sync or automatic session-end maintenance
- session changes inside a long-lived Hermes process could leave cached session metadata stale
- prefetched recall used one global result slot, so it was not safe across session switches/branches
- maintenance/graph/conflict calls did not consistently receive the derived namespace
- embedded backend queue/backpressure/runtime errors could escape as raw engine exceptions

## Test Plan
- `HERMES_HOME=/tmp/yantrikdb-plugin-test-home python -m pytest tests/test_client.py tests/test_provider.py tests/test_embedded.py -q`
- `python -m py_compile yantrikdb/__init__.py yantrikdb/client.py yantrikdb/embedded.py tests/test_client.py tests/test_provider.py tests/test_embedded.py tests/conftest.py`
- `git diff --check`
