### PR TITLE
fix: don't pass namespace to engine's relate() (TypeError)

### DIFF
--- a/yantrikdb/embedded.py
+++ b/yantrikdb/embedded.py
@@ -548,8 +548,8 @@ class EmbeddedYantrikDBClient:
             "rel_type": relationship,
             "weight": float(weight) if weight is not None else 1.0,
         }
-        if namespace:
-            rel_kwargs["namespace"] = namespace
+        # NOTE: namespace kwarg is intentionally NOT forwarded to the engine
+        # until the engine adds namespace-scoped edge support.
         try:
             edge_id = self._db.relate(entity, target, **rel_kwargs)
         except Exception as e:


### PR DESCRIPTION
## Problem

Calling `yantrikdb_relate(entity, target, relationship)` throws:

```
TypeError: Graph.relate() got an unexpected keyword argument 'namespace'
```

The plugin-level `relate()` method conditionally passes `namespace` to the engine's `Graph.relate()`, but the engine does not accept this parameter.

## Root Cause

In `embedded.py`, the `relate()` method builds `rel_kwargs` and adds `namespace` when it's not None:

```python
rel_kwargs: dict[str, Any] = {
    "rel_type": relationship,
    "weight": float(weight) if weight is not None else 1.0,
}
if namespace:
    rel_kwargs["namespace"] = namespace  # ← This causes the TypeError
edge_id = self._db.relate(entity, target, **rel_kwargs)
```

## Fix

Remove the namespace forwarding to the engine, replacing it with a comment:

```python
-        if namespace:
-            rel_kwargs["namespace"] = namespace
+        # NOTE: namespace kwarg is intentionally NOT forwarded to the engine
+        # until the engine adds namespace-scoped edge support.
```

The `namespace` parameter is preserved in the plugin-level signature for future use, but is not passed to the engine until namespace-scoped edges are supported upstream.