### PR TITLE
release: v0.7.1 — require engine yantrikdb>=0.9.2 (recall stability)

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.7.0
+version: 0.7.1
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the
@@ -7,7 +7,7 @@ version: 0.7.0
 # `yantrikdb-hermes install <hermes>`. Both should declare the same version.
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.9.0
+  - yantrikdb>=0.9.2
   - requests>=2.31
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.7.0"
+version = "0.7.1"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-  "yantrikdb>=0.9.0",
+  "yantrikdb>=0.9.2",
   "requests>=2.31",
 ]
 

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.7.1] — 2026-07-13 — Require engine 0.9.2 (recall stability)
+
+Patch release: bumps the engine pin `yantrikdb>=0.9.0` → **`>=0.9.2`** to guarantee two upstream correctness fixes for embedded-mode users. No plugin code changes; the full test suite and the recall benchmark are green on 0.9.2 (recall@1 and MRR both improved vs 0.9.0).
+
+- **0.9.2 — NaN-safe recall.** A NaN-valued embedding could panic the process during `recall()` (Rust ≥1.81's sort detecting a broken total order), which killed the call and surfaced as `-32602` in MCP sessions. The engine now guards NaN/zero norms and uses `f64::total_cmp` for every score sort. Embedded-mode plugin recall inherits the fix.
+- **0.9.1 — `set_embedder_named` with the worker pool.** Fixes a 0.9.0 regression where the named/multilingual embedder swap always failed ("requires exclusive access to the engine"). Restores the plugin's named-embedder path (`YANTRIKDB_EMBEDDER=potion-base-8M` / `potion-base-32M`).
+
 ## [0.7.0] — 2026-06-29 — Build on the engine: gap-closers, conversation + task storage
 
 Engine **0.9.0 "close the memory gaps"** (and 0.8.0) added exactly the primitives the plugin worked around in v0.6, plus two new first-class storage surfaces. v0.7 builds on them. Four waves, all additive and opt-in / graceful-degradation; existing deployments see zero behaviour change. **Requires `yantrikdb>=0.9.0`** (pin bumped on all surfaces) — which also pulls the engine's Backpressure/compactor reliability fix for long embedded write sessions. No new Python dependencies.

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,8 +1,8 @@
 name: yantrikdb
-version: 0.7.0
+version: 0.7.1
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.9.0
+  - yantrikdb>=0.9.2
   - requests>=2.31
 hooks:
   - on_session_end


### PR DESCRIPTION
## v0.7.1 — patch: require engine 0.9.2

Bumps the engine pin `yantrikdb>=0.9.0` → **`>=0.9.2`** to guarantee two upstream correctness fixes for embedded-mode users. **No plugin code changes** — the full suite (302 tests) and the recall benchmark are green on 0.9.2, with recall@1 and MRR both improving vs 0.9.0 (the NaN-safe total-order sort tightened ranking).

- **0.9.2 — NaN-safe recall.** A NaN embedding could panic `recall()` (broken sort total-order) — killing the call and surfacing as **`-32602`** in MCP sessions. Engine now guards NaN/zero norms + uses `f64::total_cmp` everywhere. Embedded recall inherits the fix.
- **0.9.1 — `set_embedder_named`.** Fixes a 0.9.0 regression that broke the named/multilingual embedder swap the plugin's `YANTRIKDB_EMBEDDER=potion-base-8M/32M` path relies on.

Bumps all four version surfaces to **0.7.1** (`test_manifest_sync` green) + CHANGELOG entry. After merge: tag `v0.7.1` + GitHub release (PyPI auto-publishes via OIDC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)