### PR TITLE
v0.4.14: sync plugin.yaml manifest version (closes #19)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.4.13"
+version = "0.4.14"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.4.14] — 2026-05-22 — Manifest version sync
+
+Fixes [#19](https://github.com/yantrikos/yantrikdb-hermes-plugin/pull/19) from **@alienos**. v0.4.13 bumped `pyproject.toml` to 0.4.13 but missed `yantrikdb/plugin.yaml`, which Hermes reads to display the plugin version. The v0.4.13 wheel on PyPI shipped with `plugin.yaml: 0.4.12`; `hermes plugins list` would consequently show 0.4.12 even on a fresh `pip install yantrikdb-hermes-plugin==0.4.13`.
+
+v0.4.14 ships with both files synced. Functionally identical to v0.4.13 — no code changes, no API changes. Recommended upgrade path: `pip install -U yantrikdb-hermes-plugin` straight to 0.4.14.
+
+### Credit
+
+Thanks to **@alienos** for opening [PR #19](https://github.com/yantrikos/yantrikdb-hermes-plugin/pull/19) within hours of the v0.4.13 release. Their plugin.yaml fix is preserved verbatim as the first commit on this release; the version bump to 0.4.14 sits on top so the corrected manifest reaches PyPI. Fifth substantive contribution from this reporter (#4, #9, #15, #17, #19 — all closed cleanly).
+
 ## [0.4.13] — 2026-05-22 — Trigger consumer tools
 
 Closes [#17](https://github.com/yantrikos/yantrikdb-hermes-plugin/issues/17) from **@alienos**. v0.4.12 exposed the producer side of the trigger lifecycle (`yantrikdb_think` returns triggers, `yantrikdb_stats.pending_triggers` shows the count) but no consumer tools — so triggers accumulated indefinitely. This release closes that loop.

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.4.12
+version: 0.4.13
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.7.6

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.4.13
+version: 0.4.14
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.7.6


### PR DESCRIPTION
Closes #19 from @alienos. Their plugin.yaml fix is preserved verbatim as the first commit; the version bump to 0.4.14 sits on top so the corrected manifest reaches PyPI.

## The miss

v0.4.13 bumped \`pyproject.toml\` + \`CHANGELOG\` but missed \`yantrikdb/plugin.yaml\` — the file Hermes reads to display the plugin version. So:

- PyPI artifact \`yantrikdb-hermes-plugin==0.4.13\` ships \`plugin.yaml: 0.4.12\`
- \`hermes plugins list\` displays \`0.4.12\` even on a fresh install
- The four new trigger consumer tools all work in v0.4.13; it's purely a version-display sync bug

PyPI is immutable so we can't republish 0.4.13 — v0.4.14 is the corrected manifest.

## What this PR ships

Two commits:
1. \`b393ef1\` — @alienos's plugin.yaml fix (0.4.12 → 0.4.13)
2. \`5499af8\` — version bump on top: pyproject.toml + plugin.yaml + CHANGELOG to 0.4.14

No code changes. No API changes. Functionally identical to v0.4.13.

## Procedural carry-forward

Pre-release version-sync checklist needs to include \`plugin.yaml\` alongside \`pyproject.toml\` + \`CHANGELOG.md\`. Same rejection-surface pattern as the v0.7.16 GitHub-release-page miss (rid 019e33fe in memory): I verified the surfaces I monitor (PyPI JSON, GitHub release page, git tag, CHANGELOG) but missed the surface the user actually monitors (\`hermes plugins list\` sourced from \`plugin.yaml\`).

## Credit

@alienos's fifth substantive contribution after #4, #9, #15, #17. Cycle time on this one: ~2h from v0.4.13 release to their PR opening — high-rigor reporter.