### PR TITLE
fix(embedded): accept namespace kwarg on think/relate + signature-parity test

### DIFF
--- a/tests/test_signature_parity.py
+++ b/tests/test_signature_parity.py
@@ -1,0 +1,88 @@
+"""Catch mock-vs-real signature drift between provider and client backends.
+
+`tests/test_provider.py` mocks the client, so a kwarg the provider
+passes can drop off the real HTTP/Embedded client signatures without
+any test failure. PR #11 hit this in code review: the provider's
+``_do_think`` / ``_do_relate`` / ``_do_conflicts`` started passing
+``namespace=self._namespace``, the HTTP client accepted it, but the
+embedded client did not — and the mocked provider tests still passed.
+Embedded mode would have TypeError'd in production at the first tool
+call.
+
+The test below stays close to the failure mode: it inspects both
+client signatures (no instantiation, no engine binary) and asserts
+that every kwarg the HTTP client accepts is also accepted by the
+embedded client for the methods the provider dispatches to. HTTP is
+the network contract; embedded must keep parity or pip-install mode
+breaks.
+
+Asymmetric on purpose: embedded may have local-only extras (cache
+tuning, etc.) that HTTP doesn't expose. The break-in-production
+shape is HTTP-has / embedded-missing, so that's what we assert.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# Methods the provider's _do_<tool> dispatch calls.
+_PROVIDER_DISPATCHED_METHODS: list[str] = [
+    "remember",
+    "recall",
+    "forget",
+    "think",
+    "conflicts",
+    "relate",
+    "stats",
+]
+
+
+@pytest.fixture
+def _embedded_module_for_parity(plugin, monkeypatch):
+    """Local embedded fixture — `test_embedded.py` defines one but it isn't
+    in conftest, so we stub the engine the same way here."""
+    fake_engine_module = types.ModuleType("yantrikdb")
+    fake_rust_module = types.ModuleType("yantrikdb._yantrikdb_rust")
+    cls = MagicMock(name="YantrikDB")
+    cls.return_value.has_embedder.return_value = True
+    cls.with_default.return_value.has_embedder.return_value = True
+    fake_rust_module.YantrikDB = cls
+    monkeypatch.setitem(sys.modules, "yantrikdb", fake_engine_module)
+    monkeypatch.setitem(sys.modules, "yantrikdb._yantrikdb_rust", fake_rust_module)
+    return sys.modules[plugin[0].__name__ + ".embedded"]
+
+
+def _kwargs(klass: type, method_name: str) -> set[str]:
+    sig = inspect.signature(getattr(klass, method_name))
+    return {name for name in sig.parameters if name != "self"}
+
+
+@pytest.mark.parametrize("method", _PROVIDER_DISPATCHED_METHODS)
+def test_embedded_accepts_every_kwarg_http_accepts(
+    client_module, _embedded_module_for_parity, method: str,
+) -> None:
+    """Every kwarg the HTTP client accepts on a provider-dispatched method
+    must also be accepted by the embedded client.
+
+    HTTP is the network contract that all backends must support, so if
+    HTTP grows a kwarg (e.g. ``namespace``) and embedded doesn't, the
+    provider's call site will TypeError in embedded mode while mocked
+    provider tests pass. PR #11 introduced exactly this drift before
+    review caught it; this test prevents the next one."""
+    http_kwargs = _kwargs(client_module.YantrikDBClient, method)
+    emb_kwargs = _kwargs(
+        _embedded_module_for_parity.EmbeddedYantrikDBClient, method,
+    )
+    missing = http_kwargs - emb_kwargs
+    assert not missing, (
+        f"EmbeddedYantrikDBClient.{method}() is missing kwarg(s) "
+        f"{sorted(missing)} that YantrikDBClient.{method}() accepts. "
+        f"Provider calls passing these will TypeError in embedded mode "
+        f"(the default pip-install backend) while mocked provider tests "
+        f"keep passing. Add the kwarg to the embedded signature."
+    )

--- a/yantrikdb/embedded.py
+++ b/yantrikdb/embedded.py
@@ -392,6 +392,7 @@ class EmbeddedYantrikDBClient:
         run_pattern_mining: bool = False,
         run_personality: bool = False,
         consolidation_limit: int | None = None,
+        namespace: str | None = None,
     ) -> dict[str, Any]:
         cfg: dict[str, Any] = {
             "run_consolidation": run_consolidation,
@@ -399,6 +400,11 @@ class EmbeddedYantrikDBClient:
             "run_pattern_mining": run_pattern_mining,
             "run_personality": run_personality,
         }
+        # Only set namespace when provided so older engine versions that
+        # don't read the key from cfg keep their existing behavior. Engine
+        # pin is `yantrikdb >= 0.7.4`; current engines honor it.
+        if namespace:
+            cfg["namespace"] = namespace
         if consolidation_limit is not None:
             cfg["consolidation_limit"] = int(consolidation_limit)
         out = self._db.think(cfg)
@@ -442,12 +448,19 @@ class EmbeddedYantrikDBClient:
         relationship: str,
         *,
         weight: float | None = None,
+        namespace: str | None = None,
     ) -> dict[str, Any]:
-        edge_id = self._db.relate(
-            entity, target,
-            rel_type=relationship,
-            weight=float(weight) if weight is not None else 1.0,
-        )
+        # Conditionally pass namespace so older engines that don't accept
+        # the kwarg keep working. When the provider derives a workspace-
+        # scoped namespace, this routes the edge into that namespace
+        # rather than the engine's constructor-time default.
+        rel_kwargs: dict[str, Any] = {
+            "rel_type": relationship,
+            "weight": float(weight) if weight is not None else 1.0,
+        }
+        if namespace:
+            rel_kwargs["namespace"] = namespace
+        edge_id = self._db.relate(entity, target, **rel_kwargs)
         return {"edge_id": edge_id}
 
     # -- Stats --------------------------------------------------------


### PR DESCRIPTION
## Summary

Lands ahead of PR #11 to close a mock-vs-real signature drift gap that PR #11 would otherwise introduce in production.

## The bug PR #11 would have introduced

PR #11 widens the provider's `_do_think` / `_do_relate` / `_do_conflicts` to pass `namespace=self._namespace` and updates the HTTP `YantrikDBClient` to accept the kwarg. The embedded client kept its old signature:

```
embedded.think params:    ['self', 'run_consolidation', 'run_conflict_scan', 'run_pattern_mining', 'run_personality', 'consolidation_limit']
embedded.relate params:   ['self', 'entity', 'target', 'relationship', 'weight']
```

Result in embedded mode (the default `pip install` backend) after PR #11 lands:

```
>>> client.think(namespace='hermes:workspace:coder')
TypeError: EmbeddedYantrikDBClient.think() got an unexpected keyword argument 'namespace'
>>> client.relate('Alice', 'Acme', 'works_at', namespace='hermes:workspace:coder')
TypeError: EmbeddedYantrikDBClient.relate() got an unexpected keyword argument 'namespace'
```

`tests/test_provider.py` uses a mocked client that accepts any kwargs, so the gap was invisible.

## Changes

- `yantrikdb/embedded.py` — `think()` and `relate()` now accept `namespace: str | None = None` and pass it through to the engine only when truthy (older engine versions that don't accept the kwarg keep working; current pin is `yantrikdb >= 0.7.4`).
- `tests/test_signature_parity.py` (new) — inspects both client signatures (no instantiation, no engine binary) and asserts every kwarg HTTP accepts on a provider-dispatched method is also accepted by embedded. Asymmetric on purpose: embedded may have local-only extras, but missing something HTTP exposes is the production-break shape.

## Test plan

- `HERMES_HOME=/tmp/x python -m pytest tests/ -q` → 170 passed, 2 skipped
- `python -m ruff check yantrikdb tests` → All checks passed!
- `python -m mypy yantrikdb` → Success: no issues found in 5 source files

## Ordering with PR #11

This PR is intentionally landed before #11 so the embedded gap is closed before the HTTP widening lands. After this merges, #11 will conflict in `yantrikdb/embedded.py` — resolve by keeping the namespace kwargs from this PR and adding wysie's `try/except _map_engine_error` wrapping on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)