### PR TITLE
release: v0.8.0 — the self-directing substrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ This is the substrate yantrikdb already ships: temporal context graph via `relat
 | Knowledge gaps (`yantrikdb_knowledge_gaps`) | ✓ v0.7.0 — "what is my memory missing?" from real recall demand | not surfaced |
 | Verbatim conversation buffer (`yantrikdb_recent_turns`) | ✓ v0.7.0 — survives compression, auto-captured | host context only |
 | Durable task store (`yantrikdb_tasks`) | ✓ v0.7.0 — namespace-scoped chores in the substrate | ephemeral / external |
+| Self-directing loop (gaps → tasks → agenda) | ✓ v0.8.0 — the memory queues its own gaps and hands the agent an agenda | none |
+
+## The self-directing substrate (v0.8)
+
+![Self-directing memory loop: gap → task → agenda → learn → close](./assets/demos/self-directing/demo.gif)
+
+The loop no other Hermes memory provider can do — the memory **notices what it doesn't know, queues the work, hands the agent its own agenda, and closes the loop** when the gap is answered. Opt-in (`YANTRIKDB_AUTO_GAP_TASKS`, `YANTRIKDB_SURFACE_AGENDA`); runnable via `python demos/self_directing_memory.py`. Details: **[assets/demos/self-directing/](./assets/demos/self-directing/)**.
 
 ## End-to-end demo — substrate growing through the skill lifecycle
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.7.1
+version: 0.8.0
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.7.1"
+version = "0.8.0"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.8.0] — 2026-07-13 — The self-directing substrate
+
+v0.7 gave the substrate new primitives (knowledge gaps, tasks). v0.8 wires them into a **loop no other Hermes memory provider can do**: the memory notices what it doesn't know, queues the work, hands the agent its own agenda, and closes the loop when the gap is answered. All additive and opt-in — zero behaviour change by default, no new tools, no new dependencies.
+
+See the loop end-to-end: [`assets/demos/self-directing/`](../assets/demos/self-directing/) (runnable via `python demos/self_directing_memory.py`).
+
+### Features
+
+- **Gap→task automation (NEW, opt-in `YANTRIKDB_AUTO_GAP_TASKS`).** On session end, run `knowledge_gaps()` and create a durable task (`Resolve knowledge gap: <query>`) for each recurring gap not already covered by an open task — so the agent's unanswered questions become actionable to-dos. Bounded per session (`gap_task_max`, default 3), deduped by title, fail-soft and graceful-degrading on engines/servers without the APIs.
+- **"Your memory's agenda" block (NEW, opt-in `YANTRIKDB_SURFACE_AGENDA`).** Prepends open tasks + top unresolved knowledge gaps to `system_prompt_block`, so every session opens with what the memory still needs.
+- **`gap_max_avg_top_score` config (default 0.5).** The gap threshold is embedder-dependent — the bundled dim-64 potion-2M scores unanswered queries ~0.6, so the engine's default of 0.4 is too strict. Exposed and tunable per embedder.
+- **Demo + reproducible GIF.** `demos/self_directing_memory.py` (runnable, no API key) plus a pure-Pillow GIF renderer under `assets/demos/self-directing/` (no VHS dependency).
+
+No tool-surface change (still 21). Several new opt-in config flags, all default to zero-behaviour-change. 311 tests pass on both engine 0.8.0 and 0.9.2; ruff + mypy clean.
+
 ## [0.7.1] — 2026-07-13 — Require engine 0.9.2 (recall stability)
 
 Patch release: bumps the engine pin `yantrikdb>=0.9.0` → **`>=0.9.2`** to guarantee two upstream correctness fixes for embedded-mode users. No plugin code changes; the full test suite and the recall benchmark are green on 0.9.2 (recall@1 and MRR both improved vs 0.9.0).

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.7.1
+version: 0.8.0
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.9.2


### PR DESCRIPTION
## v0.8.0 release cut

Version + docs cut after the feature PR (#46) merged. No code changes here.

**Shipped in this release (#46):** the self-directing substrate — gap→task automation on session end + a "your memory's agenda" block. The memory notices what it doesn't know, queues the work, and hands the agent its own agenda. All opt-in; no new tools, no new deps.

**This PR:**
- Bumps all four version surfaces to **0.8.0** (`test_manifest_sync` green).
- 0.8.0 CHANGELOG entry.
- README: self-directing demo GIF + a differentiator row.

311 tests pass on both engine 0.8.0 and 0.9.2; ruff + mypy clean; CI green on Python 3.11–3.14. After merge: tag `v0.8.0` + GitHub release (PyPI auto-publishes via OIDC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)