### PR TITLE
release: v0.7.0 — engine 0.9.0 gap-closers + conversation + task storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Tests](https://img.shields.io/badge/tests-128%20passing-brightgreen)](https://github.com/yantrikos/yantrikdb-hermes-plugin/actions)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://github.com/yantrikos/yantrikdb-hermes-plugin)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![YantrikDB](https://img.shields.io/badge/yantrikdb-%E2%89%A50.7.6-orange)](https://github.com/yantrikos/yantrikdb-server)
+[![YantrikDB](https://img.shields.io/badge/yantrikdb-%E2%89%A50.9.0-orange)](https://github.com/yantrikos/yantrikdb-server)
 [![Hermes Agent](https://img.shields.io/badge/hermes--agent-plugin-8a2be2)](https://github.com/NousResearch/hermes-agent)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![mypy](https://img.shields.io/badge/mypy-checked-2a6db2)](https://mypy-lang.org/)
@@ -37,7 +37,10 @@ This is the substrate yantrikdb already ships: temporal context graph via `relat
 | HTTP backend for HA clusters | ✓ v0.5.0 (against yantrikdb-server) | varies |
 | Reproducible recall benchmark (`benchmarks/run_recall_bench.py`) | ✓ v0.6.0 — recall@k / MRR / answer-containment, CI-guarded | claims, rarely a runnable number |
 | Self-tuning recall (`recall(reinforce=[...])`) | ✓ v0.6.0 — reinforced memories climb over time, opt-in | static ranking |
-| Proactive memory hygiene (`yantrikdb_hygiene`) | ✓ v0.6.0 — scan/apply consolidate-or-forget | manual cleanup |
+| Proactive memory hygiene (`yantrikdb_hygiene`) | ✓ v0.7.0 — engine-backed stale scan + consolidate-or-forget | manual cleanup |
+| Knowledge gaps (`yantrikdb_knowledge_gaps`) | ✓ v0.7.0 — "what is my memory missing?" from real recall demand | not surfaced |
+| Verbatim conversation buffer (`yantrikdb_recent_turns`) | ✓ v0.7.0 — survives compression, auto-captured | host context only |
+| Durable task store (`yantrikdb_tasks`) | ✓ v0.7.0 — namespace-scoped chores in the substrate | ephemeral / external |
 
 ## End-to-end demo — substrate growing through the skill lifecycle
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.6.0
+version: 0.7.0
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.6.0"
+version = "0.7.0"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.7.0] — 2026-06-29 — Build on the engine: gap-closers, conversation + task storage
+
+Engine **0.9.0 "close the memory gaps"** (and 0.8.0) added exactly the primitives the plugin worked around in v0.6, plus two new first-class storage surfaces. v0.7 builds on them. Four waves, all additive and opt-in / graceful-degradation; existing deployments see zero behaviour change. **Requires `yantrikdb>=0.9.0`** (pin bumped on all surfaces) — which also pulls the engine's Backpressure/compactor reliability fix for long embedded write sessions. No new Python dependencies.
+
+A compatibility spike (isolated 0.9.0 venv) confirmed the prior plugin was already fully compatible with 0.9.0 (full suite green, recall benchmark MRR 0.928→0.932) before any of this work; v0.7 is purely the new capabilities.
+
+### Wave H — Engine-backed hygiene scan (PR #42)
+
+- **`yantrikdb_hygiene` scan now uses engine truth.** Via the new `list_records` API it pages the namespace (bounded, truncation-flagged) and computes `stale_candidates` from real engine stats: low `importance` AND (cold `storage_tier` OR `access_count<=1` OR untouched 30d). This supersedes the v0.6 plugin-side sidecar heuristic as the primary staleness signal; `low_usefulness` (surfaced-but-never-reinforced) remains a complementary overlay. Falls back to the v0.6 path when `list_records` is unavailable. New `list_records` client method (HTTP + embedded parity).
+
+### Wave I — Knowledge gaps (PR #42)
+
+- **`yantrikdb_knowledge_gaps` (NEW tool).** Exposes the engine's `knowledge_gaps()` — queries asked often (`>= min_count`) but answered poorly (avg top recall score `<= max_avg_top_score`). The substrate's *known unknowns*: a direct signal of what your memory is missing. No other Hermes memory provider surfaces this. Engine-global scope (documented); degrades to "not available" on older engines/servers.
+
+### Wave J — Conversation storage (PR #42)
+
+- **Verbatim conversation buffer.** New `record_turn` / `recent_turns` / `clear_turns` client methods (HTTP + embedded). `sync_turn` now also records each user + assistant turn into the engine's bounded, verbatim ring buffer (default on, cheap; `YANTRIKDB_CONVERSATION_BUFFER_ENABLED`) — and it **survives Hermes compression**, complementing the semantic store + `on_pre_compress` gist.
+- **`yantrikdb_recent_turns` (NEW tool)** reads the verbatim recent exchange (or `clear=true` to wipe it).
+- **Opt-in post-compression surfacing** (`YANTRIKDB_SURFACE_CONVERSATION_BUFFER`): a "## Recent conversation (verbatim)" block in `system_prompt_block`, most useful after a compress when only the gist remains.
+
+### Wave K — Task storage (PR #42)
+
+- **`yantrikdb_tasks` (NEW tool)** — a durable, namespace-scoped task/chore store kept in the substrate (status, priority, subtasks via `parent_id`), action-dispatched (`list`/`add`/`update`/`delete`/`get`). Distinct from ephemeral host TODOs and from engine-generated triggers: agent-authored tasks that persist across sessions. New `task_add/list/get/update/delete` client methods (HTTP + embedded parity).
+
+### Tool surface
+
+18 → 21 tools (`yantrikdb_knowledge_gaps`, `yantrikdb_recent_turns`, `yantrikdb_tasks`). Several new opt-in config flags, all default to zero-behaviour-change. Pin `yantrikdb>=0.7.6` → `>=0.9.0`. 302 tests pass (verified on both 0.8.0 and 0.9.0); ruff + mypy clean.
+
 ## [0.6.0] — 2026-06-05 — Prove it, then tune it: benchmarked recall + self-tuning + hygiene
 
 v0.5 made the substrate *active*. v0.6 makes it **accountable**. The plugin has always claimed best-in-class recall; v0.6 ships a reproducible number to back the claim, closes the feedback loop so memories that keep proving useful rank higher over time, and surfaces cleanup opportunities so "self-maintaining" becomes visible instead of implicit. Two waves, both pure-plugin (no engine changes), both opt-in by default — existing deployments see zero behaviour change.

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.6.0
+version: 0.7.0
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.9.0


### PR DESCRIPTION
## v0.7.0 release cut

Version + docs cut after the four-wave feature PR (#42) merged. No code changes here.

**Shipped in this release (all in #42):**
- **Wave H** — engine-backed hygiene scan (`list_records`): `stale_candidates` from real engine access stats; supersedes the v0.6 sidecar heuristic.
- **Wave I** — `yantrikdb_knowledge_gaps`: the substrate's known unknowns ("what is my memory missing?").
- **Wave J** — conversation storage: verbatim turn buffer auto-captured in `sync_turn`, survives compression; `yantrikdb_recent_turns` tool + opt-in surfacing.
- **Wave K** — task storage: `yantrikdb_tasks` durable, namespace-scoped chore store.

**This PR:**
- Bumps all four version surfaces to **0.7.0** (`test_manifest_sync` green).
- Comprehensive 0.7.0 CHANGELOG entry.
- README: four new capability rows + engine requirement badge `>=0.9.0`.

**Requires `yantrikdb>=0.9.0`** (pin bumped in #42) — pulls the engine's Backpressure/compactor reliability fix. Tool surface 18 → 21. 302 tests pass (verified on 0.8.0 and 0.9.0); ruff + mypy clean; CI green on Python 3.11–3.14.
After merge: tag `v0.7.0` + GitHub release (PyPI auto-publishes via Trusted Publisher OIDC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)