### PR TITLE
fix: align root plugin manifest version

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.4.12
+version: 0.4.17
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the


### PR DESCRIPTION
## Summary
- Align the root `plugin.yaml` version with the bundled `yantrikdb/plugin.yaml` version.
- Keeps both manifests at `0.4.17`, matching the existing note that both copies should declare the same version.

## Test Plan
- Verified local dashboard health now reports both manifest versions as `0.4.17` with no mismatch warning.
