### PR TITLE
fix: silence stdout pollution from HuggingFace embedder (v0.4.12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,22 @@ echo "YANTRIKDB_EMBEDDER=potion-base-8M" >> ~/.hermes/.env     # 28 MB, dim=256,
 # or potion-base-32M for 121 MB, dim=512, ~95% MiniLM
 # or multilingual via the v0.4.2 model2vec path:
 echo "YANTRIKDB_EMBEDDER_MODEL2VEC=minishlab/potion-multilingual-128M" >> ~/.hermes/.env
+# or the broader HF ecosystem via sentence-transformers:
+echo "YANTRIKDB_EMBEDDER_HF=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2" >> ~/.hermes/.env
 ```
+
+### Optional: quiet the HuggingFace embedder
+
+`YANTRIKDB_EMBEDDER_HF` uses `sentence-transformers`, which by default emits noise to stdout — tqdm progress bars on every encode and a one-time HF Hub auth warning at startup. The plugin disables the per-encode progress bars internally (v0.4.12+). For the rest, add to your `.env`:
+
+```bash
+HF_HUB_DISABLE_PROGRESS_BARS=1
+TRANSFORMERS_VERBOSITY=error
+# Optional, when running fully offline after the first download:
+HF_HUB_OFFLINE=1
+```
+
+Without these, sentence-transformers / huggingface_hub output can pollute the agent's own stdout stream.
 
 ## Install (alternative — HTTP backend, for HA cluster setups)
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.4.11
+version: 0.4.12
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.4.11"
+version = "0.4.12"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.4.12] — 2026-05-18 — Quiet HuggingFace embedder
+
+Bugfix landing [#15](https://github.com/yantrikos/yantrikdb-hermes-plugin/issues/15) from **@alienos**. The `SentenceTransformerEmbedder` (selected by `YANTRIKDB_EMBEDDER_HF`) was leaking tqdm progress bars to stdout on every memory write. Under Hermes the plugin's stdout is the agent's own output stream, so per-write `Batches: 0%|...` bars polluted agent output and could interfere with log parsing or TTY rendering.
+
+### Fixed
+
+- **`SentenceTransformerEmbedder.encode()`** now passes `show_progress_bar=False` to `sentence_transformers.SentenceTransformer.encode`. Affects the startup probe (where the loader confirms the model works) and every runtime encode call from the engine. Internal fix — no API change, no env-var change, no breaking behaviour for existing callers.
+- **README** adds an "Optional: quiet the HuggingFace embedder" section documenting the complementary env vars (`HF_HUB_DISABLE_PROGRESS_BARS=1`, `TRANSFORMERS_VERBOSITY=error`, `HF_HUB_OFFLINE=1`) for the HF Hub auth warning + transformers-library output that the plugin can't suppress from inside.
+
+### Credit
+
+Thanks to **@alienos** for the bug report, root-cause diagnosis, and the working-fix workaround in [#15](https://github.com/yantrikos/yantrikdb-hermes-plugin/issues/15). Third confirmed fix from this reporter (after #4 + #9 closed cleanly).
+
 ## [0.4.11] — 2026-05-18 — Shared group owner scopes on top of owner scoping
 
 Lands [#14](https://github.com/yantrikos/yantrikdb-hermes-plugin/pull/14) from **@wysie** — seventh PR in the arc, building directly on v0.4.10's owner-scoping foundation. Adds shared group namespaces so memories created in a configured group conversation are recallable by every current group member across platforms, while personal-DM memories stay isolated.

--- a/yantrikdb/embedders.py
+++ b/yantrikdb/embedders.py
@@ -156,7 +156,7 @@ class SentenceTransformerEmbedder:
         # hand it to the engine and as a fallback when declared dim isn't
         # available.
         probe = _coerce_to_float_list(
-            self._model.encode(_PROBE_TEXT),
+            self._model.encode(_PROBE_TEXT, show_progress_bar=False),
             model_name=model_name, family="sentence-transformers",
         )
         probed = len(probe)
@@ -179,7 +179,9 @@ class SentenceTransformerEmbedder:
     def encode(self, text: str) -> list[float]:
         # SentenceTransformer.encode with a single string returns a 1-D
         # ndarray of shape (dim,). With a list it returns 2-D.
-        vec = self._model.encode(text)
+        # show_progress_bar=False keeps stdout clean — tqdm bars on every
+        # memory write would pollute the agent's own output stream.
+        vec = self._model.encode(text, show_progress_bar=False)
         return _coerce_to_float_list(
             vec, model_name=self.model_name, family="sentence-transformers",
         )

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.4.11
+version: 0.4.12
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.7.6


### PR DESCRIPTION
## Summary

- `SentenceTransformerEmbedder` (used when `YANTRIKDB_EMBEDDER_HF` is set) now passes `show_progress_bar=False` to `sentence_transformers.SentenceTransformer.encode`, so per-encode `Batches: 0%|...` tqdm bars no longer leak to stdout. Affects the startup probe (line 159) and the runtime encode call from the engine (line 182). Internal change — no API or env-var change; no behaviour change for default users (Model2Vec embedder doesn't use tqdm).
- README adds an "Optional: quiet the HuggingFace embedder" section with the complementary env vars the plugin can't suppress from inside: `HF_HUB_DISABLE_PROGRESS_BARS=1`, `TRANSFORMERS_VERBOSITY=error`, `HF_HUB_OFFLINE=1`.
- Version bump to **v0.4.12** (`pyproject.toml`, root `plugin.yaml`, `yantrikdb/plugin.yaml`); `CHANGELOG.md` entry crediting `@alienos`.

Closes #15.

## Why it matters

Under Hermes the plugin's stdout is the agent's own output stream. tqdm progress bars on every memory write polluted the agent's output and could interfere with log parsing or TTY rendering for users running the HF embedder path. The Model2Vec default path was unaffected.

## Test plan

- [x] Local pytest: 183 passed, 2 skipped (unchanged from v0.4.11 baseline)
- [x] `python -m ruff check yantrikdb tests` — All checks passed
- [x] `python -m mypy yantrikdb` — Success: no issues found in 5 source files
- [ ] CI green on Python 3.11 / 3.12 / 3.13 / 3.14 (will verify after push)
- [ ] Manual smoke: load a HF embedder model in a fresh venv, confirm no tqdm output on probe or encode

## Credit

Third confirmed fix from `@alienos` (after #4 + #9 closed cleanly). Bug report included the root-cause diagnosis and a working-fix workaround — both adopted verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)