### PR TITLE
fix(v0.8.1): knowledge_gaps namespace-scoping (engine 0.9.3+) — restores self-directing loop

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.8.0
+version: 0.8.1
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.8.0"
+version = "0.8.1"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_v07_features.py
+++ b/tests/test_v07_features.py
@@ -150,6 +150,8 @@ class TestKnowledgeGaps:
         assert kw["min_count"] == 3
         assert kw["max_avg_top_score"] == 0.4
         assert kw["limit"] == 20
+        # v0.8.1: must pass the active namespace (engine 0.9.3+ scopes demand)
+        assert kw.get("namespace")
 
 
 def _join_sync(p):

--- a/tests/test_v08_features.py
+++ b/tests/test_v08_features.py
@@ -95,6 +95,16 @@ class TestGapToTask:
         p.on_session_end([])  # must not raise
         mock_client.task_add.assert_not_called()
 
+    def test_gap_tasks_pass_namespace(
+        self, provider_module, mock_client, monkeypatch, tmp_path,
+    ):
+        # v0.8.1: engine 0.9.3+ scopes demand per namespace.
+        p = _provider(provider_module, mock_client, monkeypatch, tmp_path,
+                      YANTRIKDB_AUTO_GAP_TASKS="true")
+        mock_client.knowledge_gaps.return_value = {"gaps": [{"query": "x"}]}
+        p.on_session_end([])
+        assert mock_client.knowledge_gaps.call_args.kwargs.get("namespace")
+
 
 class TestAgendaBlock:
     def test_off_by_default(
@@ -118,6 +128,7 @@ class TestAgendaBlock:
         assert "Your memory's agenda" in block
         assert "oncall path" in block
         assert "kubernetes ingress config" in block
+        assert mock_client.knowledge_gaps.call_args.kwargs.get("namespace")
 
     def test_empty_when_nothing_pending(
         self, provider_module, mock_client, monkeypatch, tmp_path,

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.8.1] — 2026-07-17 — Fix: knowledge_gaps is namespace-scoped on engine 0.9.3+
+
+Bug fix. Engine **0.9.3** made `knowledge_gaps` namespace-scoped (demand is now recorded per namespace, and disabled entirely on encrypted DBs — a privacy fix). The plugin called it without a namespace, so on any engine **≥0.9.3** it queried the wrong (`default`) namespace and returned nothing — leaving the **`yantrikdb_knowledge_gaps` tool and the entire v0.8 self-directing loop (gap→task, "your memory's agenda") silently dormant.**
+
+- `knowledge_gaps` (HTTP + embedded) now accepts and passes `namespace`; the three call sites (`_do_knowledge_gaps`, `_auto_gap_tasks`, `_format_agenda_block`) pass the active namespace.
+- Backward-compatible: engines 0.9.0-0.9.2 have no `namespace` parameter (demand was global there) — the embedded path falls back to the unscoped call on `TypeError`.
+- Verified on engine 0.10.0: with the fix, `knowledge_gaps` returns this namespace's gaps and the self-directing loop fires again. Full suite (312 tests) + benchmark green on 0.10.0; no engine pin change.
+
 ## [0.8.0] — 2026-07-13 — The self-directing substrate
 
 v0.7 gave the substrate new primitives (knowledge gaps, tasks). v0.8 wires them into a **loop no other Hermes memory provider can do**: the memory notices what it doesn't know, queues the work, hands the agent its own agenda, and closes the loop when the gap is answered. All additive and opt-in — zero behaviour change by default, no new tools, no new dependencies.

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -771,8 +771,8 @@ KNOWLEDGE_GAPS_SCHEMA = {
         "asked often (>= min_count) but answered poorly (average top recall "
         "score <= max_avg_top_score) — a direct signal of what your memory "
         "is MISSING. Use it to decide what to research, ask the user about, "
-        "or write down. Note: this signal is engine-global (across all "
-        "namespaces on the backend), not scoped to the active namespace. "
+        "or write down. Scoped to the active namespace on engine 0.9.3+ "
+        "(global on 0.9.0-0.9.2). "
         "Returns 'not available' on engines/servers older than 0.9.0."
     ),
     "parameters": {
@@ -2784,9 +2784,11 @@ class YantrikDBMemoryProvider(MemoryProvider):
         min_count = _coerce_int(args.get("min_count"), 3)
         max_avg = _coerce_float(args.get("max_avg_top_score"), default=0.4)
         limit = _coerce_int(args.get("limit"), 20)
+        namespace = (args.get("namespace") or self._namespace or "").strip()
         try:
             resp = client.knowledge_gaps(
                 min_count=min_count, max_avg_top_score=max_avg, limit=limit,
+                namespace=namespace or None,
             )
         except (AttributeError, YantrikDBServerError):
             return tool_error(
@@ -3425,6 +3427,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
         try:
             resp = self._client.knowledge_gaps(
                 max_avg_top_score=self._config.gap_max_avg_top_score, limit=cap,
+                namespace=self._namespace,
             )
             gaps = (resp.get("gaps") if isinstance(resp, dict) else resp) or []
         except (AttributeError, YantrikDBServerError, YantrikDBError):
@@ -3525,6 +3528,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 min_count=cfg.gap_task_min_count,
                 max_avg_top_score=cfg.gap_max_avg_top_score,
                 limit=max(cfg.gap_task_max * 3, 1),
+                namespace=self._namespace,
             )
             gaps = (resp.get("gaps") if isinstance(resp, dict) else resp) or []
         except (AttributeError, YantrikDBServerError):

--- a/yantrikdb/client.py
+++ b/yantrikdb/client.py
@@ -833,12 +833,17 @@ class YantrikDBClient:
         min_count: int = 3,
         max_avg_top_score: float = 0.4,
         limit: int = 20,
+        namespace: str | None = None,
     ) -> dict[str, Any]:
         params: dict[str, Any] = {
             "min_count": int(min_count),
             "max_avg_top_score": float(max_avg_top_score),
             "limit": int(limit),
         }
+        # engine 0.9.3+ scopes demand per namespace; pass it through so gaps
+        # come from THIS agent's namespace, not the global/default one.
+        if namespace:
+            params["namespace"] = namespace
         return self._request("GET", "/v1/knowledge_gaps", params=params)
 
     # -- Conversation buffer (engine 0.9+) ----------------------------

--- a/yantrikdb/embedded.py
+++ b/yantrikdb/embedded.py
@@ -606,19 +606,28 @@ class EmbeddedYantrikDBClient:
         min_count: int = 3,
         max_avg_top_score: float = 0.4,
         limit: int = 20,
+        namespace: str | None = None,
     ) -> dict[str, Any]:
         """The substrate's known unknowns (engine ``knowledge_gaps``).
 
-        Engine-global (not namespace-scoped). Raises ``AttributeError`` on
-        engines too old to expose it; the provider catches that and returns
-        a clean "not available" envelope.
+        Namespace-scoped on engine 0.9.3+ (demand is recorded per namespace);
+        pass ``namespace`` so gaps come from this agent's namespace. Engines
+        0.9.0-0.9.2 have no ``namespace`` parameter (global demand) — we fall
+        back to the unscoped call there. Raises ``AttributeError`` on engines
+        without the method; the provider returns a clean "not available".
         """
+        base: dict[str, Any] = {
+            "min_count": int(min_count),
+            "max_avg_top_score": float(max_avg_top_score),
+            "limit": int(limit),
+        }
+        ns = namespace or self.config.namespace
         try:
-            out = self._db.knowledge_gaps(
-                min_count=int(min_count),
-                max_avg_top_score=float(max_avg_top_score),
-                limit=int(limit),
-            )
+            try:
+                out = self._db.knowledge_gaps(namespace=ns, **base)
+            except TypeError:
+                # engine < 0.9.3: no namespace kwarg, demand is global.
+                out = self._db.knowledge_gaps(**base)
         except AttributeError:
             raise
         except Exception as e:

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.8.0
+version: 0.8.1
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.9.2


### PR DESCRIPTION
## v0.8.1 — bug fix

Engine **0.9.3** made `knowledge_gaps` namespace-scoped (demand recorded per namespace; a privacy fix — also disabled on encrypted DBs). The plugin called it **without** a namespace, so on any engine **≥0.9.3** it queried the wrong (`default`) namespace and returned nothing — silently disabling the `yantrikdb_knowledge_gaps` tool **and the entire v0.8 self-directing loop** (gap→task, "your memory's agenda"). Our pin is `>=0.9.2`, so this hit anyone on a current engine.

### Fix
- `knowledge_gaps` (HTTP + embedded) now accepts + passes `namespace`; the three call sites pass the active namespace.
- **Backward-compatible:** engines 0.9.0–0.9.2 have no `namespace` param (global demand) — embedded falls back to the unscoped call on `TypeError`.
- Tool description corrected (no longer "engine-global").

### Verification
Confirmed on engine **0.10.0**: with the fix the demo detects gaps (2), auto-creates tasks (2), and closes the loop — it was **0/0** before the fix. 312 tests pass on 0.10.0; benchmark green (MRR 0.932); ruff + mypy clean. No engine pin change.

After merge: tag `v0.8.1` + GitHub release (PyPI auto-publishes via OIDC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)