### PR TITLE
ci: extend version-sync to root plugin.yaml + pin via test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,26 @@ jobs:
         run: |
           set -euo pipefail
           PYPROJECT=$(grep -E '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          PLUGIN_YAML=$(grep -E '^version: ' yantrikdb/plugin.yaml | head -1 | sed 's/version: //')
+          PLUGIN_YAML_PKG=$(grep -E '^version: ' yantrikdb/plugin.yaml | head -1 | sed 's/version: //')
+          PLUGIN_YAML_ROOT=$(grep -E '^version: ' plugin.yaml | head -1 | sed 's/version: //')
           CHANGELOG=$(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' yantrikdb/CHANGELOG.md | head -1 | sed 's/## \[\(.*\)\]/\1/')
-          echo "pyproject.toml = $PYPROJECT"
-          echo "plugin.yaml    = $PLUGIN_YAML"
-          echo "CHANGELOG.md   = $CHANGELOG"
-          if [ "$PYPROJECT" != "$PLUGIN_YAML" ] || [ "$PYPROJECT" != "$CHANGELOG" ]; then
-            echo "::error::Version drift — pyproject.toml=$PYPROJECT, plugin.yaml=$PLUGIN_YAML, CHANGELOG=$CHANGELOG"
+          echo "pyproject.toml         = $PYPROJECT"
+          echo "yantrikdb/plugin.yaml  = $PLUGIN_YAML_PKG  (read by bundled-discovery install)"
+          echo "plugin.yaml (root)     = $PLUGIN_YAML_ROOT  (read by 'hermes plugins install <gh-repo>')"
+          echo "CHANGELOG.md           = $CHANGELOG"
+          if [ "$PYPROJECT" != "$PLUGIN_YAML_PKG" ] \
+              || [ "$PYPROJECT" != "$PLUGIN_YAML_ROOT" ] \
+              || [ "$PYPROJECT" != "$CHANGELOG" ]; then
+            echo "::error::Version drift — pyproject=$PYPROJECT, plugin_yaml_pkg=$PLUGIN_YAML_PKG, plugin_yaml_root=$PLUGIN_YAML_ROOT, CHANGELOG=$CHANGELOG"
             echo ""
-            echo "Bump all three together. The repo has bump-my-version configured:"
-            echo "  pipx run bump-my-version bump patch    # 0.4.14 -> 0.4.15"
-            echo "  pipx run bump-my-version bump minor    # 0.4.14 -> 0.5.0"
-            echo "  pipx run bump-my-version bump major    # 0.4.14 -> 1.0.0"
+            echo "All four surfaces must agree. The repo has bump-my-version configured:"
+            echo "  pipx run bump-my-version bump patch    # 0.4.17 -> 0.4.18"
+            echo "  pipx run bump-my-version bump minor    # 0.4.17 -> 0.5.0"
+            echo "  pipx run bump-my-version bump major    # 0.4.17 -> 1.0.0"
             echo "Then add a matching CHANGELOG entry."
             exit 1
           fi
-          echo "All three version sources match: $PYPROJECT"
+          echo "All four version sources match: $PYPROJECT"
 
   test:
     name: Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,3 +172,16 @@ replace = 'version = "{new_version}"'
 filename = "yantrikdb/plugin.yaml"
 search = "version: {current_version}"
 replace = "version: {new_version}"
+
+# The repo root also has a plugin.yaml — read by Hermes when a user runs
+# `hermes plugins install yantrikos/yantrikdb-hermes-plugin` directly
+# against the GitHub repo (the package-internal copy is what the bundled-
+# discovery path uses after `yantrikdb-hermes install <hermes>`). Both
+# must declare the same version or `hermes plugins list` shows stale info
+# for one install path. The root copy drifted from 0.4.12 → 0.4.17 across
+# five releases before community member [@wysie] caught it via dashboard
+# mismatch warning in PR #26; CI version-sync now checks both manifests.
+[[tool.bumpversion.files]]
+filename = "plugin.yaml"
+search = "version: {current_version}"
+replace = "version: {new_version}"

--- a/tests/test_manifest_sync.py
+++ b/tests/test_manifest_sync.py
@@ -1,0 +1,69 @@
+"""The version field must agree across all four surfaces.
+
+Belt-and-suspenders with the CI `version-sync` job: if a contributor runs
+`pytest` locally before pushing, this test catches the drift before CI.
+
+The four surfaces and what reads each:
+
+- ``pyproject.toml``         — PyPI artifact metadata; pip / dependency
+  resolvers read this.
+- ``yantrikdb/plugin.yaml``  — bundled inside the wheel; the
+  ``yantrikdb-hermes install <hermes>`` CLI copies this into the user's
+  Hermes plugins dir, so it's what ``hermes plugins list`` reports for
+  pip-installed users.
+- ``plugin.yaml`` (root)     — read directly by Hermes when a user runs
+  ``hermes plugins install yantrikos/yantrikdb-hermes-plugin`` against
+  the GitHub repo (no pip involved). Drifted from 0.4.12 → 0.4.17 across
+  five releases before community member [@wysie] caught it in PR #26 via
+  a dashboard mismatch warning.
+- ``yantrikdb/CHANGELOG.md`` — first ``## [X.Y.Z]`` header. The release
+  notes the project's `gh release create` step references.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _read_pyproject_version() -> str:
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    m = re.search(r'^version = "([^"]+)"', text, re.MULTILINE)
+    assert m, "pyproject.toml missing [project] version line"
+    return m.group(1)
+
+
+def _read_yaml_version(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    m = re.search(r"^version:\s*([0-9.]+)", text, re.MULTILINE)
+    assert m, f"{path} missing top-level 'version:' line"
+    return m.group(1)
+
+
+def _read_changelog_head_version() -> str:
+    text = (REPO_ROOT / "yantrikdb" / "CHANGELOG.md").read_text(encoding="utf-8")
+    m = re.search(r"^## \[([0-9.]+)\]", text, re.MULTILINE)
+    assert m, "CHANGELOG.md missing first '## [X.Y.Z]' header"
+    return m.group(1)
+
+
+def test_all_four_version_surfaces_agree():
+    pyproject = _read_pyproject_version()
+    plugin_yaml_pkg = _read_yaml_version(REPO_ROOT / "yantrikdb" / "plugin.yaml")
+    plugin_yaml_root = _read_yaml_version(REPO_ROOT / "plugin.yaml")
+    changelog = _read_changelog_head_version()
+
+    surfaces = {
+        "pyproject.toml": pyproject,
+        "yantrikdb/plugin.yaml": plugin_yaml_pkg,
+        "plugin.yaml (root)": plugin_yaml_root,
+        "CHANGELOG.md head": changelog,
+    }
+    distinct = set(surfaces.values())
+    assert len(distinct) == 1, (
+        f"Version drift across surfaces: {surfaces!r}. "
+        "All four must agree or `hermes plugins list` and PyPI display "
+        "the wrong version on at least one install path. Use "
+        "`bump-my-version bump patch` to update all four together."
+    )


### PR DESCRIPTION
## Summary

Follow-up to #26. The root `plugin.yaml` (read by `hermes plugins install yantrikos/yantrikdb-hermes-plugin` from GitHub) drifted from 0.4.12 → 0.4.17 across five releases because the CI version-sync guard I added in #21 only checked `yantrikdb/plugin.yaml`. Community member [@wysie] caught it in #26 via dashboard mismatch warning.

Three preventive changes so this can't recur:

1. **CI version-sync extended** — now checks all four surfaces (`pyproject.toml` + `yantrikdb/plugin.yaml` + `plugin.yaml` (root) + `CHANGELOG.md` head). Error message lists each with the install path that reads it.
2. **bump-my-version config** — root `plugin.yaml` added to the files list so future bumps stay aligned.
3. **`tests/test_manifest_sync.py`** — asserts all four agree. Belt-and-suspenders with CI: a contributor running `pytest` locally catches drift before push.

## The two manifest copies and what reads each

| File | Reader | Install path |
|---|---|---|
| `yantrikdb/plugin.yaml` | bundled inside the wheel | `pip install yantrikdb-hermes-plugin && yantrikdb-hermes install <hermes>` |
| `plugin.yaml` (root) | Hermes plugin loader | `hermes plugins install yantrikos/yantrikdb-hermes-plugin` (from GitHub) |

Both must declare the same version or `hermes plugins list` reports the wrong number for at least one install path.

## Test plan

- [x] `tests/test_manifest_sync.py` passes locally
- [x] Full suite: 222 pass (+1)
- [x] ruff + mypy clean
- [x] Manually replicated new CI guard logic against current state — all four at 0.4.17

## Not in scope

Whether to cut v0.4.18 for the manifest-tag fix is a separate decision — PyPI users are unaffected (the wheel always uses the bundled copy, which has been correct), so this PR alone closes the drift on `main`. Tag-install users currently pointing at the v0.4.17 tag are still pinned to 0.4.12 in their `plugins list` until a new tag lands.