### PR TITLE
ci: version-sync guard + bump-my-version config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,35 @@ on:
     branches: [main, master]
 
 jobs:
+  # Catches the v0.4.13 release-day miss: pyproject.toml + plugin.yaml +
+  # CHANGELOG header must all carry the same version, or PyPI ships with
+  # a stale Hermes-side manifest. Cheap static check, runs once per PR.
+  version-sync:
+    name: Version sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify version surfaces match
+        run: |
+          set -euo pipefail
+          PYPROJECT=$(grep -E '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          PLUGIN_YAML=$(grep -E '^version: ' yantrikdb/plugin.yaml | head -1 | sed 's/version: //')
+          CHANGELOG=$(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' yantrikdb/CHANGELOG.md | head -1 | sed 's/## \[\(.*\)\]/\1/')
+          echo "pyproject.toml = $PYPROJECT"
+          echo "plugin.yaml    = $PLUGIN_YAML"
+          echo "CHANGELOG.md   = $CHANGELOG"
+          if [ "$PYPROJECT" != "$PLUGIN_YAML" ] || [ "$PYPROJECT" != "$CHANGELOG" ]; then
+            echo "::error::Version drift — pyproject.toml=$PYPROJECT, plugin.yaml=$PLUGIN_YAML, CHANGELOG=$CHANGELOG"
+            echo ""
+            echo "Bump all three together. The repo has bump-my-version configured:"
+            echo "  pipx run bump-my-version bump patch    # 0.4.14 -> 0.4.15"
+            echo "  pipx run bump-my-version bump minor    # 0.4.14 -> 0.5.0"
+            echo "  pipx run bump-my-version bump major    # 0.4.14 -> 1.0.0"
+            echo "Then add a matching CHANGELOG entry."
+            exit 1
+          fi
+          echo "All three version sources match: $PYPROJECT"
+
   test:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,3 +130,38 @@ disallow_untyped_defs = false
 explicit_package_bases = true
 namespace_packages = true
 exclude = ["reference/", "tests/", "^__init__\\.py$"]
+
+# ---------------------------------------------------------------------------
+# bump-my-version — atomic version bumps across all three surfaces
+# ---------------------------------------------------------------------------
+#
+# The plugin's version lives in three places that all have to agree or
+# Hermes-side display drifts (see CHANGELOG v0.4.14 for the post-mortem on
+# the v0.4.13 ship that missed plugin.yaml). bump-my-version edits all of
+# them in one command:
+#
+#   pipx run bump-my-version bump patch     # 0.4.14 -> 0.4.15
+#   pipx run bump-my-version bump minor     # 0.4.14 -> 0.5.0
+#   pipx run bump-my-version bump major     # 0.4.14 -> 1.0.0
+#
+# CHANGELOG.md still needs a hand-written entry for the new version — the
+# tool can't generate meaningful release notes. After bumping, add the
+# matching `## [X.Y.Z] — YYYY-MM-DD — Summary` header. The CI `version-sync`
+# job blocks merge if the three sources drift.
+[tool.bumpversion]
+current_version = "0.4.14"
+commit = false       # let the human author the commit message + body
+tag = false          # tag via `gh release create`, not on bump
+allow_dirty = true
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "yantrikdb/plugin.yaml"
+search = "version: {current_version}"
+replace = "version: {new_version}"


### PR DESCRIPTION
Pipeline hardening so the v0.4.13 → v0.4.14 manifest-drift miss doesn't recur.

## Why

v0.4.13 shipped with `pyproject.toml` + `CHANGELOG` bumped to 0.4.13 but `plugin.yaml` stuck at 0.4.12. PyPI is immutable so the broken-manifest wheel sits there permanently; we had to cut v0.4.14 with the corrected manifest. @alienos caught it (PR #19) within ~2h of release, but a CI guard would have caught it before merge.

## What this PR ships

**1. CI version-sync guard** (new `version-sync` job in `.github/workflows/ci.yml`)

Reads three sources and fails if any differ:
- `pyproject.toml` — `version = "X.Y.Z"`
- `yantrikdb/plugin.yaml` — `version: X.Y.Z`
- `yantrikdb/CHANGELOG.md` — latest `## [X.Y.Z]` header

~20 lines of bash, zero new deps, runs once per PR (not per Python matrix row).

**2. `bump-my-version` config** (under `[tool.bumpversion]` in `pyproject.toml`)

Atomic bumps via `pipx run bump-my-version bump patch` (or `minor` / `major`) edit both `pyproject.toml` and `plugin.yaml` in one command. CHANGELOG stays human-curated since meaningful release notes can't be auto-generated; the CI guard catches the case where humans forget the CHANGELOG entry.

## Local dry-run

```
$ bash -c 'PYPROJECT=$(grep ^version pyproject.toml | sed ...); ...'
pyproject.toml = 0.4.14
plugin.yaml    = 0.4.14
CHANGELOG.md   = 0.4.14
OK: all three match at 0.4.14
```

The guard will pass on this PR (versions all sit at 0.4.14, the v0.4.14 baseline).

## Future release flow

```
pipx run bump-my-version bump patch    # 0.4.14 -> 0.4.15
(hand-edit CHANGELOG.md with new section header + notes)
git commit + push + PR
gh release create v0.4.15
```

Any version drift blocks merge. Carries forward the procedural lesson from rid 019e33fe (v0.7.16 release-page miss) and 019e50ec (v0.4.13 plugin.yaml miss): rejection-surface checks need to cover every surface a downstream consumer queries, not just the PyPI artifact.