### PR TITLE
feat(v0.5 Wave C): bundled UI + yantrikdb_observability tool

### DIFF
--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -241,6 +241,7 @@ EXPECTED_TOOL_NAMES = {
     "yantrikdb_skill_define",
     "yantrikdb_skill_outcome",
     "yantrikdb_extraction_stats",
+    "yantrikdb_observability",
 }
 
 
@@ -262,7 +263,7 @@ class TestToolSchemas:
             "yantrikdb_skill_search", "yantrikdb_skill_define", "yantrikdb_skill_outcome",
         }
         assert names == base
-        assert len(names) == 13  # 8 originals + 4 trigger consumer tools (v0.4.13) + extraction_stats (v0.5)
+        assert len(names) == 14  # 8 originals + 4 trigger consumer tools (v0.4.13) + extraction_stats + observability (v0.5)
 
     def test_no_tools_in_cron_context(self, provider_module, monkeypatch):
         monkeypatch.setenv("YANTRIKDB_TOKEN", "ydb_test")
@@ -1380,8 +1381,8 @@ class TestSkillsFeatureFlag:
         names = {s["name"] for s in p.get_tool_schemas()}
         skill_names = {n for n in names if n.startswith("yantrikdb_skill_")}
         assert skill_names == set(), f"skills should be hidden by default, got {skill_names}"
-        # 8 core tools + 4 trigger consumer tools (v0.4.13) + extraction_stats (v0.5) = 13
-        assert len(names) == 13
+        # 8 core + 4 trigger + extraction_stats + observability (v0.5) = 14
+        assert len(names) == 14
 
     def test_enabled_includes_skill_tools(
         self, provider_module, mock_client, monkeypatch,
@@ -1391,8 +1392,8 @@ class TestSkillsFeatureFlag:
         assert "yantrikdb_skill_search" in names
         assert "yantrikdb_skill_define" in names
         assert "yantrikdb_skill_outcome" in names
-        # 13 core+trigger+stats tools + 3 skill tools = 16
-        assert len(names) == 16
+        # 14 core+trigger+stats+observability + 3 skill tools = 17
+        assert len(names) == 17
 
     def test_disabled_skill_call_short_circuits(
         self, provider_module, mock_client, monkeypatch,
@@ -2319,6 +2320,137 @@ class TestWaveBRecallFilter:
         )
         texts = [r["text"] for r in json.loads(out)["results"]]
         assert "extracted hit" in texts
+
+
+class TestWaveCBundledUI:
+    """v0.5 Wave C1 — pure-stdlib HTTP inspector at `yantrikdb-hermes ui`.
+
+    We don't spin up the actual HTTP server here; that's covered by
+    manual smoke + the Hermes-in-docker e2e. These tests pin the
+    module imports cleanly, the HTML renderer escapes content, and the
+    handler routes the two endpoints.
+    """
+
+    def test_ui_module_imports(self, provider_module):
+        # Provider-module dependency forces conftest plugin loader.
+        import importlib
+        import sys
+        # ui.py uses relative imports from the plugin package — load it
+        # through the same plugin_under_test namespace as everything else.
+        spec = importlib.util.spec_from_file_location(
+            "yantrikdb_plugin_under_test.ui",
+            str(provider_module.__file__).rsplit("\\", 1)[0].rsplit("/", 1)[0]
+            + "/yantrikdb/ui.py"
+            if "\\" in provider_module.__file__
+            else "/".join(provider_module.__file__.split("/")[:-1]) + "/ui.py",
+        )
+        # Robust path discovery from the provider module's location
+        from pathlib import Path
+        p = Path(provider_module.__file__).parent / "ui.py"
+        assert p.exists(), f"ui.py expected at {p}"
+        spec = importlib.util.spec_from_file_location(
+            "yantrikdb_plugin_under_test.ui", str(p),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["yantrikdb_plugin_under_test.ui"] = mod
+        spec.loader.exec_module(mod)
+        # The two public hooks must be present.
+        assert hasattr(mod, "serve")
+        assert hasattr(mod, "build_snapshot")
+
+    def test_render_html_escapes_user_content(self, provider_module):
+        import importlib
+        import sys
+        from pathlib import Path
+        p = Path(provider_module.__file__).parent / "ui.py"
+        if "yantrikdb_plugin_under_test.ui" not in sys.modules:
+            spec = importlib.util.spec_from_file_location(
+                "yantrikdb_plugin_under_test.ui", str(p),
+            )
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules["yantrikdb_plugin_under_test.ui"] = mod
+            spec.loader.exec_module(mod)
+        mod = sys.modules["yantrikdb_plugin_under_test.ui"]
+        # The render passes user-content through json.dumps (escape-safe)
+        # and the inline JS uses an HTML-escape helper for conflict text.
+        snapshot = {
+            "namespace": "ns",
+            "memories": [{"rid": "r1", "text": "<script>alert(1)</script>",
+                          "score": 0.9, "source": "", "domain": "general"}],
+            "conflicts": [{"conflict_id": "c1",
+                           "text_a": "<img src=x onerror=alert(2)>",
+                           "text_b": "B"}],
+            "recent_skills": [],
+            "stats": {},
+        }
+        html = mod._render_html(snapshot)
+        # The JSON-embedded snapshot is escaped via json.dumps; raw
+        # tags must not appear unescaped in a SCRIPT-tag-safe way.
+        # json.dumps escapes "</" to "<\/" via slash inversion is NOT
+        # the default — we accept the embedding as long as the JS-side
+        # `escape()` runs on the conflict.text_*. Verify it's wrapped
+        # in escape() in the template.
+        assert 'escape(a)' in html or 'escape(b)' in html, (
+            "conflict text must pass through the JS escape() helper"
+        )
+
+
+class TestWaveCObservability:
+    """yantrikdb_observability rolls up engine stats + extraction +
+    recent skills + provider health into a single response so the agent
+    can answer 'how is my memory doing' without 6 separate tool calls.
+    """
+
+    def test_returns_summary_engine_extraction_provider_sections(
+        self, provider, mock_client,
+    ):
+        mock_client.stats.return_value = {
+            "active_memories": 42, "consolidated_memories": 3,
+            "tombstoned_memories": 5, "edges": 17, "entities": 12,
+            "operations": 128, "open_conflicts": 1, "pending_triggers": 0,
+        }
+        mock_client.recall.return_value = {
+            "results": [{
+                "rid": "e1", "text": "user prefers tabs", "score": 0.9,
+                "metadata": {"source": "extracted", "extractor": "preference",
+                             "speaker": "user"},
+            }],
+        }
+        out = provider.handle_tool_call("yantrikdb_observability", {})
+        parsed = json.loads(out)
+        assert "summary" in parsed
+        assert "engine" in parsed
+        assert "extraction" in parsed
+        assert "provider" in parsed
+        assert parsed["engine"]["active_memories"] == 42
+        assert parsed["engine"]["open_conflicts"] == 1
+        assert parsed["extraction"]["by_pattern"]["preference"] == 1
+        # provider health surfaces breaker state
+        assert "circuit_breaker_open" in parsed["provider"]
+
+    def test_summary_line_human_readable(self, provider, mock_client):
+        mock_client.stats.return_value = {
+            "active_memories": 10, "entities": 3, "edges": 5,
+            "open_conflicts": 0, "consolidated_memories": 0,
+            "tombstoned_memories": 0, "operations": 0, "pending_triggers": 0,
+        }
+        mock_client.recall.return_value = {"results": []}
+        out = provider.handle_tool_call("yantrikdb_observability", {})
+        summary = json.loads(out)["summary"]
+        assert "memories=10" in summary
+        assert "entities=3" in summary
+        assert "breaker=closed" in summary
+
+    def test_degrades_when_one_call_fails(self, provider, mock_client):
+        # If stats() raises, extraction + provider sections still surface.
+        from yantrikdb_plugin_under_test.client import YantrikDBError
+        mock_client.stats.side_effect = YantrikDBError("upstream timeout")
+        mock_client.recall.return_value = {"results": []}
+        out = provider.handle_tool_call("yantrikdb_observability", {})
+        parsed = json.loads(out)
+        assert "error" in parsed["engine"]
+        assert "extraction" in parsed
+        assert "provider" in parsed
 
 
 class TestWaveBExtractionStatsTool:

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -631,6 +631,29 @@ SKILL_OUTCOME_SCHEMA = {
     },
 }
 
+OBSERVABILITY_SCHEMA = {
+    "name": "yantrikdb_observability",
+    "description": (
+        "v0.5 Wave C — one-call substrate health snapshot. Aggregates "
+        "stats, recent extraction activity, conflict counts, breaker "
+        "state, recent skill activity. Use to answer 'how is my memory "
+        "doing' without 6 separate tool calls. Returns engine counters, "
+        "extractor pattern breakdown, recent-skill list, plus a "
+        "human-readable summary line at top."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "namespace": {
+                "type": "string",
+                "description": "Optional namespace to scope to. "
+                              "Defaults to the provider's active namespace.",
+            },
+        },
+        "required": [],
+    },
+}
+
 EXTRACTION_STATS_SCHEMA = {
     "name": "yantrikdb_extraction_stats",
     "description": (
@@ -672,6 +695,7 @@ ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
     SKILL_DEFINE_SCHEMA,
     SKILL_OUTCOME_SCHEMA,
     EXTRACTION_STATS_SCHEMA,
+    OBSERVABILITY_SCHEMA,
 ]
 
 
@@ -1741,6 +1765,8 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 raw = self._do_act_on_trigger(args)
             elif tool_name == "yantrikdb_extraction_stats":
                 raw = self._do_extraction_stats(args)
+            elif tool_name == "yantrikdb_observability":
+                raw = self._do_observability(args)
             elif tool_name.startswith("yantrikdb_skill_"):
                 if not (self._config and self._config.skills_enabled):
                     return tool_error(
@@ -1926,6 +1952,103 @@ class YantrikDBMemoryProvider(MemoryProvider):
             "open_conflicts": resp.get("open_conflicts", 0),
             "pending_triggers": resp.get("pending_triggers", 0),
         })
+
+    def _do_observability(self, args: dict[str, Any]) -> str:
+        """v0.5 Wave C2 — one-call substrate health snapshot.
+
+        Aggregates the four most-useful substrate signals into a single
+        response so the agent (or a curious user) can answer "how is my
+        memory doing" without 6 separate tool calls. Each component
+        degrades gracefully — if one upstream call fails, the others
+        still surface.
+        """
+        client = self._require_client()
+        namespace = (args.get("namespace") or self._namespace or "").strip()
+
+        snapshot: dict[str, Any] = {"namespace": namespace}
+
+        # Engine counters
+        try:
+            engine_stats = client.stats(namespace=namespace)
+            snapshot["engine"] = {
+                "active_memories": engine_stats.get("active_memories", 0),
+                "consolidated_memories": engine_stats.get(
+                    "consolidated_memories", 0,
+                ),
+                "tombstoned_memories": engine_stats.get(
+                    "tombstoned_memories", 0,
+                ),
+                "edges": engine_stats.get("edges", 0),
+                "entities": engine_stats.get("entities", 0),
+                "operations": engine_stats.get("operations", 0),
+                "open_conflicts": engine_stats.get("open_conflicts", 0),
+                "pending_triggers": engine_stats.get("pending_triggers", 0),
+            }
+        except (YantrikDBClientError, YantrikDBError) as e:
+            snapshot["engine"] = {"error": str(e)}
+
+        # Recent extraction activity (reuses extraction_stats logic)
+        try:
+            extraction = json.loads(
+                self._do_extraction_stats({"namespace": namespace})
+            )
+            snapshot["extraction"] = {
+                "total_sampled": extraction.get(
+                    "total_candidates_sampled", 0,
+                ),
+                "by_pattern": extraction.get("by_pattern", {}),
+                "by_speaker": extraction.get("by_speaker", {}),
+            }
+        except Exception as e:
+            snapshot["extraction"] = {"error": str(e)}
+
+        # Recently-defined skills (cross-session, from v0.4.17 record)
+        try:
+            recent = self._load_recent_skills() if hasattr(
+                self, "_load_recent_skills",
+            ) else []
+            snapshot["recent_skills"] = [
+                {
+                    "skill_id": e.get("skill_id"),
+                    "skill_type": e.get("skill_type"),
+                    "age_seconds": int(time.time() - (e.get("ts") or time.time())),
+                }
+                for e in recent[-5:]
+            ]
+        except Exception as e:
+            snapshot["recent_skills"] = {"error": str(e)}
+
+        # Provider health: breaker + queues
+        snapshot["provider"] = {
+            "circuit_breaker_open": self._breaker_open(),
+            "failure_count": self._failure_count,
+            "prefetch_thread_alive": bool(
+                self._prefetch_thread and self._prefetch_thread.is_alive()
+            ),
+            "sync_thread_alive": bool(
+                self._sync_thread and self._sync_thread.is_alive()
+            ),
+        }
+
+        # One-line human summary at the top — what an LLM should read first
+        eng = snapshot["engine"] if isinstance(snapshot["engine"], dict) and "error" not in snapshot["engine"] else {}
+        ext_count = (
+            snapshot["extraction"].get("total_sampled", 0)
+            if isinstance(snapshot["extraction"], dict)
+            and "error" not in snapshot["extraction"] else 0
+        )
+        snapshot["summary"] = (
+            f"namespace={namespace} | "
+            f"memories={eng.get('active_memories', '?')} "
+            f"entities={eng.get('entities', '?')} "
+            f"edges={eng.get('edges', '?')} | "
+            f"open_conflicts={eng.get('open_conflicts', '?')} | "
+            f"extracted_candidates={ext_count} | "
+            f"breaker={'OPEN' if snapshot['provider']['circuit_breaker_open'] else 'closed'}"
+        )
+
+        self._record_success()
+        return json.dumps(snapshot)
 
     def _do_pending_triggers(self, args: dict[str, Any]) -> str:
         limit = _coerce_int(args.get("limit"), 10)

--- a/yantrikdb/cli.py
+++ b/yantrikdb/cli.py
@@ -197,6 +197,24 @@ def cmd_path(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_ui(args: argparse.Namespace) -> int:
+    """v0.5 Wave C — open the bundled read-only substrate inspector.
+
+    Loads the substrate via the same config the provider uses (env vars
+    + $HERMES_HOME/yantrikdb.json), starts a localhost HTTP server, and
+    optionally opens it in the user's browser.
+    """
+    from . import ui as _ui
+    if args.hermes_home:
+        os.environ.setdefault("HERMES_HOME", str(Path(args.hermes_home).expanduser()))
+    try:
+        _ui.serve(host=args.host, port=args.port, open_browser=args.open)
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 4
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="yantrikdb-hermes",
@@ -256,6 +274,20 @@ def main(argv: list[str] | None = None) -> int:
         help="print the on-disk path of the installed provider source",
     )
     p_path.set_defaults(func=cmd_path)
+
+    p_ui = sub.add_parser(
+        "ui",
+        help="open the bundled read-only substrate inspector (v0.5+)",
+    )
+    p_ui.add_argument("--host", default="127.0.0.1",
+                      help="host to bind (default: 127.0.0.1)")
+    p_ui.add_argument("--port", type=int, default=8767,
+                      help="port to listen on (default: 8767)")
+    p_ui.add_argument("--open", action="store_true",
+                      help="open the page in the default browser on startup")
+    p_ui.add_argument("--hermes-home", type=str, default=None,
+                      help="HERMES_HOME override (default: $HERMES_HOME or ~/.hermes)")
+    p_ui.set_defaults(func=cmd_ui)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/yantrikdb/ui.py
+++ b/yantrikdb/ui.py
@@ -1,0 +1,385 @@
+"""v0.5 Wave C bundled UI — pure-stdlib HTTP server + single-page constellation.
+
+``yantrikdb-hermes ui [--port 8767] [--open]`` opens a localhost web
+inspector that shows three sections against the active substrate:
+
+1. **Constellation** — memories rendered as glowing nodes, semantic
+   neighbours linked by faint edges. Stripped-down version of the
+   constellation in `assets/demos/skill-lifecycle/demo_visual.py` and
+   wysie's full dashboard. Read-only.
+2. **Recent skills** — last N skills surfaced from
+   ``$HERMES_HOME/yantrikdb-recent-skills.json`` (the v0.4.17 carry-
+   forward record) plus a recall pass over the skill namespace.
+3. **Unresolved conflicts** — current ``conflicts()`` output, displayed
+   as A/B pairs with the conflict_id for follow-up via
+   ``yantrikdb_resolve_conflict``.
+
+Scope per design (`docs/v0.5-design.md` §C1): read-only, single page,
+3 sections, ~250 LOC total. **NOT** a replacement for wysie's full
+dashboard — this is the *first-10-minutes-after-install* tool that
+ships in the wheel so users can see the substrate within 30 seconds of
+``pip install``.
+"""
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import socketserver
+import threading
+import webbrowser
+from pathlib import Path
+from typing import Any
+
+__all__ = ["serve", "build_snapshot"]
+
+
+def _load_client() -> tuple[Any, str]:
+    """Connect to the active substrate via the same config the provider uses."""
+    from .client import YantrikDBConfig
+    from .embedded import EmbeddedYantrikDBClient
+
+    hermes_home = os.environ.get("HERMES_HOME")
+    cfg = YantrikDBConfig.load(Path(hermes_home) if hermes_home else None)
+    if cfg.mode != "embedded":
+        raise RuntimeError(
+            "bundled UI only supports embedded mode. For HTTP-cluster "
+            "deployments use wysie's full dashboard."
+        )
+    client = EmbeddedYantrikDBClient(cfg)
+    namespace = cfg.namespace or "hermes"
+    return client, namespace
+
+
+def build_snapshot() -> dict[str, Any]:
+    """One-shot substrate snapshot for the UI (called per page refresh)."""
+    client, namespace = _load_client()
+
+    # Memories — pull recent via broad probes, dedupe by rid.
+    seen: set[str] = set()
+    memories: list[dict[str, Any]] = []
+    for q in ("user", "agent", "is", "prefers", "the"):
+        try:
+            resp = client.recall(query=q, top_k=20, namespace=namespace)
+        except Exception:
+            continue
+        for r in (resp.get("results") or []):
+            rid = r.get("rid")
+            if not rid or rid in seen:
+                continue
+            seen.add(rid)
+            memories.append({
+                "rid": rid,
+                "text": (r.get("text") or "")[:200],
+                "score": r.get("score"),
+                "source": (r.get("metadata") or {}).get("source", ""),
+                "domain": r.get("domain") or (r.get("metadata") or {}).get("domain", ""),
+            })
+
+    # Conflicts
+    try:
+        conflicts_resp = client.conflicts(namespace=namespace)
+        conflicts = conflicts_resp.get("conflicts", []) or []
+    except Exception:
+        conflicts = []
+
+    # Recently-defined skills (the v0.4.17 record under $HERMES_HOME)
+    recent_skills: list[dict[str, Any]] = []
+    hermes_home = os.environ.get("HERMES_HOME")
+    if hermes_home:
+        path = Path(hermes_home) / "yantrikdb-recent-skills.json"
+        if path.exists():
+            try:
+                recent_skills = json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                recent_skills = []
+
+    # Engine stats for the header
+    try:
+        stats = client.stats(namespace=namespace)
+    except Exception:
+        stats = {}
+
+    return {
+        "namespace": namespace,
+        "memories": memories,
+        "conflicts": conflicts,
+        "recent_skills": recent_skills,
+        "stats": stats,
+    }
+
+
+def _render_html(snapshot: dict[str, Any]) -> str:
+    """Render the single-page UI. Inline HTML/CSS/JS — no external assets."""
+    return _PAGE_TEMPLATE.replace(
+        "__SNAPSHOT_JSON__",
+        json.dumps(snapshot, default=str),
+    )
+
+
+_PAGE_TEMPLATE = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>YantrikDB · substrate inspector</title>
+<style>
+  :root {
+    --bg: #0a0e1a; --grid: #1a2030; --text: #cdd6f4; --dim: #6c7086;
+    --proc: #94e2d5; --ref: #89b4fa; --lesson: #f9e2af; --rule: #cba6f7;
+    --new: #f38ba8; --ok: #a6e3a1; --warn: #f9e2af;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; padding: 24px; background: var(--bg); color: var(--text);
+         font-family: "JetBrains Mono", "Fira Code", Consolas, monospace;
+         font-size: 13px; line-height: 1.45; }
+  h1 { font-size: 18px; margin: 0 0 4px; font-weight: 600; }
+  h2 { font-size: 14px; margin: 24px 0 8px; color: var(--dim); font-weight: 500;
+       text-transform: uppercase; letter-spacing: 0.05em; }
+  .sub { color: var(--dim); margin-bottom: 24px; font-size: 11px; }
+  .stats { display: flex; gap: 16px; flex-wrap: wrap; padding: 12px 16px;
+           background: #11151f; border-radius: 6px; margin-bottom: 24px; }
+  .stat { display: flex; flex-direction: column; }
+  .stat .v { color: var(--text); font-size: 16px; font-weight: 600; }
+  .stat .l { color: var(--dim); font-size: 10px; text-transform: uppercase; }
+  svg.constellation { display: block; width: 100%; height: 480px;
+                      background: #11151f; border-radius: 6px;
+                      margin-bottom: 24px; }
+  .node circle { stroke: white; stroke-width: 1.2; opacity: 0.9; }
+  .node text { fill: var(--text); font-size: 9px; font-family: inherit;
+               pointer-events: none; }
+  .edge { stroke: #3b4252; stroke-width: 0.8; opacity: 0.4; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 16px; }
+  th, td { padding: 6px 10px; text-align: left; border-bottom: 1px solid var(--grid);
+           vertical-align: top; }
+  th { color: var(--dim); text-transform: uppercase; font-size: 10px;
+       letter-spacing: 0.05em; font-weight: 500; }
+  td { color: var(--text); font-size: 12px; }
+  .pill { display: inline-block; padding: 2px 8px; border-radius: 99px;
+          font-size: 10px; }
+  .pill-extracted { background: #2d1f1f; color: var(--new); }
+  .pill-skill { background: #1f2d2d; color: var(--proc); }
+  .empty { color: var(--dim); font-style: italic; padding: 16px 0; }
+  .conflict { border-left: 2px solid var(--new); padding: 8px 12px;
+              margin-bottom: 8px; background: #11151f; }
+  .conflict .id { color: var(--dim); font-size: 10px; }
+  .conflict .pair { display: flex; gap: 16px; margin-top: 4px; }
+  .conflict .pair > div { flex: 1; padding: 6px 10px; background: #0a0e1a;
+                          border-radius: 4px; }
+  .conflict .label { color: var(--dim); font-size: 10px; margin-bottom: 2px; }
+  footer { color: var(--dim); font-size: 11px; margin-top: 32px;
+           padding-top: 16px; border-top: 1px solid var(--grid); }
+  a { color: var(--ref); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+<h1>YantrikDB · substrate inspector</h1>
+<div class="sub" id="sub"></div>
+<div class="stats" id="stats"></div>
+
+<h2>Constellation</h2>
+<svg class="constellation" id="constellation"></svg>
+
+<h2>Recently learned skills</h2>
+<table id="skills-table"><thead><tr>
+  <th>skill_id</th><th>type</th><th>scope</th><th>age</th>
+</tr></thead><tbody></tbody></table>
+<div class="empty" id="skills-empty" style="display:none">
+  No skills defined recently. Run with YANTRIKDB_SKILLS_ENABLED=true and call
+  yantrikdb_skill_define to record one.
+</div>
+
+<h2>Unresolved contradictions</h2>
+<div id="conflicts"></div>
+<div class="empty" id="conflicts-empty" style="display:none">
+  No unresolved conflicts. Run yantrikdb_think() to surface new ones.
+</div>
+
+<footer>
+  Read-only UI from yantrikdb-hermes-plugin. For full dashboard
+  (multi-DB, mutations, auth) install
+  <a href="https://github.com/wysie/yantrikdb-hermes-dashboard" target="_blank">wysie's dashboard</a>.
+  &nbsp;|&nbsp; <a href="/api/snapshot">raw JSON</a>
+</footer>
+
+<script>
+const data = __SNAPSHOT_JSON__;
+
+document.getElementById("sub").textContent =
+  "namespace: " + (data.namespace || "(unset)") + " · live snapshot at page load";
+
+const s = data.stats || {};
+const stats = [
+  ["memories", s.active_memories],
+  ["entities", s.entities],
+  ["edges", s.edges],
+  ["conflicts", s.open_conflicts],
+  ["operations", s.operations],
+  ["tombstoned", s.tombstoned_memories],
+];
+document.getElementById("stats").innerHTML = stats.map(([l, v]) =>
+  `<div class="stat"><div class="v">${v ?? "?"}</div><div class="l">${l}</div></div>`
+).join("");
+
+// Constellation: simple circular layout over the recent memories.
+const svg = document.getElementById("constellation");
+const W = svg.clientWidth || 1000, H = 480;
+const memories = (data.memories || []).slice(0, 40);
+const cx = W / 2, cy = H / 2;
+const r = Math.min(W, H) * 0.4;
+
+// Edges: connect each memory to its nearest neighbours by domain match
+const byDomain = {};
+memories.forEach((m, i) => {
+  const d = m.domain || m.source || "general";
+  (byDomain[d] = byDomain[d] || []).push(i);
+});
+
+const edges = [];
+for (const grp of Object.values(byDomain)) {
+  for (let i = 0; i < grp.length - 1; i++) {
+    edges.push([grp[i], grp[i + 1]]);
+  }
+}
+
+const COLOR = {
+  "preference": "#94e2d5", "people": "#89b4fa", "work": "#f9e2af",
+  "reference": "#cba6f7", "extracted": "#f38ba8",
+  "general": "#cdd6f4",
+};
+
+const pts = memories.map((_, i) => {
+  const a = (2 * Math.PI * i) / Math.max(memories.length, 1) - Math.PI / 2;
+  return [cx + r * Math.cos(a), cy + r * Math.sin(a) * 0.75];
+});
+
+let html = "";
+for (const [a, b] of edges) {
+  html += `<line class="edge" x1="${pts[a][0]}" y1="${pts[a][1]}" `
+        + `x2="${pts[b][0]}" y2="${pts[b][1]}"/>`;
+}
+memories.forEach((m, i) => {
+  const [x, y] = pts[i];
+  const color = COLOR[m.source === "extracted" ? "extracted" : (m.domain || "general")]
+              || "#cdd6f4";
+  const text = (m.text || "").slice(0, 28);
+  html += `<g class="node">`
+        + `<circle cx="${x}" cy="${y}" r="6" fill="${color}"/>`
+        + `<text x="${x}" y="${y + 16}" text-anchor="middle">${text.replace(/[<>&]/g, c => ({"<":"&lt;",">":"&gt;","&":"&amp;"}[c]))}</text>`
+        + `</g>`;
+});
+if (!memories.length) {
+  html = `<text x="${cx}" y="${cy}" text-anchor="middle" fill="#6c7086" font-size="12">`
+       + `Substrate is empty. Add memories via yantrikdb_remember.</text>`;
+}
+svg.innerHTML = html;
+
+// Skills table
+const skillsBody = document.querySelector("#skills-table tbody");
+const skills = data.recent_skills || [];
+if (!skills.length) {
+  document.getElementById("skills-table").style.display = "none";
+  document.getElementById("skills-empty").style.display = "block";
+} else {
+  skillsBody.innerHTML = skills.slice(-10).reverse().map(sk => {
+    const age = sk.ts ? formatAge(Date.now() / 1000 - sk.ts) : "—";
+    const applies = (sk.applies_to || []).join(", ");
+    return `<tr>`
+      + `<td><span class="pill pill-skill">${sk.skill_id || "?"}</span></td>`
+      + `<td>${sk.skill_type || "?"}</td>`
+      + `<td>${applies}</td>`
+      + `<td>${age}</td>`
+      + `</tr>`;
+  }).join("");
+}
+
+// Conflicts
+const conflictsDiv = document.getElementById("conflicts");
+const conflicts = data.conflicts || [];
+if (!conflicts.length) {
+  document.getElementById("conflicts-empty").style.display = "block";
+} else {
+  conflictsDiv.innerHTML = conflicts.slice(0, 10).map(c => {
+    const id = c.conflict_id || c.rid || "?";
+    const a = c.text_a || c.a || "";
+    const b = c.text_b || c.b || "";
+    return `<div class="conflict">`
+      + `<div class="id">${id}</div>`
+      + `<div class="pair">`
+        + `<div><div class="label">A</div>${escape(a)}</div>`
+        + `<div><div class="label">B</div>${escape(b)}</div>`
+      + `</div></div>`;
+  }).join("");
+}
+
+function escape(s) {
+  return String(s).replace(/[<>&]/g, c => ({"<":"&lt;",">":"&gt;","&":"&amp;"}[c]));
+}
+
+function formatAge(secs) {
+  if (secs < 60) return `${Math.round(secs)}s`;
+  if (secs < 3600) return `${Math.round(secs / 60)}m`;
+  if (secs < 86400) return `${Math.round(secs / 3600)}h`;
+  return `${Math.round(secs / 86400)}d`;
+}
+</script>
+</body>
+</html>
+"""
+
+
+class _UIHandler(http.server.BaseHTTPRequestHandler):
+    """Serve the index page and a JSON snapshot endpoint. Read-only."""
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        # Quiet — don't spam stderr per request.
+        pass
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = self.path.split("?", 1)[0]
+        try:
+            if path == "/" or path == "/index.html":
+                snapshot = build_snapshot()
+                body = _render_html(snapshot).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            elif path == "/api/snapshot":
+                snapshot = build_snapshot()
+                body = json.dumps(snapshot, default=str, indent=2).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            else:
+                self.send_response(404)
+                self.end_headers()
+        except Exception as e:
+            body = f"500 internal: {type(e).__name__}: {e}".encode()
+            self.send_response(500)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+
+def serve(host: str = "127.0.0.1", port: int = 8767, open_browser: bool = False) -> None:
+    """Block serving the UI at ``http://host:port/``."""
+    addr = (host, port)
+    httpd = socketserver.TCPServer(addr, _UIHandler)
+    url = f"http://{host}:{port}/"
+    print(f"YantrikDB substrate inspector listening at {url}")
+    print("Ctrl-C to stop.")
+    if open_browser:
+        threading.Thread(
+            target=lambda: webbrowser.open(url), daemon=True,
+        ).start()
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopping…")
+    finally:
+        httpd.server_close()


### PR DESCRIPTION
Third slice of v0.5 active-memory ([design doc](https://github.com/yantrikos/yantrikdb-hermes-plugin/blob/main/docs/v0.5-design.md)). The substrate becomes inspectable in 30 seconds of `pip install`, and the agent gains a one-call health snapshot.

## C1 — bundled UI (`yantrikdb-hermes ui`)

```bash
pip install -U yantrikdb-hermes-plugin
yantrikdb-hermes ui --open       # opens http://127.0.0.1:8767/
```

- Pure-stdlib `http.server`, ~250 LOC inline HTML/CSS/JS, **no new dependencies**.
- One page, three sections:
  - **Constellation** — SVG, circular layout, color-coded by domain (`preference`/`people`/`work`/`reference`/`extracted`)
  - **Recently learned skills** — table from `$HERMES_HOME/yantrikdb-recent-skills.json` + the v0.4.17 record
  - **Unresolved contradictions** — A/B pairs with `conflict_id` for follow-up via `yantrikdb_resolve_conflict`
- Read-only. **NOT** a replacement for [wysie's full dashboard](https://github.com/wysie/yantrikdb-hermes-dashboard) (multi-DB, mutations, auth) — this is the *first-10-minutes-after-install* tool that ships in the wheel.
- `/api/snapshot` also serves the raw JSON for tooling.
- New CLI subcommand registered in `cli.py`; `--hermes-home` override for non-default substrate locations.

## C2 — `yantrikdb_observability` tool

One dispatch returning four sections + a summary line:

```json
{
  "summary": "namespace=hermes:hermes:default | memories=42 entities=12 edges=17 | open_conflicts=1 | extracted_candidates=3 | breaker=closed",
  "engine": { "active_memories": 42, "entities": 12, "edges": 17, ... },
  "extraction": { "total_sampled": 3, "by_pattern": {"preference": 2, "possession": 1}, "by_speaker": {"user": 3} },
  "recent_skills": [{"skill_id": "git.commit_clean", "skill_type": "procedure", "age_seconds": 1200}, ...],
  "provider": { "circuit_breaker_open": false, "failure_count": 0, "prefetch_thread_alive": false, "sync_thread_alive": false }
}
```

- Each section degrades gracefully — if `engine.stats()` fails, the extraction + provider sections still surface with `error` markers for diagnosis.
- Lets the agent (or curious user) answer "how is my memory doing" without 6 separate tool calls.

## Tests

- [x] 256 pass (+5 new)
  - `TestWaveCBundledUI` (2): module imports cleanly, render passes conflict-text through the JS escape helper
  - `TestWaveCObservability` (3): all four sections present, summary line is human-readable, single-call failure degrades gracefully
- [x] `yantrikdb-hermes ui --help` parses cleanly
- [x] ruff clean
- [x] mypy clean
- [ ] CI matrix (3.11/3.12/3.13/3.14)

## v0.5 progress

| Wave | Status |
|---|---|
| A — active memory | merged (PR #28) |
| B — auto-extraction + recall filter + stats | merged (PR #29) |
| **C — bundled UI + observability** | **this PR** |
| D — smarter on_pre_compress + time-aware recall | next |
| E — cross-agent shared brain | last |

No version bump per slice plan — release cut after Wave D lands.