### PR TITLE
feat(v0.5 Wave E): opt-in cross-agent shared brain

### DIFF
--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -2510,6 +2510,102 @@ class TestWaveDPreCompressGist:
         assert compression_writes == []
 
 
+class TestWaveECrossAgentSharedBrain:
+    """v0.5 Wave E — opt-in cross-agent shared brain. When
+    shared_brain_namespace is set, explicit yantrikdb_remember writes
+    mirror to that namespace AND recall unions both namespaces.
+    Single-agent default: zero behaviour change.
+    """
+
+    def test_default_off_writes_only_to_local(self, provider, mock_client):
+        provider.handle_tool_call(
+            "yantrikdb_remember", {"text": "Pranab prefers tabs"},
+        )
+        calls = mock_client.remember.call_args_list
+        assert len(calls) == 1
+        assert calls[0].kwargs["namespace"] == provider._namespace
+        meta = calls[0].kwargs.get("metadata") or {}
+        assert not str(meta.get("source", "")).startswith("agent:")
+
+    def test_opt_in_mirrors_write_to_shared_brain(self, provider, mock_client):
+        provider._config.shared_brain_namespace = "yantrikdb:shared:household"
+        provider._config.agent_name = "coding-agent"
+        provider.handle_tool_call(
+            "yantrikdb_remember", {"text": "Pranab prefers tabs"},
+        )
+        calls = mock_client.remember.call_args_list
+        assert len(calls) == 2
+        nss = [c.kwargs["namespace"] for c in calls]
+        assert provider._namespace in nss
+        assert "yantrikdb:shared:household" in nss
+        shared_call = next(
+            c for c in calls
+            if c.kwargs["namespace"] == "yantrikdb:shared:household"
+        )
+        meta = shared_call.kwargs["metadata"]
+        assert meta["source"] == "agent:coding-agent"
+        assert meta["shared_brain_origin_namespace"] == provider._namespace
+
+    def test_recall_unions_shared_brain_namespace(self, provider, mock_client):
+        provider._config.shared_brain_namespace = "yantrikdb:shared:household"
+        responses = {
+            provider._namespace: {"results": [
+                {"rid": "local-1", "text": "from local", "score": 0.9,
+                 "metadata": {}},
+            ]},
+            "yantrikdb:shared:household": {"results": [
+                {"rid": "shared-1", "text": "from shared brain", "score": 0.85,
+                 "metadata": {"source": "agent:whatsapp-bot"}},
+            ]},
+        }
+
+        def _recall_router(query, *, namespace=None, **_kw):
+            return responses.get(namespace, {"results": []})
+
+        mock_client.recall.side_effect = _recall_router
+        out = provider.handle_tool_call(
+            "yantrikdb_recall", {"query": "x", "top_k": 10},
+        )
+        texts = [r["text"] for r in json.loads(out)["results"]]
+        assert "from local" in texts
+        assert "from shared brain" in texts, (
+            "Wave E should union the shared-brain namespace into recall"
+        )
+
+    def test_agent_name_auto_derived_from_namespace_when_blank(
+        self, provider, mock_client,
+    ):
+        provider._config.shared_brain_namespace = "shared:ns"
+        provider._config.agent_name = ""
+        provider.handle_tool_call("yantrikdb_remember", {"text": "x"})
+        shared_call = next(
+            c for c in mock_client.remember.call_args_list
+            if c.kwargs["namespace"] == "shared:ns"
+        )
+        # Provider fixture sets agent_workspace="workspace" → namespace
+        # second segment is "workspace"
+        assert shared_call.kwargs["metadata"]["source"] == "agent:workspace"
+
+    def test_failed_mirror_does_not_break_primary_write(
+        self, provider, mock_client,
+    ):
+        from yantrikdb_plugin_under_test.client import YantrikDBError
+        provider._config.shared_brain_namespace = "shared:ns"
+        provider._config.agent_name = "test"
+
+        def _remember_router(text, *, namespace=None, **kw):
+            if namespace == "shared:ns":
+                raise YantrikDBError("shared brain unreachable")
+            return {"rid": "primary-ok"}
+
+        mock_client.remember.side_effect = _remember_router
+        out = provider.handle_tool_call(
+            "yantrikdb_remember", {"text": "x"},
+        )
+        assert json.loads(out)["stored"] is True
+        assert json.loads(out)["rid"] == "primary-ok"
+
+
 class TestWaveCObservability:
     """yantrikdb_observability rolls up engine stats + extraction +
     recent skills + provider health into a single response so the agent

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -1451,6 +1451,12 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 namespaces.append(namespace)
         if self._should_recall_base_namespace() and self._base_namespace not in namespaces:
             namespaces.append(self._base_namespace)
+        # v0.5 Wave E: union the cross-agent shared brain when opted in.
+        # Sibling agents' writes appear in this agent's recall results,
+        # tagged source=agent:<name> for traceability.
+        shared = self._shared_brain_namespace()
+        if shared and shared != self._namespace and shared not in namespaces:
+            namespaces.append(shared)
         return namespaces
 
     def _recall_with_base_fallback(
@@ -1881,15 +1887,63 @@ class YantrikDBMemoryProvider(MemoryProvider):
         if not text:
             return tool_error("Missing required parameter: text")
         importance = _coerce_float(args.get("importance"), default=0.6)
-        resp = self._require_client().remember(
+        client = self._require_client()
+        resp = client.remember(
             text,
             namespace=self._namespace,
             importance=importance,
             domain=args.get("domain"),
             metadata={"session_id": self._session_id, **self._write_scope_metadata()},
         )
+        # v0.5 Wave E: mirror to the cross-agent shared brain when opted in.
+        # Tag with source=agent:<name> so each contributor is traceable; a
+        # failed mirror write doesn't break the primary remember path.
+        shared_ns = self._shared_brain_namespace()
+        if shared_ns and shared_ns != self._namespace:
+            try:
+                client.remember(
+                    text,
+                    namespace=shared_ns,
+                    importance=importance,
+                    domain=args.get("domain"),
+                    metadata={
+                        "session_id": self._session_id,
+                        "source": f"agent:{self._agent_name()}",
+                        "shared_brain_origin_namespace": self._namespace,
+                        **self._write_scope_metadata(),
+                    },
+                )
+            except (YantrikDBClientError, YantrikDBError) as e:
+                logger.debug(
+                    "YantrikDB shared-brain mirror write failed (%s): %s",
+                    shared_ns, e,
+                )
         self._record_success()
         return json.dumps({"rid": resp.get("rid"), "stored": True})
+
+    def _shared_brain_namespace(self) -> str:
+        """Resolved shared-brain namespace; empty string when opted out."""
+        if self._config is None:
+            return ""
+        ns = (self._config.shared_brain_namespace or "").strip()
+        return ns
+
+    def _agent_name(self) -> str:
+        """Human-readable agent name for shared-brain attribution."""
+        if self._config is None:
+            return "unknown"
+        explicit = (self._config.agent_name or "").strip()
+        if explicit:
+            return explicit
+        # Auto-derive: prefer the second segment of agent's namespace
+        # (typically agent_workspace), fall back to base_namespace, then
+        # a hostname-shaped placeholder.
+        parts = (self._namespace or "").split(":")
+        if len(parts) >= 2 and parts[1]:
+            return parts[1]
+        if self._base_namespace:
+            return self._base_namespace
+        return "agent"
 
     def _do_recall(self, args: dict[str, Any]) -> str:
         query = (args.get("query") or "").strip()

--- a/yantrikdb/client.py
+++ b/yantrikdb/client.py
@@ -163,6 +163,29 @@ class YantrikDBConfig:
     # opt in (per-call recall arg also overrides this).
     recall_includes_candidates: bool = False
 
+    # v0.5.0+ Wave E — cross-agent shared brain (OPT-IN, default off).
+    #
+    # A user's coding agent learns "Pranab prefers tabs"; their WhatsApp
+    # agent automatically knows. When shared_brain_namespace is set,
+    # explicit yantrikdb_remember writes are MIRRORED to that namespace
+    # in addition to the agent's local namespace, tagged with
+    # metadata.source=f"agent:{agent_name}" so each contributing agent
+    # is traceable. Recalls union the local + shared namespaces;
+    # think() canonicalization runs over both as usual.
+    #
+    # Scope intentionally narrow in v1: only explicit remember writes
+    # are mirrored. Skills, extracted candidates, compression summaries
+    # stay agent-local — the user explicitly chooses what gets shared.
+    # This sidesteps coordination headaches around agent-specific
+    # skill outcomes leaking across agent boundaries.
+    #
+    # Single-agent users see ZERO behaviour change with default empty.
+    shared_brain_namespace: str = ""
+    # Human-readable agent name used to tag shared-brain writes. Defaults
+    # blank — provider auto-derives from agent_workspace when blank, so
+    # this is mostly a manual override for explicit branding.
+    agent_name: str = ""
+
     @classmethod
     def from_env(cls) -> YantrikDBConfig:
         return cls(
@@ -224,6 +247,10 @@ class YantrikDBConfig:
                 os.environ.get("YANTRIKDB_RECALL_INCLUDES_CANDIDATES"),
                 default=False,
             ),
+            shared_brain_namespace=os.environ.get(
+                "YANTRIKDB_SHARED_BRAIN_NAMESPACE", "",
+            ).strip(),
+            agent_name=os.environ.get("YANTRIKDB_AGENT_NAME", "").strip(),
             sync_user_messages=_parse_bool(
                 os.environ.get("YANTRIKDB_SYNC_USER_MESSAGES"), default=True,
             ),


### PR DESCRIPTION
Fifth and final slice of v0.5 active-memory ([design](https://github.com/yantrikos/yantrikdb-hermes-plugin/blob/main/docs/v0.5-design.md)). Real user demand per Pranab — multi-agent users want sibling agents to inherit each other's discoveries.

## What changes

When the user runs multiple Hermes agents (coding agent + WhatsApp agent + research agent), all of them can write to ONE shared substrate namespace. The coding agent learns *"Pranab prefers tabs"*; their WhatsApp agent automatically knows.

### Setup (opt-in)

```bash
export YANTRIKDB_SHARED_BRAIN_NAMESPACE=yantrikdb:shared:household
export YANTRIKDB_AGENT_NAME=coding-agent       # optional, auto-derived if blank
```

Set the same `SHARED_BRAIN_NAMESPACE` across all agents; each agent's `AGENT_NAME` tags its writes so contributions are traceable.

### Wiring

- `_do_remember` mirrors to `shared_brain_namespace` when configured. Shared write carries `metadata.source="agent:<name>"` and `metadata.shared_brain_origin_namespace` pointing back to the writer's local namespace.
- `_fallback_recall_namespaces` unions `shared_brain_namespace` into recall — every recall pulls in sibling agents' contributions automatically.
- `agent_name` auto-derived from `agent_workspace` (the second segment of the resolved namespace) when not explicitly set.
- Mirror-write failure swallowed silently — never breaks the primary `remember`.

### Scope intentionally narrow in v1

Only **explicit `yantrikdb_remember` writes** are mirrored. Skills, extracted candidates, and compression summaries stay agent-local. Rationale:

- Users explicitly choose what gets shared (the agent that calls `remember` is opting that fact into the brain).
- Sidesteps coordination concerns around skill-specific outcomes leaking across agent boundaries (a deploy-rollback skill in the coding agent doesn't make sense for the WhatsApp agent).
- Substrate `think()` canonicalization still runs over both namespaces as usual.

### Single-agent default

Empty `shared_brain_namespace` → zero behaviour change for existing single-agent users.

## Tests

- [x] 267 pass (+5 new)
  - `TestWaveECrossAgentSharedBrain` (5): default-off local-only, opt-in mirrors, recall unions, `agent_name` auto-derived, mirror failure doesn't break primary
- [x] ruff + mypy clean
- [ ] CI matrix

## v0.5 progress — ALL WAVES COMPLETE

| Wave | Status |
|---|---|
| A — active memory | merged PR #28 |
| B — auto-extraction + recall filter + stats | merged PR #29 |
| C — bundled UI + observability | merged PR #30 |
| D — smarter on_pre_compress + time-aware recall | merged PR #31 |
| **E — cross-agent shared brain** | **this PR** |

After this merges, v0.5.0 cuts as a single release covering all 5 waves.