### PR TITLE
fix: use get_embedding_dimension to avoid FutureWarning

### DIFF
--- a/yantrikdb/embedders.py
+++ b/yantrikdb/embedders.py
@@ -144,7 +144,7 @@ class SentenceTransformerEmbedder:
             ) from e
         # Prefer the model's declared dim if available — saves an encode
         # call and matches what HF says rather than relying on probe.
-        declared = getattr(self._model, "get_sentence_embedding_dimension", None)
+        declared = getattr(self._model, "get_embedding_dimension", None) or getattr(self._model, "get_sentence_embedding_dimension", None)
         if callable(declared):
             try:
                 self.embedding_dim = int(declared())


### PR DESCRIPTION
## Problem

`sentence-transformers` has deprecated `get_sentence_embedding_dimension` in favor of `get_embedding_dimension`. The current code only checks for the old name, which produces a `FutureWarning` on every startup:

```
FutureWarning: get_sentence_embedding_dimension is deprecated. Use get_embedding_dimension instead.
```

## Fix

Check for the new API name first, fall back to the old one:

```python
-        declared = getattr(self._model, "get_sentence_embedding_dimension", None)
+        declared = getattr(self._model, "get_embedding_dimension", None) or \
+                  getattr(self._model, "get_sentence_embedding_dimension", None)
```

Backward compatible — works with both old and new versions of sentence-transformers.