### PR TITLE
feat: add shared group owner scopes

### DIFF
--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -184,10 +184,12 @@ class TestInitialize:
         assert p._namespace.startswith("hermes:workspace:coder:owner:owner-primary-user-")
         assert p._scope_metadata == {
             "owner_id": "owner:primary-user",
+            "actor_owner_id": "owner:primary-user",
             "actor_id": "whatsapp:actor-a",
             "channel": "whatsapp",
             "conversation_id": "whatsapp:chat-1",
             "owner_actors": ["telegram:actor-b", "whatsapp:actor-a"],
+            "shared_owner_ids": [],
         }
 
     def test_owner_scoping_defaults_to_actor_owner_without_map(
@@ -447,6 +449,98 @@ class TestHandleToolCall:
 
         mock_client.recall.assert_called_once()
         assert json.loads(out)["results"][0]["rid"] == "scoped"
+
+    def test_group_conversation_writes_to_configured_group_namespace(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        monkeypatch.setenv("YANTRIKDB_MODE", "http")
+        monkeypatch.setenv("YANTRIKDB_TOKEN", "ydb_test")
+        monkeypatch.setenv("YANTRIKDB_OWNER_SCOPING", "true")
+        monkeypatch.setenv(
+            "YANTRIKDB_IDENTITY_MAP_JSON",
+            json.dumps({
+                "actors": {"whatsapp:actor-a": "owner:primary-user"},
+                "groups": {
+                    "group:household": {
+                        "members": ["owner:primary-user", "owner:secondary-user"],
+                        "conversations": ["whatsapp:family-chat"],
+                    },
+                },
+            }),
+        )
+        p = provider_module.YantrikDBMemoryProvider()
+        with patch.object(provider_module, "make_backend", return_value=mock_client):
+            p.initialize(
+                "sess-1",
+                agent_workspace="workspace",
+                agent_identity="coder",
+                platform="whatsapp",
+                user_id="actor-a",
+                chat_id="family-chat",
+                chat_type="group",
+            )
+
+        p.handle_tool_call("yantrikdb_remember", {"text": "Shared household fact"})
+
+        call = mock_client.remember.call_args
+        assert call.kwargs["namespace"].startswith("hermes:workspace:coder:owner:group-household-")
+        assert call.kwargs["metadata"]["owner_id"] == "group:household"
+        assert call.kwargs["metadata"]["actor_id"] == "whatsapp:actor-a"
+        assert call.kwargs["metadata"]["actor_owner_id"] == "owner:primary-user"
+        assert call.kwargs["metadata"]["conversation_id"] == "whatsapp:family-chat"
+
+    def test_personal_recall_includes_configured_group_memberships(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        monkeypatch.setenv("YANTRIKDB_MODE", "http")
+        monkeypatch.setenv("YANTRIKDB_TOKEN", "ydb_test")
+        monkeypatch.setenv("YANTRIKDB_OWNER_SCOPING", "true")
+        monkeypatch.setenv("YANTRIKDB_INCLUDE_BASE_NAMESPACE_RECALL", "false")
+        monkeypatch.setenv("YANTRIKDB_INCLUDE_LEGACY_ACTOR_NAMESPACE_RECALL", "false")
+        monkeypatch.setenv(
+            "YANTRIKDB_IDENTITY_MAP_JSON",
+            json.dumps({
+                "actors": {
+                    "telegram:actor-b": "owner:primary-user",
+                    "whatsapp:actor-a": "owner:primary-user",
+                    "whatsapp:actor-c": "owner:removed-user",
+                },
+                "groups": {
+                    "group:household": {
+                        "members": ["owner:primary-user", "owner:secondary-user"],
+                        "conversations": ["whatsapp:family-chat"],
+                    },
+                    "group:other": {
+                        "members": ["owner:someone-else"],
+                        "conversations": ["telegram:other-chat"],
+                    },
+                },
+            }),
+        )
+        p = provider_module.YantrikDBMemoryProvider()
+        with patch.object(provider_module, "make_backend", return_value=mock_client):
+            p.initialize(
+                "sess-1",
+                agent_workspace="workspace",
+                agent_identity="coder",
+                platform="telegram",
+                user_id="actor-b",
+                chat_id="actor-b-dm",
+                chat_type="dm",
+            )
+
+        mock_client.recall.side_effect = [
+            {"results": [{"rid": "personal", "text": "personal", "score": 0.8}]},
+            {"results": [{"rid": "household", "text": "shared", "score": 0.9}]},
+        ]
+        out = p.handle_tool_call("yantrikdb_recall", {"query": "prefs", "top_k": 5})
+
+        namespaces = [call.kwargs["namespace"] for call in mock_client.recall.call_args_list]
+        assert len(namespaces) == 2
+        assert namespaces[0].startswith("hermes:workspace:coder:owner:owner-primary-user-")
+        assert namespaces[1].startswith("hermes:workspace:coder:owner:group-household-")
+        assert not any("group-other" in ns for ns in namespaces)
+        assert [r["rid"] for r in json.loads(out)["results"]] == ["household", "personal"]
 
     def test_recall_handles_missing_why_retrieved(self, provider, mock_client):
         mock_client.recall.return_value = {

--- a/yantrikdb/README.md
+++ b/yantrikdb/README.md
@@ -82,13 +82,24 @@ Optional config file: `$HERMES_HOME/yantrikdb.json`. Env vars are the primary so
 
 ## Optional owner scoping for multi-user Hermes gateways
 
-By default, the effective namespace remains `namespace:agent_workspace:agent_identity`, preserving existing behavior. If one Hermes gateway serves multiple users and you want hard memory isolation without changing YantrikDB core, enable owner scoping:
+By default, the effective namespace remains `namespace:agent_workspace:agent_identity`, preserving existing behavior. If one Hermes gateway serves multiple users and you want hard memory isolation without changing YantrikDB core, enable owner scoping in `$HERMES_HOME/yantrikdb.json`:
 
 ```json
 {
   "owner_scoping": true,
-  "identity_map_path": "/path/to/identity-map.json"
+  "identity_map_path": "/path/to/identity-map.json",
+  "include_base_namespace_recall": true,
+  "include_legacy_actor_namespace_recall": true
 }
+```
+
+Equivalent environment variables:
+
+```bash
+export YANTRIKDB_OWNER_SCOPING=true
+export YANTRIKDB_IDENTITY_MAP_PATH=/path/to/identity-map.json
+export YANTRIKDB_INCLUDE_BASE_NAMESPACE_RECALL=true
+export YANTRIKDB_INCLUDE_LEGACY_ACTOR_NAMESPACE_RECALL=true
 ```
 
 Identity map formats:
@@ -114,7 +125,9 @@ or:
 }
 ```
 
-Shared groups can be declared in the same identity map:
+Shared groups can be declared in the same identity map. Use stable, app-owned ids for both owners and groups; the plugin hashes these ids into namespace shards, so they do not have to be database ids.
+
+Example: one person across WhatsApp + Telegram, plus a household group shared by two owners:
 
 ```json
 {
@@ -131,6 +144,30 @@ Shared groups can be declared in the same identity map:
   }
 }
 ```
+
+How to read the example:
+
+- `actors` maps platform actor ids to canonical personal owners. `whatsapp:actor-a` and `telegram:actor-b` are the same person, so their personal memories share `owner:primary-user`.
+- `groups.group:household.members` lists canonical owners who may recall memories from that shared group namespace during personal recall.
+- `groups.group:household.conversations` lists group chat conversation ids whose writes should be stored under `group:household` instead of the sender's personal owner.
+- A message from `whatsapp:actor-a` inside `whatsapp:family-chat` writes to the `group:household` namespace and records `actor_owner_id: owner:primary-user` in metadata for provenance.
+- A later DM recall by `telegram:actor-b` searches `owner:primary-user` plus `group:household`, because `owner:primary-user` is a current group member.
+- A user not listed in `members` does not get that group namespace during personal recall, even if they have an actor mapping elsewhere.
+
+To remove access for a member, edit the identity map and remove that owner id from the group's `members` list:
+
+```json
+{
+  "groups": {
+    "group:household": {
+      "members": ["owner:primary-user"],
+      "conversations": ["whatsapp:family-chat", "telegram:family-chat"]
+    }
+  }
+}
+```
+
+After the provider is restarted or a fresh session initializes, `owner:secondary-user` no longer recalls `group:household` during personal recall. Historical rows remain in the group namespace; the plugin does not rewrite or tombstone them automatically.
 
 When enabled, the plugin resolves the current Hermes `platform` + `user_id` to an owner, appends a stable, collision-resistant owner shard to the namespace, and writes `owner_id`, `actor_id`, `actor_owner_id`, `channel`, and `conversation_id` into metadata. The shard preserves the first 32 chars of the original identifier as a debuggable slug plus a sha256-12 suffix; if you want pure-hash sharding without identifier leakage, pre-hash the owner ids in your identity map before passing them in. If no identity map is configured, the actor becomes its own owner by default, so actors are still stored and isolated without any owner config.
 

--- a/yantrikdb/README.md
+++ b/yantrikdb/README.md
@@ -114,7 +114,29 @@ or:
 }
 ```
 
-When enabled, the plugin resolves the current Hermes `platform` + `user_id` to an owner, appends a stable, collision-resistant owner shard to the namespace, and writes `owner_id`, `actor_id`, `channel`, and `conversation_id` into metadata. The shard preserves the first 32 chars of the original identifier as a debuggable slug plus a sha256-12 suffix; if you want pure-hash sharding without identifier leakage, pre-hash the owner ids in your identity map before passing them in. If no identity map is configured, the actor becomes its own owner by default, so actors are still stored and isolated without any owner config. Recall also includes fallback namespaces by default: old per-actor owner namespaces for every actor mapped to the same owner (`include_legacy_actor_namespace_recall=true`), then the base pre-owner namespace (`include_base_namespace_recall=true`). This means memories written as `whatsapp:actor-a` remain visible after `whatsapp:actor-a` and `telegram:actor-b` are mapped to `owner:primary-user`, and older unscoped memories behave as shared/global legacy memory. New writes still go only to the canonical owner-scoped namespace. Set either fallback false if you want stricter recall. This is a plugin/application concern; YantrikDB core does not need to know platform alias policy.
+Shared groups can be declared in the same identity map:
+
+```json
+{
+  "actors": {
+    "whatsapp:actor-a": "owner:primary-user",
+    "telegram:actor-b": "owner:primary-user",
+    "whatsapp:actor-c": "owner:secondary-user"
+  },
+  "groups": {
+    "group:household": {
+      "members": ["owner:primary-user", "owner:secondary-user"],
+      "conversations": ["whatsapp:family-chat", "telegram:family-chat"]
+    }
+  }
+}
+```
+
+When enabled, the plugin resolves the current Hermes `platform` + `user_id` to an owner, appends a stable, collision-resistant owner shard to the namespace, and writes `owner_id`, `actor_id`, `actor_owner_id`, `channel`, and `conversation_id` into metadata. The shard preserves the first 32 chars of the original identifier as a debuggable slug plus a sha256-12 suffix; if you want pure-hash sharding without identifier leakage, pre-hash the owner ids in your identity map before passing them in. If no identity map is configured, the actor becomes its own owner by default, so actors are still stored and isolated without any owner config.
+
+If the current `conversation_id` matches a configured group conversation, writes go to that group owner namespace (for example `group:household`) rather than the actor's personal namespace. Personal recalls include the actor's own namespace plus any configured group namespaces where the resolved owner is a current `member`. Removing someone from a group is therefore a config edit: remove their owner id from `groups.<group>.members`, restart/new-session the provider, and future personal recall stops including that group namespace. Historical memories remain under the group owner; nothing is rewritten.
+
+Recall also includes fallback namespaces by default: old per-actor owner namespaces for every actor mapped to the same owner (`include_legacy_actor_namespace_recall=true`), then the base pre-owner namespace (`include_base_namespace_recall=true`). This means memories written as `whatsapp:actor-a` remain visible after `whatsapp:actor-a` and `telegram:actor-b` are mapped to `owner:primary-user`, and older unscoped memories behave as shared/global legacy memory. New writes still go only to the canonical current owner namespace. Set either fallback false if you want stricter recall. This is a plugin/application concern; YantrikDB core does not need to know platform alias policy.
 
 **Operational notes:**
 

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -532,13 +532,8 @@ def _safe_namespace_part(value: str) -> str:
     return f"{slug or 'owner'}-{digest}"
 
 
-def _load_identity_map(config: YantrikDBConfig) -> dict[str, str]:
-    """Load actor->owner aliases from plugin/app config.
-
-    Supported shapes:
-      {"actors": {"whatsapp:123": "owner:primary"}}
-      {"owners": {"owner:primary": {"actors": ["whatsapp:123"]}}}
-    """
+def _load_identity_config(config: YantrikDBConfig) -> dict[str, Any]:
+    """Load identity config containing actor aliases and optional groups."""
     raw: Any = None
     if config.identity_map_json:
         try:
@@ -552,9 +547,17 @@ def _load_identity_map(config: YantrikDBConfig) -> dict[str, str]:
         except (OSError, json.JSONDecodeError) as e:
             logger.warning("Failed to read identity map %s: %s", config.identity_map_path, e)
             raw = None
-    if not isinstance(raw, dict):
-        return {}
+    return raw if isinstance(raw, dict) else {}
 
+
+def _load_identity_map(config: YantrikDBConfig) -> dict[str, str]:
+    """Load actor->owner aliases from plugin/app config.
+
+    Supported shapes:
+      {"actors": {"whatsapp:123": "owner:primary"}}
+      {"owners": {"owner:primary": {"actors": ["whatsapp:123"]}}}
+    """
+    raw = _load_identity_config(config)
     out: dict[str, str] = {}
     actors = raw.get("actors")
     if isinstance(actors, dict):
@@ -572,18 +575,69 @@ def _load_identity_map(config: YantrikDBConfig) -> dict[str, str]:
     return out
 
 
+def _load_group_map(config: YantrikDBConfig) -> dict[str, dict[str, list[str]]]:
+    """Load shared group/space owner config.
+
+    Shape:
+      {"groups": {"group:household": {
+          "members": ["owner:primary"],
+          "conversations": ["whatsapp:family-chat"]
+      }}}
+
+    The plugin only enforces this configured allow-list. Updating membership is
+    an app/config operation; existing group memories stay in the group namespace.
+    """
+    raw = _load_identity_config(config)
+    groups = raw.get("groups")
+    if not isinstance(groups, dict):
+        return {}
+    out: dict[str, dict[str, list[str]]] = {}
+    for group_id, spec in groups.items():
+        if not group_id or not isinstance(spec, dict):
+            continue
+        members = [str(v) for v in (spec.get("members") or []) if v]
+        conversations = [str(v) for v in (spec.get("conversations") or []) if v]
+        out[str(group_id)] = {"members": members, "conversations": conversations}
+    return out
+
+
+def _configured_group_for_conversation(
+    config: YantrikDBConfig,
+    conversation_id: str | None,
+) -> str | None:
+    if not conversation_id:
+        return None
+    for group_id, spec in _load_group_map(config).items():
+        if conversation_id in spec.get("conversations", []):
+            return group_id
+    return None
+
+
+def _shared_groups_for_owner(config: YantrikDBConfig, owner_id: str) -> list[str]:
+    groups: list[str] = []
+    for group_id, spec in _load_group_map(config).items():
+        if owner_id in spec.get("members", []) and group_id not in groups:
+            groups.append(group_id)
+    return groups
+
 def _derive_owner_scope(config: YantrikDBConfig, kwargs: dict[str, Any]) -> dict[str, Any]:
     actor_id = _identity_actor_id(kwargs)
+    conversation_id = _conversation_id(kwargs)
     aliases = _load_identity_map(config)
-    owner_id = aliases.get(actor_id, actor_id)
-    owner_actors = sorted(actor for actor, owner in aliases.items() if owner == owner_id)
+    actor_owner_id = aliases.get(actor_id, actor_id)
+    group_owner_id = _configured_group_for_conversation(config, conversation_id)
+    owner_id = group_owner_id or actor_owner_id
+    owner_actors = sorted(actor for actor, owner in aliases.items() if owner == actor_owner_id)
+    shared_owner_ids = [] if group_owner_id else _shared_groups_for_owner(config, actor_owner_id)
     platform = (kwargs.get("platform") or "cli").strip() or "cli"
     return {
         "owner_id": owner_id,
+        "actor_owner_id": actor_owner_id,
         "actor_id": actor_id,
         "channel": platform,
-        "conversation_id": _conversation_id(kwargs),
+        "conversation_id": conversation_id,
         "owner_actors": owner_actors,
+        "shared_owner_ids": shared_owner_ids,
     }
 
 def _derive_namespace(base: str, kwargs: dict[str, Any]) -> str:
@@ -689,6 +743,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
         self._namespace: str = DEFAULT_NAMESPACE
         self._base_namespace: str = DEFAULT_NAMESPACE
         self._legacy_actor_namespace: str = ""
+        self._shared_owner_namespaces: list[str] = []
         self._scope_metadata: dict[str, Any] = {}
         self._session_id: str = ""
         self._cron_skipped: bool = False
@@ -899,6 +954,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
         self._base_namespace = _derive_namespace(self._config.namespace, kwargs)
         self._namespace = self._base_namespace
         self._legacy_actor_namespace = ""
+        self._shared_owner_namespaces = []
         self._scope_metadata = {}
         if self._config.owner_scoping:
             self._scope_metadata = _derive_owner_scope(self._config, kwargs)
@@ -906,6 +962,10 @@ class YantrikDBMemoryProvider(MemoryProvider):
             actor_shard = _safe_namespace_part(self._scope_metadata["actor_id"])
             self._namespace = f"{self._base_namespace}:owner:{owner_shard}"
             self._legacy_actor_namespace = f"{self._base_namespace}:owner:{actor_shard}"
+            self._shared_owner_namespaces = [
+                f"{self._base_namespace}:owner:{_safe_namespace_part(str(owner_id))}"
+                for owner_id in self._scope_metadata.get("shared_owner_ids", [])
+            ]
 
         # v0.4.4: defensively pre-create the engine's model-cache dir before
         # any bundled-named download path runs. Otherwise an environment
@@ -1020,12 +1080,15 @@ class YantrikDBMemoryProvider(MemoryProvider):
     def _write_scope_metadata(self) -> dict[str, Any]:
         return {
             k: v for k, v in self._scope_metadata.items()
-            if k != "owner_actors"
+            if k not in {"owner_actors", "shared_owner_ids"}
         }
 
     def _fallback_recall_namespaces(self) -> list[str]:
         namespaces: list[str] = []
         namespaces.extend(self._legacy_actor_namespaces())
+        for namespace in self._shared_owner_namespaces:
+            if namespace != self._namespace and namespace not in namespaces:
+                namespaces.append(namespace)
         if self._should_recall_base_namespace() and self._base_namespace not in namespaces:
             namespaces.append(self._base_namespace)
         return namespaces


### PR DESCRIPTION
## Summary
- Add configured shared group owner scopes to the existing owner-scoping identity map
- Store memories from mapped group conversations under the group owner namespace
- Include configured group namespaces during a member's personal recall, without leaking unrelated groups
- Document setup examples for personal owner aliases, group owners, membership changes, and fallback recall behavior

## Why
Hermes can already merge the same person across platforms by mapping multiple platform actors to one canonical owner. Shared group chats need the same portability: a memory created in a configured group should be recallable later by current group members across platforms/DMs, while private person namespaces remain isolated.

This keeps membership policy in the Hermes plugin/config layer. YantrikDB core remains unaware of platform actors, group membership, or chat IDs.

## Configuration examples

Enable owner scoping in `$HERMES_HOME/yantrikdb.json`:

```json
{
  "owner_scoping": true,
  "identity_map_path": "/path/to/identity-map.json",
  "include_base_namespace_recall": true,
  "include_legacy_actor_namespace_recall": true
}
```

Equivalent environment variables:

```bash
export YANTRIKDB_OWNER_SCOPING=true
export YANTRIKDB_IDENTITY_MAP_PATH=/path/to/identity-map.json
export YANTRIKDB_INCLUDE_BASE_NAMESPACE_RECALL=true
export YANTRIKDB_INCLUDE_LEGACY_ACTOR_NAMESPACE_RECALL=true
```

### Personal owner aliases

Map multiple platform actors to the same canonical person:

```json
{
  "actors": {
    "whatsapp:actor-a": "owner:primary-user",
    "telegram:actor-b": "owner:primary-user"
  }
}
```

Result:
- Writes from `whatsapp:actor-a` and `telegram:actor-b` use the same personal owner namespace: `owner:primary-user`
- Legacy per-actor namespaces can still be searched if `include_legacy_actor_namespace_recall=true`

### Group owner setup

Declare shared group namespaces in the same identity map:

```json
{
  "actors": {
    "whatsapp:actor-a": "owner:primary-user",
    "telegram:actor-b": "owner:primary-user",
    "whatsapp:actor-c": "owner:secondary-user"
  },
  "groups": {
    "group:household": {
      "members": ["owner:primary-user", "owner:secondary-user"],
      "conversations": ["whatsapp:family-chat", "telegram:family-chat"]
    }
  }
}
```

How this works:
- `actors` maps platform actor ids to canonical personal owners
- `groups.<group>.members` lists canonical owners who may recall that group namespace during personal recall
- `groups.<group>.conversations` lists group chat conversation ids whose writes should go to the group namespace
- A message from `whatsapp:actor-a` inside `whatsapp:family-chat` writes to `group:household`, not to `owner:primary-user`
- The write metadata still records `actor_id` and `actor_owner_id` so provenance is preserved
- A later DM recall by `telegram:actor-b` searches `owner:primary-user` plus `group:household`, because `owner:primary-user` is a current member
- A user not listed in `members` does not get that group namespace during personal recall

### Removing a group member

Membership removal is intentionally a config edit, not a core database migration. Remove the canonical owner from the group `members` list:

```json
{
  "groups": {
    "group:household": {
      "members": ["owner:primary-user"],
      "conversations": ["whatsapp:family-chat", "telegram:family-chat"]
    }
  }
}
```

After the provider restarts or a fresh session initializes:
- `owner:secondary-user` no longer recalls `group:household` during personal recall
- Historical rows remain under the group namespace
- The plugin does not rewrite, tombstone, or migrate old group memories automatically

## Safety
- `owner_scoping` remains opt-in; default behavior is unchanged
- Group sharing only happens for explicitly configured `groups` entries
- Personal recall only includes groups where the resolved owner is a current member
- Removing a member is handled by config and affects future recall only
- Historical group memories remain under the group owner; nothing is rewritten
- Tests use generic fixture IDs only

## Test Plan
- `HERMES_HOME=$(mktemp -d) python -m pytest tests/test_provider.py -q -k 'group_conversation or personal_recall_includes_configured_group'`
- `HERMES_HOME=$(mktemp -d) python -m pytest tests/test_provider.py tests/test_client.py -q`
- `HERMES_HOME=$(mktemp -d) python -m pytest tests -q`
- `python -m py_compile yantrikdb/__init__.py yantrikdb/client.py`
- `python -m ruff check yantrikdb tests`
- `git diff --check`
