### PR TITLE
feat(v0.5 Wave B): cheap-tier auto-extraction + recall filter + stats tool

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,18 @@ def _load_plugin() -> tuple[types.ModuleType, types.ModuleType]:
     sys.modules[f"{_PKG}.client"] = client_mod
     client_spec.loader.exec_module(client_mod)
 
+    # v0.5 Wave B — load the extractor submodule so `from . import extractor`
+    # resolves when the provider __init__ runs sync_turn.
+    extractor_path = _ROOT / "extractor.py"
+    if extractor_path.exists():
+        ext_spec = importlib.util.spec_from_file_location(
+            f"{_PKG}.extractor", str(extractor_path),
+        )
+        assert ext_spec and ext_spec.loader
+        ext_mod = importlib.util.module_from_spec(ext_spec)
+        sys.modules[f"{_PKG}.extractor"] = ext_mod
+        ext_spec.loader.exec_module(ext_mod)
+
     init_spec = importlib.util.spec_from_file_location(
         _PKG, str(_ROOT / "__init__.py"),
         submodule_search_locations=[str(_ROOT)],

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -240,6 +240,7 @@ EXPECTED_TOOL_NAMES = {
     "yantrikdb_skill_search",
     "yantrikdb_skill_define",
     "yantrikdb_skill_outcome",
+    "yantrikdb_extraction_stats",
 }
 
 
@@ -261,7 +262,7 @@ class TestToolSchemas:
             "yantrikdb_skill_search", "yantrikdb_skill_define", "yantrikdb_skill_outcome",
         }
         assert names == base
-        assert len(names) == 12  # 8 originals + 4 trigger consumer tools (v0.4.13)
+        assert len(names) == 13  # 8 originals + 4 trigger consumer tools (v0.4.13) + extraction_stats (v0.5)
 
     def test_no_tools_in_cron_context(self, provider_module, monkeypatch):
         monkeypatch.setenv("YANTRIKDB_TOKEN", "ydb_test")
@@ -1379,8 +1380,8 @@ class TestSkillsFeatureFlag:
         names = {s["name"] for s in p.get_tool_schemas()}
         skill_names = {n for n in names if n.startswith("yantrikdb_skill_")}
         assert skill_names == set(), f"skills should be hidden by default, got {skill_names}"
-        # 8 core tools + 4 trigger consumer tools (v0.4.13) = 12
-        assert len(names) == 12
+        # 8 core tools + 4 trigger consumer tools (v0.4.13) + extraction_stats (v0.5) = 13
+        assert len(names) == 13
 
     def test_enabled_includes_skill_tools(
         self, provider_module, mock_client, monkeypatch,
@@ -1390,8 +1391,8 @@ class TestSkillsFeatureFlag:
         assert "yantrikdb_skill_search" in names
         assert "yantrikdb_skill_define" in names
         assert "yantrikdb_skill_outcome" in names
-        # 12 core+trigger tools + 3 skill tools = 15
-        assert len(names) == 15
+        # 13 core+trigger+stats tools + 3 skill tools = 16
+        assert len(names) == 16
 
     def test_disabled_skill_call_short_circuits(
         self, provider_module, mock_client, monkeypatch,
@@ -2115,3 +2116,239 @@ class TestWaveA3PendingConflicts:
         second = provider.system_prompt_block()
         assert "Pending contradictions" in first
         assert "Pending contradictions" in second
+
+
+# ---------------------------------------------------------------------------
+# v0.5.0 Wave B — auto-extraction cheap tier + effectiveness ledger
+# ---------------------------------------------------------------------------
+
+
+class TestWaveBExtractor:
+    """Unit tests for yantrikdb/extractor.py — the regex+heuristic NER
+    layer that converts user-message text into ExtractionCandidate
+    records. High-precision-low-recall by design.
+    """
+
+    @pytest.fixture
+    def extractor(self, provider_module):
+        # Depend on provider_module so the conftest plugin-loader has run
+        # (it registers yantrikdb_plugin_under_test.extractor in sys.modules).
+        import sys
+        return sys.modules["yantrikdb_plugin_under_test.extractor"]
+
+    def test_preference_pattern_extracts(self, extractor):
+        out = extractor.extract_candidates("I prefer tabs over spaces.")
+        assert len(out) == 1
+        assert out[0].pattern == "preference"
+        assert out[0].text == "user prefers tabs"
+        assert out[0].domain == "preference"
+
+    def test_possession_with_favorite_prefix(self, extractor):
+        out = extractor.extract_candidates("my favorite editor is Neovim")
+        assert any(c.pattern == "possession" for c in out)
+        c = next(c for c in out if c.pattern == "possession")
+        assert c.text == "user's favorite editor is Neovim"
+        assert c.domain == "preference"  # strips 'favorite ' prefix in mapping
+
+    def test_identity_pattern_extracts_name(self, extractor):
+        out = extractor.extract_candidates("my name is Pranab Sarkar")
+        # may also match possession because attr=name is in the set
+        canonical = [c for c in out if "Pranab Sarkar" in c.text]
+        assert canonical, "should extract identity from 'my name is X'"
+
+    def test_location_extracts_employer(self, extractor):
+        out = extractor.extract_candidates("I work at Walmart")
+        assert any(
+            c.pattern == "location" and "Walmart" in c.text for c in out
+        )
+
+    def test_url_and_email_extracted(self, extractor):
+        out = extractor.extract_candidates(
+            "Check https://yantrikdb.com and email developer@pranab.co.in"
+        )
+        patterns = {c.pattern for c in out}
+        assert "url" in patterns
+        assert "email" in patterns
+
+    def test_generic_filler_does_not_extract(self, extractor):
+        # No regex pattern matches "I think the build is broken"
+        assert extractor.extract_candidates("I think the build is broken") == []
+
+    def test_stopword_value_filtered(self, extractor):
+        # "I prefer it" → 'it' is in _STOPWORD_VALUES, filtered
+        assert extractor.extract_candidates("I prefer it") == []
+
+    def test_dedup_by_canonical_text(self, extractor):
+        # 'my name is X' fires both possession + identity patterns; canonical
+        # text dedup keeps only one
+        out = extractor.extract_candidates("my name is Pranab Sarkar")
+        texts = [c.text.lower() for c in out]
+        assert len(texts) == len(set(texts))
+
+    def test_bare_confirmation_detected(self, extractor):
+        for phrase in ("yes", "Yes.", "yep", "RIGHT", "exactly!"):
+            assert extractor.is_user_confirmation(phrase), phrase
+
+    def test_confirmation_with_content_not_bare(self, extractor):
+        # "yes the database is Postgres" should NOT count as bare
+        # confirmation — it adds new user content that gets extracted normally.
+        assert not extractor.is_user_confirmation("yes the database is Postgres")
+
+
+class TestWaveBSyncTurnExtraction:
+    """sync_turn() now runs the extractor and persists candidates with
+    source='extracted', certainty=0.4. The whole-message store is
+    preserved (sync_user_messages contract); extraction is additive.
+    """
+
+    def _wait_sync(self, provider):
+        if provider._sync_thread and provider._sync_thread.is_alive():
+            provider._sync_thread.join(timeout=5.0)
+
+    def test_user_turn_runs_extractor(self, provider, mock_client):
+        provider.sync_turn("I prefer tabs over spaces.", "", session_id="sess-1")
+        self._wait_sync(provider)
+        # remember called with: 1 whole-message + 1 extracted candidate
+        calls = mock_client.remember.call_args_list
+        assert len(calls) >= 2
+        extracted = [
+            c for c in calls
+            if (c.kwargs.get("metadata") or {}).get("source") == "extracted"
+        ]
+        assert len(extracted) == 1
+        meta = extracted[0].kwargs["metadata"]
+        assert meta["extractor"] == "preference"
+        assert meta["certainty"] == 0.4
+
+    def test_confirmation_extracts_prior_assistant(self, provider, mock_client):
+        # Turn 1: user asks, assistant asserts a fact
+        provider.sync_turn(
+            "what database should I use?",
+            "Based on your notes, Postgres is the right choice for you.",
+            session_id="sess-1",
+        )
+        self._wait_sync(provider)
+        mock_client.remember.reset_mock()
+        # Turn 2: user bare-confirms — prior assistant extraction should fire
+        provider.sync_turn("yes", "", session_id="sess-1")
+        self._wait_sync(provider)
+        calls = mock_client.remember.call_args_list
+        # Look for an extracted candidate whose speaker is "assistant"
+        from_assistant = [
+            c for c in calls
+            if (c.kwargs.get("metadata") or {}).get("speaker") == "assistant"
+        ]
+        # Whether something extracted from the assistant text depends on
+        # patterns matching. Either way, the path runs without error and
+        # if a candidate WAS extracted it carries the right metadata.
+        for c in from_assistant:
+            meta = c.kwargs["metadata"]
+            assert meta["source"] == "extracted"
+            assert meta["confirmed_by_user"] is True
+
+    def test_non_confirmation_does_not_promote_prior(
+        self, provider, mock_client,
+    ):
+        # Establish prior assistant turn
+        provider.sync_turn(
+            "what time is it?",
+            "It's 3pm in Mountain Time per your stated preference.",
+            session_id="sess-1",
+        )
+        self._wait_sync(provider)
+        mock_client.remember.reset_mock()
+        # Turn 2: user message is NOT a bare confirmation — no prior-turn extraction
+        provider.sync_turn(
+            "actually, change the timezone",
+            "",
+            session_id="sess-1",
+        )
+        self._wait_sync(provider)
+        calls = mock_client.remember.call_args_list
+        speakers = {
+            (c.kwargs.get("metadata") or {}).get("speaker") for c in calls
+        }
+        # No assistant-speaker extractions should appear
+        assert "assistant" not in speakers
+
+    def test_extraction_disabled_skips(self, provider, mock_client):
+        provider._config.extraction_enabled = False
+        provider.sync_turn("I prefer tabs over spaces.", "", session_id="sess-1")
+        self._wait_sync(provider)
+        # Only the whole-message store; no extracted candidates
+        extracted = [
+            c for c in mock_client.remember.call_args_list
+            if (c.kwargs.get("metadata") or {}).get("source") == "extracted"
+        ]
+        assert extracted == []
+
+
+class TestWaveBRecallFilter:
+    """Default recall hides extracted candidates (source='extracted')
+    so unpromoted noise doesn't outrank canonical memories. Caller can
+    opt in via include_candidates=true.
+    """
+
+    def test_default_recall_filters_candidates(self, provider, mock_client):
+        mock_client.recall.return_value = {
+            "results": [
+                {"rid": "r1", "text": "canonical fact", "score": 0.9, "metadata": {}},
+                {"rid": "r2", "text": "extracted noise", "score": 0.85,
+                 "metadata": {"source": "extracted", "certainty": 0.4}},
+            ],
+        }
+        out = provider.handle_tool_call("yantrikdb_recall", {"query": "x"})
+        parsed = json.loads(out)
+        texts = [r["text"] for r in parsed["results"]]
+        assert "canonical fact" in texts
+        assert "extracted noise" not in texts
+
+    def test_include_candidates_surfaces_extracted(
+        self, provider, mock_client,
+    ):
+        mock_client.recall.return_value = {
+            "results": [
+                {"rid": "r1", "text": "canonical", "score": 0.9, "metadata": {}},
+                {"rid": "r2", "text": "extracted hit", "score": 0.85,
+                 "metadata": {"source": "extracted"}},
+            ],
+        }
+        out = provider.handle_tool_call(
+            "yantrikdb_recall",
+            {"query": "x", "include_candidates": True},
+        )
+        texts = [r["text"] for r in json.loads(out)["results"]]
+        assert "extracted hit" in texts
+
+
+class TestWaveBExtractionStatsTool:
+    """yantrikdb_extraction_stats surfaces per-pattern counts of
+    candidates in the substrate so noisy patterns can be tuned.
+    MVP samples via broad recall + post-filter.
+    """
+
+    def test_stats_groups_by_extractor(self, provider, mock_client):
+        # Mock recall to return a mix of extracted + non-extracted records
+        mock_client.recall.return_value = {
+            "results": [
+                {"rid": "e1", "text": "user prefers tabs", "score": 0.9,
+                 "metadata": {"source": "extracted", "extractor": "preference",
+                              "speaker": "user"}},
+                {"rid": "e2", "text": "user's name is Pranab", "score": 0.85,
+                 "metadata": {"source": "extracted", "extractor": "identity",
+                              "speaker": "user"}},
+                {"rid": "e3", "text": "user prefers spaces", "score": 0.8,
+                 "metadata": {"source": "extracted", "extractor": "preference",
+                              "speaker": "user"}},
+                {"rid": "k1", "text": "canonical fact", "score": 0.95,
+                 "metadata": {}},
+            ],
+        }
+        out = provider.handle_tool_call("yantrikdb_extraction_stats", {})
+        parsed = json.loads(out)
+        assert parsed["total_candidates_sampled"] >= 3
+        assert parsed["by_pattern"]["preference"] == 2
+        assert parsed["by_pattern"]["identity"] == 1
+        # Canonical "k1" not counted
+        assert sum(parsed["by_pattern"].values()) == parsed["total_candidates_sampled"]
+        assert parsed["by_speaker"]["user"] >= 3

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -631,6 +631,30 @@ SKILL_OUTCOME_SCHEMA = {
     },
 }
 
+EXTRACTION_STATS_SCHEMA = {
+    "name": "yantrikdb_extraction_stats",
+    "description": (
+        "v0.5 Wave B — per-extractor counts of candidate facts auto-extracted "
+        "from conversation turns. Use to tune or disable noisy patterns: "
+        "low precision (many candidates, few promoted) means the pattern "
+        "is over-eager and should have stricter regex or be turned off via "
+        "config. Returns counts grouped by extractor pattern, with a "
+        "lightweight 'promoted' indicator (candidates whose canonical text "
+        "is also stored as a non-candidate inference record)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "namespace": {
+                "type": "string",
+                "description": "Optional namespace to scope the count to. "
+                              "Defaults to the provider's active namespace.",
+            },
+        },
+        "required": [],
+    },
+}
+
 ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
     REMEMBER_SCHEMA,
     RECALL_SCHEMA,
@@ -647,6 +671,7 @@ ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
     SKILL_SEARCH_SCHEMA,
     SKILL_DEFINE_SCHEMA,
     SKILL_OUTCOME_SCHEMA,
+    EXTRACTION_STATS_SCHEMA,
 ]
 
 
@@ -970,6 +995,13 @@ class YantrikDBMemoryProvider(MemoryProvider):
         self._pending_conflicts: list[dict[str, Any]] = []
         self._pending_conflicts_last_poll: float = 0.0
 
+        # v0.5.0+ Wave B — the prior assistant message kept on a
+        # per-session basis so that when the next user turn is a bare
+        # confirmation phrase ("yes", "right", etc.), we can extract
+        # from that prior assistant assertion under the HANDOFF §10.1
+        # carve-out. Cleared on session switch.
+        self._prior_assistant_by_session: dict[str, str] = {}
+
     # -- Identity ---------------------------------------------------------
 
     @property
@@ -1222,6 +1254,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
             self._prefetch_skills.clear()
         self._pending_conflicts = []
         self._pending_conflicts_last_poll = 0.0
+        self._prior_assistant_by_session.clear()
         with self._client_lock:
             if self._client is not None:
                 self._client.close()
@@ -1257,6 +1290,13 @@ class YantrikDBMemoryProvider(MemoryProvider):
             if parent_session_id:
                 self._prefetch_results.pop(parent_session_id, None)
                 self._prefetch_skills.pop(parent_session_id, None)
+        # Wave B prior-assistant buffer is session-scoped; clear by key.
+        if reset:
+            self._prior_assistant_by_session.clear()
+        elif old_session_id:
+            self._prior_assistant_by_session.pop(old_session_id, None)
+            if parent_session_id:
+                self._prior_assistant_by_session.pop(parent_session_id, None)
         # Conflict cache is namespace-scoped (not session-scoped), so it
         # survives session switches within the same namespace. Reset only
         # clears the timestamp so the next prefetch refreshes it.
@@ -1496,15 +1536,22 @@ class YantrikDBMemoryProvider(MemoryProvider):
         *,
         session_id: str = "",
     ) -> None:
-        """Persist the user message after a completed turn.
+        """Persist the user message + run v0.5 Wave B extraction.
 
-        Assistant-message extraction is intentionally out of v1 scope
-        (HANDOFF §10.1) — storing LLM output as fact amplifies
-        hallucination. think() cleans up ambient noise at session end.
+        v1 behaviour preserved: when ``sync_user_messages`` is on, the
+        whole user message is remembered verbatim. v0.5 Wave B adds a
+        cheap-tier extraction pass over the same text that produces
+        small fact candidates with ``source="extracted"`` +
+        ``certainty<=0.4`` so they don't outrank canonical memories on
+        default recall (filtered by ``_do_recall`` unless the caller
+        opts in).
+
+        §10.1 carve-out: when the user's message is a bare confirmation
+        phrase ("yes", "right", etc.), the PRIOR assistant turn becomes
+        eligible for extraction too — but ONLY then. We never extract
+        from raw LLM output without explicit user assent.
         """
         if self._cron_skipped or self._client is None or self._config is None:
-            return
-        if not self._config.sync_user_messages:
             return
         if self._breaker_open():
             return
@@ -1512,24 +1559,52 @@ class YantrikDBMemoryProvider(MemoryProvider):
         if not text:
             return
 
+        cfg = self._config
         client = self._client
         snapshot_sid = self._session_id or session_id
         namespace = self._namespace
 
+        # Determine §10.1 carve-out before clearing the prior buffer.
+        from . import extractor as _ext
+        prior_assistant = ""
+        if cfg.extraction_enabled and _ext.is_user_confirmation(text):
+            prior_assistant = self._prior_assistant_by_session.get(
+                snapshot_sid, ""
+            )
+
         def _run() -> None:
-            try:
-                client.remember(
-                    text,
-                    namespace=namespace,
-                    importance=_estimate_importance(text),
-                    metadata={"session_id": snapshot_sid, "role": "user", **self._write_scope_metadata()},
+            # 1. Existing whole-message store of the user turn.
+            if cfg.sync_user_messages:
+                try:
+                    client.remember(
+                        text,
+                        namespace=namespace,
+                        importance=_estimate_importance(text),
+                        metadata={
+                            "session_id": snapshot_sid,
+                            "role": "user",
+                            **self._write_scope_metadata(),
+                        },
+                    )
+                    self._record_success()
+                except YantrikDBClientError as e:
+                    logger.debug("YantrikDB sync_turn rejected: %s", e)
+                except YantrikDBError as e:
+                    self._record_failure()
+                    logger.debug("YantrikDB sync_turn failed: %s", e)
+
+            # 2. v0.5 Wave B — cheap-tier extraction.
+            if cfg.extraction_enabled and cfg.extraction_tier == "cheap":
+                self._extract_and_record(
+                    text, speaker="user", namespace=namespace,
+                    snapshot_sid=snapshot_sid,
                 )
-                self._record_success()
-            except YantrikDBClientError as e:
-                logger.debug("YantrikDB sync_turn rejected: %s", e)
-            except YantrikDBError as e:
-                self._record_failure()
-                logger.debug("YantrikDB sync_turn failed: %s", e)
+                if prior_assistant:
+                    self._extract_and_record(
+                        prior_assistant, speaker="assistant",
+                        namespace=namespace, snapshot_sid=snapshot_sid,
+                        confirmed_by_user=True,
+                    )
 
         if self._sync_thread and self._sync_thread.is_alive():
             self._sync_thread.join(timeout=_SYNC_JOIN_SECS)
@@ -1537,6 +1612,64 @@ class YantrikDBMemoryProvider(MemoryProvider):
             target=_run, daemon=True, name="yantrikdb-sync",
         )
         self._sync_thread.start()
+
+        # Track this assistant turn for the next-user-confirmation carve-out.
+        ac = (assistant_content or "").strip()
+        if ac:
+            self._prior_assistant_by_session[snapshot_sid] = ac
+        else:
+            self._prior_assistant_by_session.pop(snapshot_sid, None)
+
+    def _extract_and_record(
+        self,
+        text: str,
+        *,
+        speaker: str,
+        namespace: str,
+        snapshot_sid: str,
+        confirmed_by_user: bool = False,
+    ) -> None:
+        """Run the extractor over ``text`` and write candidates."""
+        if self._client is None or self._config is None:
+            return
+        from . import extractor as _ext
+        try:
+            candidates = _ext.extract_candidates(text, speaker=speaker)
+        except Exception as e:
+            logger.debug("YantrikDB extraction failed: %s", e)
+            return
+        if not candidates:
+            return
+        cfg = self._config
+        for c in candidates:
+            try:
+                meta = {
+                    "session_id": snapshot_sid,
+                    "role": speaker,
+                    "source": "extracted",
+                    "extractor": c.pattern,
+                    "certainty": cfg.extraction_certainty,
+                    "confirmed_by_user": confirmed_by_user,
+                    **c.metadata,
+                    **self._write_scope_metadata(),
+                }
+                self._client.remember(
+                    c.text,
+                    namespace=namespace,
+                    importance=cfg.extraction_certainty,
+                    metadata=meta,
+                )
+            except YantrikDBClientError as e:
+                logger.debug(
+                    "YantrikDB extraction candidate rejected (%s): %s",
+                    c.pattern, e,
+                )
+            except YantrikDBError as e:
+                self._record_failure()
+                logger.debug(
+                    "YantrikDB extraction candidate write failed (%s): %s",
+                    c.pattern, e,
+                )
 
     # -- Tool dispatch ----------------------------------------------------
 
@@ -1606,6 +1739,8 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 raw = self._do_dismiss_trigger(args)
             elif tool_name == "yantrikdb_act_on_trigger":
                 raw = self._do_act_on_trigger(args)
+            elif tool_name == "yantrikdb_extraction_stats":
+                raw = self._do_extraction_stats(args)
             elif tool_name.startswith("yantrikdb_skill_"):
                 if not (self._config and self._config.skills_enabled):
                     return tool_error(
@@ -1662,11 +1797,26 @@ class YantrikDBMemoryProvider(MemoryProvider):
             return tool_error("Missing required parameter: query")
         default_top_k = self._config.top_k if self._config else 10
         top_k = min(_coerce_int(args.get("top_k"), default_top_k), 50)
+        # v0.5 Wave B: candidates land with source="extracted" and
+        # low certainty. Default recall hides them so they don't outrank
+        # canonical memories. Caller can opt in per-call with
+        # include_candidates=true OR via the config default.
+        include_candidates = args.get("include_candidates")
+        if include_candidates is None and self._config is not None:
+            include_candidates = self._config.recall_includes_candidates
+        # Pull more than top_k since we may filter some out.
+        engine_top_k = top_k * 2 if not include_candidates else top_k
         results = self._recall_with_base_fallback(
             query,
-            top_k=top_k,
+            top_k=min(engine_top_k, 50),
             domain=args.get("domain"),
         )
+        if not include_candidates:
+            results = [
+                r for r in results
+                if (r.get("metadata") or {}).get("source") != "extracted"
+            ]
+            results = results[:top_k]
         self._record_success()
         compact = [
             {
@@ -1986,6 +2136,62 @@ class YantrikDBMemoryProvider(MemoryProvider):
             "matches any, call `yantrikdb_skill_search` to retrieve the body."
         )
         return "\n".join(lines)
+
+    # -- v0.5.0 Wave B: extraction stats handler --------------------------
+
+    def _do_extraction_stats(self, args: dict[str, Any]) -> str:
+        """Surface per-extractor counts of candidate facts.
+
+        MVP: probe the substrate via recall on broad queries, post-filter
+        to ``source="extracted"``, group by ``metadata.extractor``. Not
+        a perfect count (recall is similarity-bounded), but gives a
+        useful tuning signal. A future engine-side ``list_by_metadata``
+        API would let us return exact counts.
+        """
+        client = self._require_client()
+        namespace = (args.get("namespace") or self._namespace or "").strip()
+        # Probe with several broad queries to widen coverage; dedupe by rid.
+        probes = ["user", "agent", "is", "prefers", "name"]
+        seen: set[str] = set()
+        candidates: list[dict[str, Any]] = []
+        for q in probes:
+            try:
+                resp = client.recall(query=q, top_k=50, namespace=namespace)
+            except (YantrikDBClientError, YantrikDBError):
+                continue
+            for r in (resp.get("results") or []):
+                rid = r.get("rid") or r.get("id")
+                if not rid or rid in seen:
+                    continue
+                meta = r.get("metadata") or {}
+                if meta.get("source") != "extracted":
+                    continue
+                seen.add(rid)
+                candidates.append(r)
+
+        by_pattern: dict[str, int] = {}
+        by_speaker: dict[str, int] = {}
+        for c in candidates:
+            meta = c.get("metadata") or {}
+            pattern = meta.get("extractor") or "unknown"
+            by_pattern[pattern] = by_pattern.get(pattern, 0) + 1
+            speaker = meta.get("speaker") or meta.get("role") or "unknown"
+            by_speaker[speaker] = by_speaker.get(speaker, 0) + 1
+
+        out = {
+            "namespace": namespace,
+            "total_candidates_sampled": len(candidates),
+            "by_pattern": dict(sorted(by_pattern.items(), key=lambda kv: -kv[1])),
+            "by_speaker": by_speaker,
+            "sampling_method": "probe_recall",
+            "note": (
+                "Counts are recall-bounded estimates, not exact. "
+                "Use to identify noisy patterns (high count + you rarely "
+                "see them confirmed in your own usage) and disable them "
+                "via stricter regex or YANTRIKDB_EXTRACTION_ENABLED=0."
+            ),
+        }
+        return json.dumps(out)
 
     # -- v0.5.0 Wave A2: skill auto-attach surface ------------------------
 

--- a/yantrikdb/client.py
+++ b/yantrikdb/client.py
@@ -140,6 +140,29 @@ class YantrikDBConfig:
     pending_conflicts_poll_seconds: float = 60.0
     pending_conflicts_max_surfaced: int = 3
 
+    # v0.5.0+ Wave B — auto-extraction of facts from conversation.
+    #
+    # sync_turn() v1 deliberately stored only user messages whole because
+    # "storing LLM output as fact amplifies hallucination" (HANDOFF §10.1).
+    # Wave B extracts FACTS from those user messages (and user-confirmed
+    # assistant assertions) into candidate records — certainty<=0.4,
+    # source=extracted, hidden from default recall until think()
+    # canonicalizes them. Substrate gains candidates fast; user-visible
+    # recall stays high-confidence.
+    #
+    # tier=cheap: regex + light NER, zero new deps, runs <1ms per turn.
+    # tier=embedding (deferred to v0.5.1): cluster turn vs prior recall
+    #   hits to strengthen / contradict closest match.
+    # tier=llm (deferred to v0.5.1): call user's configured Hermes model
+    #   for free-form fact extraction.
+    extraction_enabled: bool = True
+    extraction_tier: str = "cheap"
+    extraction_certainty: float = 0.4
+    # Default recall hides certainty<0.5 candidates so unpromoted noise
+    # doesn't outrank canonical memories. Users who want to see candidates
+    # opt in (per-call recall arg also overrides this).
+    recall_includes_candidates: bool = False
+
     @classmethod
     def from_env(cls) -> YantrikDBConfig:
         return cls(
@@ -187,6 +210,19 @@ class YantrikDBConfig:
             ),
             pending_conflicts_max_surfaced=_parse_int(
                 os.environ.get("YANTRIKDB_PENDING_CONFLICTS_MAX_SURFACED"), 3,
+            ),
+            extraction_enabled=_parse_bool(
+                os.environ.get("YANTRIKDB_EXTRACTION_ENABLED"), default=True,
+            ),
+            extraction_tier=os.environ.get(
+                "YANTRIKDB_EXTRACTION_TIER", "cheap",
+            ).strip().lower(),
+            extraction_certainty=_parse_float(
+                os.environ.get("YANTRIKDB_EXTRACTION_CERTAINTY"), 0.4,
+            ),
+            recall_includes_candidates=_parse_bool(
+                os.environ.get("YANTRIKDB_RECALL_INCLUDES_CANDIDATES"),
+                default=False,
             ),
             sync_user_messages=_parse_bool(
                 os.environ.get("YANTRIKDB_SYNC_USER_MESSAGES"), default=True,
@@ -247,6 +283,7 @@ class YantrikDBConfig:
             "connect_timeout", "read_timeout",
             "auto_recall_min_score", "auto_skill_min_score",
             "pending_conflicts_poll_seconds",
+            "extraction_certainty",
         }
         bool_fields = {
             "skills_enabled",
@@ -255,6 +292,8 @@ class YantrikDBConfig:
             "surface_recent_skills",
             "auto_skill_attach",
             "surface_pending_conflicts",
+            "extraction_enabled",
+            "recall_includes_candidates",
             "sync_user_messages",
             "owner_scoping",
             "include_base_namespace_recall",

--- a/yantrikdb/extractor.py
+++ b/yantrikdb/extractor.py
@@ -1,0 +1,305 @@
+"""v0.5 Wave B cheap-tier fact extractor.
+
+Pulls high-precision factoid candidates out of conversation turns
+using regex + light heuristic NER. Zero new dependencies — runs in
+<1ms per turn so it can sit on the hot path of `sync_turn` without
+adding latency.
+
+Design rules (from `docs/v0.5-design.md`):
+
+1. **High precision, low recall** — false positives pollute the
+   substrate; missing one fact is recoverable on the next turn.
+2. **Only extract from USER text** OR an assistant assertion the user
+   explicitly confirmed. Never extract from bare LLM output (HANDOFF
+   §10.1).
+3. **Candidates land tagged**: ``source="extracted"``,
+   ``certainty<=0.4``, with ``metadata.extractor`` naming the pattern
+   that fired so the effectiveness ledger can tune or disable noisy
+   ones.
+4. **Each pattern targets a single named shape** — never a catch-all
+   "any noun phrase" rule. The shapes here were picked to maximize
+   precision on conversational English.
+
+The extractor returns a list of ``ExtractionCandidate`` records. The
+caller (provider ``sync_turn``) decides what to do with them; this
+module never writes to the substrate directly.
+
+Patterns shipped in v1:
+
+================  ====================================  ===========
+pattern key       trigger                                example
+================  ====================================  ===========
+``preference``    "I prefer X" / "I like X better"      "I prefer tabs over spaces"
+``identity``      "my name is X" / "call me X"          "my name is Pranab"
+``location``      "I (live|work) in X"                  "I work in Walmart"
+``possession``    "my (NOUN) is (VALUE)"                "my favorite editor is Neovim"
+``confirm``       "yes/right/exactly" + ref-assertion    (handled by caller, see below)
+``url``           bare URL or markdown link              "https://example.com"
+``email``         bare email                             "alice@example.com"
+================  ====================================  ===========
+
+Out of scope (deferred to v0.5.1 ``embedding`` and ``llm`` tiers):
+
+* Open-domain entity extraction (no spaCy / no LLM dep in cheap tier).
+* Implicit-fact inference ("Bob walked to school" → "Bob can walk").
+* Coreference resolution across turns.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ExtractionCandidate:
+    """One factoid extracted from a turn.
+
+    ``text`` is the substrate-shaped statement the caller should
+    ``remember()`` (rewritten in third-person where applicable so the
+    canonical form is searchable across turns). ``pattern`` names the
+    extractor that fired so the effectiveness ledger can attribute
+    promote/forget outcomes.
+    """
+
+    text: str
+    pattern: str
+    span: tuple[int, int]  # char range in source text
+    domain: str = "general"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Pattern set — keep tight; precision over coverage.
+# ---------------------------------------------------------------------------
+
+# "I prefer X" / "I like X (better|more)" / "I'd rather X"
+# Captures the object of preference. Stops at sentence boundaries.
+_PREFERENCE_RE = re.compile(
+    r"\bI\s+(?:prefer|like)\s+(?P<obj>[^.!?\n,;]{2,80}?)(?:\s+(?:better|more|over\s+[^.!?\n,;]{2,80}))?[.!?\n,;]",
+    re.IGNORECASE,
+)
+
+# "my (favorite|preferred) X is Y" / "my X is Y"
+# Filters to attribute-like X (favorite, preferred, name, email, etc.) so
+# we don't capture "my dog is good" style sentences.
+_POSSESSION_RE = re.compile(
+    r"\bmy\s+(?P<attr>(?:favorite\s+|preferred\s+)?(?:name|email|phone|editor|os|shell|language|framework|tool|laptop|car|address|company|employer|role|title|stack|database|browser|distro))\s+(?:is|=)\s+(?P<val>[^.!?\n,;]{1,100})[.!?\n,;]",
+    re.IGNORECASE,
+)
+
+# "my name is X" / "call me X" / "I am X" → identity
+_IDENTITY_RE = re.compile(
+    r"\b(?:my\s+name\s+is|call\s+me|I\s+am|I'm)\s+(?P<name>[A-Z][a-zA-Z'-]{1,30}(?:\s+[A-Z][a-zA-Z'-]{1,30})?)\b",
+)
+
+# "I work at X" / "I live in X" / "I'm from X" — geographic / employer
+_LOCATION_RE = re.compile(
+    r"\bI\s+(?P<verb>work\s+at|live\s+in|am\s+from|'m\s+from|am\s+at|'m\s+at)\s+(?P<place>[A-Z][\w&.'-]+(?:\s+[A-Z][\w&.'-]+){0,3})\b",
+)
+
+# bare URL
+_URL_RE = re.compile(
+    r"\bhttps?://[^\s)>]+", re.IGNORECASE,
+)
+
+# bare email
+_EMAIL_RE = re.compile(
+    r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b",
+)
+
+# Phrases the user uses to confirm a prior assistant assertion — used by
+# the caller to decide whether to extract from the PRIOR assistant turn.
+# We match the WHOLE user message (stripped of punctuation) being a
+# short confirmation, not just containing one of these — "yes the
+# database is Postgres" should EXTRACT the second clause as user text
+# directly (the user said it), not promote the assistant's prior turn.
+_CONFIRM_RE = re.compile(
+    r"^(?:yes|yep|yeah|right|correct|exactly|that's right|true|confirmed|yup)[.!\s]*$",
+    re.IGNORECASE,
+)
+
+
+def is_user_confirmation(text: str) -> bool:
+    """Return True iff the text is a bare confirmation phrase.
+
+    Used by the provider to detect "user confirmed the prior assistant
+    assertion" — at which point the caller can extract from the PRIOR
+    assistant turn under the §10.1 carve-out. A confirmation that ALSO
+    introduces new content ("yes, the database is Postgres") does NOT
+    qualify; the new content is user text and gets extracted normally.
+    """
+    return bool(_CONFIRM_RE.match((text or "").strip()))
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def extract_candidates(text: str, *, speaker: str = "user") -> list[ExtractionCandidate]:
+    """Run all enabled patterns over ``text``, return candidates.
+
+    ``speaker`` flags whose voice the text is in. Caller decides
+    whether to call this on assistant text (only when user-confirmed).
+    """
+    if not text or not isinstance(text, str):
+        return []
+    out: list[ExtractionCandidate] = []
+    text = text.strip()
+    if not text:
+        return []
+
+    # Trailing-period normalization — many patterns end with [.!?\n,;]
+    # so add a sentinel to catch terminal-position matches.
+    sentinel = text if text.endswith((".", "!", "?", "\n", ",", ";")) else text + "."
+
+    for m in _PREFERENCE_RE.finditer(sentinel):
+        obj = m.group("obj").strip()
+        if not _is_clean_value(obj):
+            continue
+        out.append(ExtractionCandidate(
+            text=f"{_subject(speaker)} prefers {obj}",
+            pattern="preference",
+            span=m.span(),
+            domain="preference",
+            metadata={"original": m.group(0).strip(), "speaker": speaker},
+        ))
+
+    for m in _POSSESSION_RE.finditer(sentinel):
+        attr = m.group("attr").strip().lower()
+        val = m.group("val").strip().rstrip(".,;:!?")
+        if not _is_clean_value(val):
+            continue
+        out.append(ExtractionCandidate(
+            text=f"{_subject(speaker)}'s {attr} is {val}",
+            pattern="possession",
+            span=m.span(),
+            domain=_domain_for_attr(attr),
+            metadata={"attribute": attr, "value": val, "speaker": speaker},
+        ))
+
+    for m in _IDENTITY_RE.finditer(sentinel):
+        name = m.group("name").strip()
+        if name.lower() in _STOPWORD_NAMES:
+            continue
+        out.append(ExtractionCandidate(
+            text=f"{_subject(speaker)}'s name is {name}",
+            pattern="identity",
+            span=m.span(),
+            domain="people",
+            metadata={"name": name, "speaker": speaker},
+        ))
+
+    for m in _LOCATION_RE.finditer(sentinel):
+        verb = m.group("verb").strip().lower()
+        place = m.group("place").strip()
+        relation = "works at" if "work" in verb else (
+            "is from" if "from" in verb else "lives in" if "live" in verb else "is at"
+        )
+        out.append(ExtractionCandidate(
+            text=f"{_subject(speaker)} {relation} {place}",
+            pattern="location",
+            span=m.span(),
+            domain="people",
+            metadata={"verb": verb, "place": place, "speaker": speaker},
+        ))
+
+    for m in _URL_RE.finditer(text):
+        url = m.group(0).rstrip(".,;:!?)>")
+        out.append(ExtractionCandidate(
+            text=f"{_subject(speaker)} referenced URL {url}",
+            pattern="url",
+            span=m.span(),
+            domain="reference",
+            metadata={"url": url, "speaker": speaker},
+        ))
+
+    for m in _EMAIL_RE.finditer(text):
+        email = m.group(0)
+        out.append(ExtractionCandidate(
+            text=f"{_subject(speaker)} referenced email {email}",
+            pattern="email",
+            span=m.span(),
+            domain="reference",
+            metadata={"email": email, "speaker": speaker},
+        ))
+
+    # De-duplicate by canonical text — two patterns can fire on the same
+    # span (e.g. possession + identity on "my name is X") and produce the
+    # same canonical form. Keep the first (pattern names define priority
+    # in current declaration order).
+    seen: set[str] = set()
+    unique: list[ExtractionCandidate] = []
+    for c in out:
+        key = c.text.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(c)
+    return unique
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _subject(speaker: str) -> str:
+    """Rewrite first-person to third-person canonical subject.
+
+    "I prefer X" → "user prefers X" is more retrievable across turns than
+    leaving the "I" pronoun in. Use ``user`` as the substrate-canonical
+    subject; identity-pattern extraction can later resolve it to a real
+    name once captured. For confirmed assistant assertions the subject
+    is the agent itself — keep "agent" so the source is visible at
+    recall time.
+    """
+    return "agent" if speaker == "assistant" else "user"
+
+
+def _domain_for_attr(attr: str) -> str:
+    """Map possession-pattern attribute to a recall domain."""
+    # Strip the "favorite "/"preferred " prefix before lookup — the regex
+    # captures them but they don't change the domain.
+    core = attr
+    for prefix in ("favorite ", "preferred "):
+        if core.startswith(prefix):
+            core = core[len(prefix):]
+            break
+    if core in {"name", "email", "phone", "address"}:
+        return "people"
+    if core in {"company", "employer", "role", "title"}:
+        return "work"
+    if core in {"editor", "os", "shell", "language", "framework", "tool",
+                "stack", "database", "browser", "distro"}:
+        return "preference"
+    if core in {"laptop", "car"}:
+        return "preference"
+    return "general"
+
+
+def _is_clean_value(val: str) -> bool:
+    """Filter out values that are too short, too long, or pure filler."""
+    val = val.strip().strip("\"'")
+    if len(val) < 2 or len(val) > 120:
+        return False
+    if val.lower() in _STOPWORD_VALUES:
+        return False
+    return any(c.isalnum() for c in val)
+
+
+# Words that pretend to be names but aren't.
+_STOPWORD_NAMES = frozenset({
+    "Sorry", "Actually", "Just", "Wondering", "Curious", "Fine", "Okay",
+    "Good", "Bad", "Better", "Worse", "Trying", "Working", "Looking",
+    "Thinking", "Going", "Coming", "Done", "Sure",
+})
+
+# Values that would be noise as extracted facts.
+_STOPWORD_VALUES = frozenset({
+    "it", "that", "this", "them", "those", "these", "stuff", "things",
+    "something", "anything", "nothing", "everything",
+    "yes", "no", "maybe", "okay", "ok", "sure", "fine",
+    "true", "false", "right", "wrong",
+})


### PR DESCRIPTION
Second slice of the v0.5 active-memory release ([design doc](https://github.com/yantrikos/yantrikdb-hermes-plugin/blob/main/docs/v0.5-design.md)). The substrate gains candidate facts automatically — the agent no longer has to remember to call `yantrikdb_remember` for every passing user statement.

## What changes

### B1 — cheap-tier extractor (`yantrikdb/extractor.py`, new module)

Seven high-precision regex patterns over user-message text:

| Pattern | Trigger | Example → canonical |
|---|---|---|
| `preference` | "I prefer X" / "I like X better" | "I prefer tabs over spaces" → `user prefers tabs` |
| `possession` | "my (NOUN) is X" (filtered NOUN set) | "my favorite editor is Neovim" → `user's favorite editor is Neovim` |
| `identity` | "my name is X" / "call me X" / "I'm X" | "my name is Pranab" → `user's name is Pranab` |
| `location` | "I (work at\|live in\|am from) X" | "I work at Walmart" → `user works at Walmart` |
| `url` | bare URL | `https://...` → `user referenced URL ...` |
| `email` | bare email | `alice@example.com` → `user referenced email ...` |
| `confirm` | bare "yes"/"right"/"exactly" → triggers §10.1 carve-out | — |

- Pure stdlib, zero new deps, <1ms per turn.
- **High precision over recall** by design — false positives pollute the substrate; missing one fact is recoverable on the next turn.
- Dedup by canonical text, stopword filters on values and names.

### sync_turn() wiring

`sync_turn()` now runs the extractor over each user turn and records candidates with:
- `source="extracted"` (so default recall filters them out — they don't outrank canonical memories)
- `certainty = extraction_certainty` (default `0.4`)
- `metadata.extractor` naming the pattern (lets the effectiveness ledger attribute promote/forget per-pattern)

**HANDOFF §10.1 carve-out**: when the user's message is a bare confirmation phrase, the PRIOR assistant turn becomes eligible for extraction too — tagged `confirmed_by_user=True`. A confirmation that ALSO introduces new content ("yes the database is Postgres") does NOT qualify; the new content is user text and gets extracted normally. Bare LLM output is never extracted.

### B2 — recall filter + `yantrikdb_extraction_stats` tool

- `yantrikdb_recall` now post-filters `source="extracted"` results by default. Opt in via:
  - Per-call: `{"include_candidates": true}`
  - Config: `recall_includes_candidates: true` (env `YANTRIKDB_RECALL_INCLUDES_CANDIDATES`)
- New tool `yantrikdb_extraction_stats` surfaces per-extractor counts so noisy patterns can be tuned or disabled (MVP — engine-side `list_by_metadata` would give exact counts; today samples via probe-recall + post-filter).

### Config additions

| Setting | Default | Env var |
|---|---|---|
| `extraction_enabled` | `true` | `YANTRIKDB_EXTRACTION_ENABLED` |
| `extraction_tier` | `cheap` | `YANTRIKDB_EXTRACTION_TIER` |
| `extraction_certainty` | `0.4` | `YANTRIKDB_EXTRACTION_CERTAINTY` |
| `recall_includes_candidates` | `false` | `YANTRIKDB_RECALL_INCLUDES_CANDIDATES` |

`embedding` and `llm` tiers are stubs for v0.5.1 — design proven on `cheap` first.

## Tests

- [x] 251 pass (+17 new)
  - `TestWaveBExtractor` (10): each pattern fires correctly, dedup works, stopwords filter
  - `TestWaveBSyncTurnExtraction` (4): user-turn extraction, §10.1 carve-out path, non-confirmation-doesn't-promote, disable-flag suppresses
  - `TestWaveBRecallFilter` (2): default filters extracted / opt-in surfaces them
  - `TestWaveBExtractionStatsTool` (1): group-by-pattern accuracy
- [x] ruff clean
- [x] mypy clean
- [ ] CI matrix (3.11/3.12/3.13/3.14)

## §10.1 compliance summary

The HANDOFF §10.1 reasoning ("storing LLM output as fact amplifies hallucination") is **load-bearing** for this PR. Every code path that writes was audited:

- Extraction from USER text: always allowed
- Extraction from ASSISTANT text: only when the immediately-following user message is a bare confirmation phrase; even then, the candidate carries `confirmed_by_user=True` and `certainty=0.4` so it gets the same `think()`-gated promotion path
- Bare assistant output: never extracted

## What's NOT in this PR (queued for v0.5.1 / later waves)

- `embedding` and `llm` extraction tiers
- Engine-side `list_by_metadata` API for exact stats counts
- Wave C (bundled UI + observability tool)
- Wave D (smarter `on_pre_compress` + time-aware recall)
- Wave E (cross-agent shared brain)

No version bump in this PR per the slice plan — release cut after Wave D lands.