### PR TITLE
feat(v0.9.1): capability-gated HTTP idempotency forwarding

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.9.0
+version: 0.9.1
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.9.0"
+version = "0.9.1"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/integration/test_live.py
+++ b/tests/integration/test_live.py
@@ -116,3 +116,28 @@ class TestLiveRoundtrip:
         for r in (r1, r2, r3):
             resp = live_client.forget(r["rid"])
             assert resp.get("rid") == r["rid"]
+
+    def test_idempotency_dedup_and_conflict(self, live_client):
+        # v0.9.1 — HTTP idempotency against a live server (yantrikdb-server
+        # #67). Feature-probed: skip if the server doesn't advertise the
+        # capability, per the contract (never version-parse).
+        if not live_client._supports_idempotency_key():
+            pytest.skip("server does not advertise idempotency_key capability")
+        ns = live_client.config.namespace
+        key = f"it:{uuid.uuid4().hex[:8]}"
+        before = live_client.stats(namespace=ns).get("active_memories", 0)
+        r1 = live_client.remember(
+            "Idempotency live test - original.", importance=0.7, idempotency_key=key,
+        )
+        r2 = live_client.remember(
+            "Idempotency live test - original.", importance=0.7, idempotency_key=key,
+        )
+        after = live_client.stats(namespace=ns).get("active_memories", 0)
+        assert r1.get("rid") and r1.get("rid") == r2.get("rid")  # dedup -> same rid
+        assert after == before + 1                               # zero-writes on retry
+        r3 = live_client.remember(
+            "Idempotency live test - DIVERGENT.", importance=0.7, idempotency_key=key,
+        )
+        assert r3.get("idempotency_conflict") is True
+        assert r3.get("rid") == r1.get("rid")                    # surfaces the winner
+        live_client.forget(r1["rid"])

--- a/tests/test_v09_features.py
+++ b/tests/test_v09_features.py
@@ -56,21 +56,65 @@ class TestIdempotentRememberTool:
         assert out["stored"] is False
 
 
-class TestHttpKeyRefusal:
-    def test_http_remember_refuses_key(self, client_module):
-        cfg = client_module.YantrikDBConfig(mode="http", url="http://x", token="t")
-        client = client_module.YantrikDBClient(cfg)
-        with pytest.raises(client_module.YantrikDBClientError, match="http mode"):
-            client.remember("fact", idempotency_key="k1")
+class TestHttpIdempotency:
+    """v0.9.1 — capability-gated key forwarding in http mode (server #67)."""
 
-    def test_http_remember_ok_without_key(self, client_module):
+    def _client(self, client_module, health_caps):
         cfg = client_module.YantrikDBConfig(mode="http", url="http://x", token="t")
         client = client_module.YantrikDBClient(cfg)
-        # no key → no early refusal; it would proceed to _request (patched away)
-        with patch.object(client, "_request", return_value={"rid": "r1"}) as req:
-            out = client.remember("fact")
-        assert out["rid"] == "r1"
-        assert "idempotency_key" not in req.call_args.args[2]
+
+        def fake_request(method, path, body=None, params=None):
+            if path == "/v1/health":
+                return {"capabilities": health_caps} if health_caps is not None else {}
+            return {"rid": "r1", "_body": body}
+
+        return client, fake_request
+
+    def test_forwards_key_when_capability_present_list(self, client_module):
+        client, fr = self._client(client_module, ["recall", "idempotency_key"])
+        with patch.object(client, "_request", side_effect=fr):
+            out = client.remember("fact", idempotency_key="k1")
+        assert out["_body"]["idempotency_key"] == "k1"
+
+    def test_forwards_key_when_capability_present_dict(self, client_module):
+        client, fr = self._client(client_module, {"idempotency_key": True})
+        with patch.object(client, "_request", side_effect=fr):
+            out = client.remember("fact", idempotency_key="k1")
+        assert out["_body"]["idempotency_key"] == "k1"
+
+    def test_refuses_when_capability_absent(self, client_module):
+        client, fr = self._client(client_module, ["recall"])  # no idempotency_key
+        with patch.object(client, "_request", side_effect=fr):
+            with pytest.raises(client_module.YantrikDBClientError, match="idempotency_key"):
+                client.remember("fact", idempotency_key="k1")
+
+    def test_refuses_when_health_probe_fails(self, client_module):
+        cfg = client_module.YantrikDBConfig(mode="http", url="http://x", token="t")
+        client = client_module.YantrikDBClient(cfg)
+
+        def boom(method, path, body=None, params=None):
+            if path == "/v1/health":
+                raise client_module.YantrikDBTransientError("no server")
+            return {"rid": "r1"}
+
+        with patch.object(client, "_request", side_effect=boom):
+            with pytest.raises(client_module.YantrikDBClientError):
+                client.remember("fact", idempotency_key="k1")
+
+    def test_probe_is_cached(self, client_module):
+        client, fr = self._client(client_module, ["idempotency_key"])
+        with patch.object(client, "_request", side_effect=fr) as req:
+            client.remember("a", idempotency_key="k1")
+            client.remember("b", idempotency_key="k2")
+        health_calls = [c for c in req.call_args_list if c.args[1] == "/v1/health"]
+        assert len(health_calls) == 1  # probed once, cached
+
+    def test_no_key_skips_probe_and_field(self, client_module):
+        client, fr = self._client(client_module, ["idempotency_key"])
+        with patch.object(client, "_request", side_effect=fr) as req:
+            client.remember("fact")
+        assert not any(c.args[1] == "/v1/health" for c in req.call_args_list)
+        assert "idempotency_key" not in (req.call_args.args[2] or {})
 
 
 class TestTypedExceptionMap:

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.9.1] — 2026-07-19 — HTTP idempotency: capability-gated key forwarding
+
+Completes the idempotency story for the **optional HTTP backend**. (The default embedded/core path has had idempotent `remember` since v0.9.0 — this only affects `YANTRIKDB_MODE=http` against a `yantrikdb-server`.) Coordinated with yantrikdb-server, whose PR #67 shipped the endpoint with the conflict as **HTTP 200** so it stays byte-identical to the embedded surface.
+
+- **Capability-gated forward (agreement #6).** In http mode, `remember(idempotency_key=…)` now probes `/v1/health` once (cached) for an advertised `idempotency_key` capability. Present → the key is forwarded and the server's response flows through unchanged (same-key/same-text → original rid; same-key/divergent-text → `200 {stored:false, idempotency_conflict:true, rid}`). Absent, or the probe can't confirm → the plugin still **refuses loudly** — never forward-and-silently-drop. Handles both capability shapes (list of features or `{feature: bool}` map).
+- A follower-write leader-redirect (503) maps to a transient via the existing error taxonomy. Auto-following the leader is out of scope (the http client is single-endpoint; point it at the leader or a load balancer).
+- New live integration case (`tests/integration/test_live.py`, gated on `YANTRIKDB_INTEGRATION_URL`) validates dedup zero-writes + divergent-conflict against a real server; feature-probed, skips when the capability is absent.
+
+No engine pin change (`yantrikdb>=0.10.0`). Mock-covered for the capability-gate logic; ruff + mypy clean.
+
 ## [0.9.0] — 2026-07-17 — Idempotent writes, typed errors, and a contract gate
 
 Built with the yantrikdb ecosystem (core / server / mcp) on engine **0.10.0 "the Reliability release"**, and the reason the plugin now **requires `yantrikdb>=0.10.0`** (pin bumped). Three additive pieces; existing behaviour unchanged.

--- a/yantrikdb/client.py
+++ b/yantrikdb/client.py
@@ -569,6 +569,9 @@ class YantrikDBClient:
     def __init__(self, config: YantrikDBConfig, session: Session | None = None):
         self.config = config
         self._session = session if session is not None else self._build_session(config)
+        # v0.9.1 — cached /v1/health capability probe for idempotency keys.
+        # None = not yet probed; True/False after the first check.
+        self._idem_cap: bool | None = None
 
     @staticmethod
     def _build_session(config: YantrikDBConfig) -> Session:
@@ -660,15 +663,15 @@ class YantrikDBClient:
         metadata: dict[str, Any] | None = None,
         idempotency_key: str | None = None,
     ) -> dict[str, Any]:
-        # Honest surface (ecosystem agreement #6): yantrikdb-server does not
-        # yet accept idempotency keys, so REFUSE loudly rather than forward
-        # and silently drop the key. Flip to a request param the day the
-        # server ships it.
-        if idempotency_key:
+        # Honest surface (ecosystem agreement #6): forward an idempotency key
+        # only if the server advertises support (v0.9.1 capability probe);
+        # otherwise REFUSE loudly rather than forward-and-silently-drop.
+        if idempotency_key and not self._supports_idempotency_key():
             raise YantrikDBClientError(
-                "idempotency keys are not yet supported in http mode "
-                "(yantrikdb-server has not shipped the endpoint). Use "
-                "embedded mode with yantrikdb>=0.10.0, or omit the key."
+                "idempotency keys are not supported by this yantrikdb-server "
+                "(its /v1/health capabilities do not advertise "
+                "'idempotency_key'). Upgrade the server, use embedded mode "
+                "(yantrikdb>=0.10.0), or omit the key."
             )
         safe_text = truncate_text(text, self.config.max_text_len)
         body: dict[str, Any] = {
@@ -682,7 +685,36 @@ class YantrikDBClient:
             body["memory_type"] = memory_type
         if metadata:
             body["metadata"] = metadata
+        if idempotency_key:
+            body["idempotency_key"] = idempotency_key
+        # Server returns 200 {stored:false, idempotency_conflict:true, rid} on
+        # a same-key/divergent-text conflict (byte-identical to embedded), so
+        # the response flows through unchanged; a same-key/same-text hit
+        # returns the original rid. A follower-write 503 (leader redirect)
+        # maps to a transient via _parse_response.
         return self._request("POST", "/v1/remember", body)
+
+    def _supports_idempotency_key(self) -> bool:
+        """Cached /v1/health probe for the ``idempotency_key`` capability.
+
+        Only forward a key the server actually advertises (agreement #6),
+        never assume. Probed once, cached for the client's lifetime. Handles
+        both capability shapes — a list of feature strings, or a
+        ``{feature: bool}`` map.
+        """
+        if self._idem_cap is not None:
+            return self._idem_cap
+        supported = False
+        try:
+            caps = (self._request("GET", "/v1/health") or {}).get("capabilities")
+            if isinstance(caps, dict):
+                supported = bool(caps.get("idempotency_key"))
+            elif isinstance(caps, (list, tuple)):
+                supported = "idempotency_key" in caps
+        except YantrikDBError:
+            supported = False  # can't confirm → refuse, never assume support
+        self._idem_cap = supported
+        return supported
 
     def recall(
         self,

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.9.0
+version: 0.9.1
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.10.0


### PR DESCRIPTION
## v0.9.1 — HTTP idempotency (optional backend only)

Completes the idempotency story for the **optional HTTP backend**. The default embedded/core path has had idempotent `remember` since v0.9.0 — this only affects `YANTRIKDB_MODE=http`. Coordinated with **yantrikdb-server #67**, which shipped the endpoint and returns the conflict as **HTTP 200** so it's byte-identical to embedded.

- **Capability-gated forward (agreement #6):** http `remember(idempotency_key=…)` probes `/v1/health` once (cached) for an advertised `idempotency_key` capability. Present → forward the key, server response flows through unchanged. Absent / unprobeable → **refuse loudly** (never forward-and-drop). Handles list and `{feature: bool}` capability shapes.
- Follower-write **503 leader-redirect** → transient via the existing taxonomy (single-endpoint client; auto-redirect out of scope — point at the leader/LB).
- New **gated live case** (`test_live.py`, `YANTRIKDB_INTEGRATION_URL`) validates dedup zero-writes + divergent conflict against a real server; feature-probed.

No engine pin change (`yantrikdb>=0.10.0`). 331 tests (global) / 323 (bare CI) pass; ruff + mypy clean. After merge: tag `v0.9.1` + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)