### PR TITLE
fix(v0.9.2): collision-proof embedded engine load + loud write-failure (#50)

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.9.1
+version: 0.9.2
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.9.1"
+version = "0.9.2"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_issue50_collision.py
+++ b/tests/test_issue50_collision.py
@@ -1,0 +1,157 @@
+"""Issue #50 — embedded package-name collision + silent-success hardening (v0.9.2).
+
+The plugin's own top-level package is named ``yantrikdb`` (to match
+``plugin.yaml`` and the ``hermes plugins install`` layout), identical to the
+engine distribution it depends on. When the plugin dir wins ``sys.path``
+resolution, ``from yantrikdb._yantrikdb_rust import YantrikDB`` binds to the
+plugin (no ``_yantrikdb_rust``) and embedded init fails — even though the real
+engine is installed. These tests simulate that shadow WITHOUT a native engine,
+so they run in CI, and pin the two-layer fix:
+
+  Layer 1 — ``load_engine_yantrikdb_class`` recovers by loading the engine's
+            extension from its installed distribution, with truthful errors.
+  Layer 2 — a dropped write (backend never initialized) is loud + counted, and
+            ``is_available`` tells the truth under the shadow.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+import types
+
+import pytest
+
+
+def _emb(provider_module):
+    return importlib.import_module(provider_module.__name__ + ".embedded")
+
+
+def _shadow_engine(monkeypatch) -> None:
+    """Simulate the plugin package shadowing the engine on ``sys.path``:
+    a ``yantrikdb`` package with an empty ``__path__`` and no ``_yantrikdb_rust``
+    submodule, so the fast-path import raises ``ImportError`` deterministically —
+    regardless of whether a real engine is installed in the test environment."""
+    fake = types.ModuleType("yantrikdb")
+    fake.__path__ = []  # a package, but with no discoverable submodules
+    monkeypatch.setitem(sys.modules, "yantrikdb", fake)
+    monkeypatch.delitem(sys.modules, "yantrikdb._yantrikdb_rust", raising=False)
+
+
+class TestEngineLoaderCollision:
+    def test_collision_with_missing_engine_raises_truthful(
+        self, monkeypatch, provider_module, client_module,
+    ):
+        emb = _emb(provider_module)
+        _shadow_engine(monkeypatch)
+        monkeypatch.setattr(emb, "find_engine_ext_path", lambda: None)
+        with pytest.raises(client_module.YantrikDBError, match="not installed"):
+            emb.load_engine_yantrikdb_class()
+
+    def test_collision_loads_engine_from_located_path(
+        self, monkeypatch, tmp_path, provider_module,
+    ):
+        emb = _emb(provider_module)
+        _shadow_engine(monkeypatch)
+        # A stand-in "extension": a .py file exposing YantrikDB. spec_from_file_
+        # location uses SourceFileLoader for .py, exercising the same load path a
+        # real compiled .so would take.
+        fake_ext = tmp_path / "_yantrikdb_rust.py"
+        fake_ext.write_text("class YantrikDB:\n    marker = 'real-engine'\n")
+        monkeypatch.setattr(emb, "find_engine_ext_path", lambda: str(fake_ext))
+        try:
+            cls = emb.load_engine_yantrikdb_class()
+            assert getattr(cls, "marker", None) == "real-engine"
+            # Loaded module cached so a later plain import resolves the engine
+            # despite the shadowing package (fixes is_available too).
+            assert sys.modules.get("yantrikdb._yantrikdb_rust") is not None
+        finally:
+            sys.modules.pop("yantrikdb._yantrikdb_rust", None)
+
+    def test_find_engine_ext_path_fallback_scan_excludes_own_dir(
+        self, monkeypatch, tmp_path, provider_module,
+    ):
+        emb = _emb(provider_module)
+        from importlib import metadata as ilm
+
+        def _raise(_name):
+            raise ilm.PackageNotFoundError()
+
+        # Force the metadata branch to miss so the sys.path scan runs.
+        monkeypatch.setattr(ilm, "distribution", _raise)
+        engine_root = tmp_path / "site"
+        (engine_root / "yantrikdb").mkdir(parents=True)
+        ext = engine_root / "yantrikdb" / "_yantrikdb_rust.cpython-311.so"
+        ext.write_bytes(b"\x00")
+        monkeypatch.syspath_prepend(str(engine_root))
+        found = emb.find_engine_ext_path()
+        assert found is not None and found.endswith(".so")
+
+
+class TestDroppedWriteSignal:
+    """Layer 2 — a write dropped because the backend never initialized must be
+    loud and counted, never silent (issue #50)."""
+
+    def _uninit_provider(self, provider_module):
+        p = provider_module.YantrikDBMemoryProvider()
+        p._client = None
+        p._cron_skipped = False
+        p._init_error = "collision: engine shadowed by plugin (issue #50)"
+        return p
+
+    def test_dropped_write_logs_once_and_keeps_counting(
+        self, provider_module, caplog,
+    ):
+        p = self._uninit_provider(provider_module)
+        with caplog.at_level(logging.ERROR):
+            p.on_memory_write("add", "memory", "Don is CEO of Agilicus")
+            p.on_memory_write("add", "user", "Don uses he/him")
+        assert p._dropped_writes == 2
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1  # logged once, not per write
+        assert "DROPPED" in errors[0].getMessage()
+
+    def test_non_qualifying_writes_do_not_count(self, provider_module):
+        p = self._uninit_provider(provider_module)
+        p.on_memory_write("delete", "memory", "x")   # not an add
+        p.on_memory_write("add", "scratch", "x")      # unmirrored target
+        p.on_memory_write("add", "memory", "")        # empty content
+        assert p._dropped_writes == 0
+
+
+class TestIsAvailableTruthful:
+    """Layer 2 — availability reflects reality under the shadow so
+    `hermes memory status` doesn't report a phantom-absent backend."""
+
+    def test_available_via_locator_when_import_shadowed(
+        self, monkeypatch, provider_module,
+    ):
+        p = provider_module.YantrikDBMemoryProvider()
+        emb = _emb(provider_module)
+        _shadow_engine(monkeypatch)  # plain import fails
+        monkeypatch.setattr(
+            emb, "find_engine_ext_path", lambda: "/opt/_yantrikdb_rust.so",
+        )
+        assert p.is_available() is True
+
+    def test_unavailable_when_locator_empty(self, monkeypatch, provider_module):
+        p = provider_module.YantrikDBMemoryProvider()
+        emb = _emb(provider_module)
+        _shadow_engine(monkeypatch)
+        monkeypatch.setattr(emb, "find_engine_ext_path", lambda: None)
+        assert p.is_available() is False
+
+
+class TestNotAvailablePromptBlock:
+    def test_block_forbids_claiming_saves_and_names_collision(
+        self, provider_module,
+    ):
+        p = provider_module.YantrikDBMemoryProvider()
+        p._client = None
+        p._cron_skipped = False
+        p._init_error = "boom"
+        block = p.system_prompt_block()
+        assert "NOT AVAILABLE" in block
+        assert "Do NOT tell the user their memories were saved" in block
+        assert "issue #50" in block.lower() or "#50" in block

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.9.2] — 2026-07-19 — Fix embedded package-name collision (issue #50)
+
+Fixes a real, high-severity bug reported by [@AtheIIa](https://github.com/AtheIIa) in [#50](https://github.com/yantrikos/yantrikdb-hermes-plugin/issues/50): embedded mode could silently fail to initialize because this plugin's own top-level package is named `yantrikdb` — identical to the engine it depends on. When the plugin directory wins `sys.path` resolution (the `hermes plugins install` layout, or any run from a source checkout), `from yantrikdb._yantrikdb_rust import YantrikDB` bound to the plugin (which has no `_yantrikdb_rust`) and raised `ModuleNotFoundError`, surfaced misleadingly as "requires yantrikdb >= 0.7.4" even though the engine was installed and importable on its own. The `pip install yantrikdb-hermes-plugin` path was never affected (setuptools imports it as `yantrikdb_hermes_plugin`).
+
+- **Layer 1 — collision-proof engine load.** `embedded.py` now loads the engine through `load_engine_yantrikdb_class()`: a fast-path plain import first, and on failure it locates the real `yantrikdb` **distribution** (unambiguous — the plugin's distribution is `yantrikdb-hermes-plugin`) via `importlib.metadata`, loads its `_yantrikdb_rust` extension directly regardless of `sys.path` order, and caches it so later plain imports resolve the engine too. Errors are now truthful: "engine not installed" vs. "engine installed but shadowed — install via pip to avoid the collision."
+- **Layer 2 — no more silent success.** When init genuinely fails (`_client is None`), a dropped `memory add` mirror is now **loud and counted** (`ERROR` logged once, `_dropped_writes` tally) instead of a silent no-op — the reporter's agent had no in-band signal that persistence was broken and confabulated successful writes. `is_available()` now reports the truth under the shadow (locates the engine without importing the shadowed name), and the NOT-AVAILABLE system-prompt block explicitly instructs the model **not** to claim memories were saved and names the collision as a likely cause.
+- The permanent rename (`yantrikdb` → `yantrikdb_hermes_plugin`) that would eliminate the collision class entirely is deliberately deferred to a later minor: it changes the `hermes plugins install` registration path and is breaking for existing installs.
+- 8 new CI-safe tests (`tests/test_issue50_collision.py`) simulate the shadow without a native engine; suite 339 pass / 3 skip.
+
 ## [0.9.1] — 2026-07-19 — HTTP idempotency: capability-gated key forwarding
 
 Completes the idempotency story for the **optional HTTP backend**. (The default embedded/core path has had idempotent `remember` since v0.9.0 — this only affects `YANTRIKDB_MODE=http` against a `yantrikdb-server`.) Coordinated with yantrikdb-server, whose PR #67 shipped the endpoint with the conflict as **HTTP 200** so it stays byte-identical to the embedded surface.

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -1286,6 +1286,11 @@ class YantrikDBMemoryProvider(MemoryProvider):
         # dir), capture the reason here so system_prompt_block can surface
         # it to the model instead of yantrikdb appearing silently absent.
         self._init_error: str | None = None
+        # v0.9.2: count writes dropped because the backend never initialized,
+        # and log the first one loudly (issue #50, layer 2). A silent drop lets
+        # the model believe a memory was saved when it was not.
+        self._dropped_writes: int = 0
+        self._dropped_write_logged: bool = False
 
         self._prefetch_results: dict[str, str] = {}
         self._prefetch_lock = threading.Lock()
@@ -1350,7 +1355,13 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 import yantrikdb._yantrikdb_rust  # noqa: F401
                 return True
             except ImportError:
-                return False
+                # The plain import can fail while the engine is installed and
+                # usable, when this plugin package (also named ``yantrikdb``)
+                # shadows the engine on sys.path (issue #50). Fall back to
+                # locating the engine's extension without importing the name,
+                # so `hermes memory status` reports the truth.
+                from .embedded import find_engine_ext_path
+                return find_engine_ext_path() is not None
         return bool(cfg.token)
 
     def get_config_schema(self) -> list[dict[str, Any]]:
@@ -1735,9 +1746,15 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 return (
                     "# YantrikDB Memory — NOT AVAILABLE\n"
                     f"The plugin failed to initialize: {self._init_error}\n"
-                    "Memory tools (`yantrikdb_*`) will not work this session. "
-                    "Inform the user and proceed without memory tooling. "
-                    "Common cause: the engine's model-cache directory "
+                    "Memory tools (`yantrikdb_*`) will not work this session, "
+                    "and any `memory add` will NOT be saved to YantrikDB. "
+                    "Do NOT tell the user their memories were saved — they were "
+                    "not. Inform the user memory persistence is unavailable and "
+                    "proceed without memory tooling.\n"
+                    "Common causes: (1) the plugin package (named `yantrikdb`) "
+                    "is shadowing the engine on sys.path — install via "
+                    "`pip install yantrikdb-hermes-plugin` to avoid it "
+                    "(issue #50); (2) the engine's model-cache directory "
                     "(`$XDG_CACHE_HOME/yantrikdb/models/` or "
                     "`$HOME/.cache/yantrikdb/models/`) isn't writable. "
                     "See https://github.com/yantrikos/yantrikdb-hermes-plugin/issues "
@@ -3784,7 +3801,17 @@ class YantrikDBMemoryProvider(MemoryProvider):
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in MEMORY.md / USER.md additions into YantrikDB."""
-        if self._cron_skipped or self._client is None:
+        if self._cron_skipped:
+            return
+        if self._client is None:
+            # Init failed (e.g. issue #50 collision) — the mirror to YantrikDB
+            # cannot happen. Hermes' `memory add` still reports success for its
+            # own MEMORY.md write and does not check this hook's return, so the
+            # ONLY signal we can raise is a loud, deduplicated log. Without it
+            # the failure is fully silent and the model may confabulate a saved
+            # memory (issue #50, layer 2).
+            if action == "add" and target in ("memory", "user") and content:
+                self._warn_write_dropped()
             return
         if action != "add" or target not in ("memory", "user") or not content:
             return
@@ -3819,6 +3846,27 @@ class YantrikDBMemoryProvider(MemoryProvider):
         threading.Thread(
             target=_run, daemon=True, name="yantrikdb-memwrite",
         ).start()
+
+    def _warn_write_dropped(self) -> None:
+        """Record + loudly log a write dropped because the backend is down.
+
+        Hermes reports its own `memory add` as successful and ignores this
+        hook's return, so a log is the only in-band signal we can raise that
+        the YantrikDB mirror did not happen (issue #50, layer 2). Logged once
+        at ERROR to avoid per-write spam; the count keeps accumulating.
+        """
+        self._dropped_writes += 1
+        if not self._dropped_write_logged:
+            self._dropped_write_logged = True
+            reason = self._init_error or "backend not initialized"
+            logger.error(
+                "YantrikDB memory write DROPPED — the plugin failed to "
+                "initialize (%s). Hermes' `memory add` reports success for its "
+                "own store, but nothing was mirrored into YantrikDB. Fix the "
+                "init failure or install via `pip install yantrikdb-hermes-"
+                "plugin` to avoid the package-name collision (issue #50).",
+                reason,
+            )
 
     # -- Circuit breaker --------------------------------------------------
 

--- a/yantrikdb/embedded.py
+++ b/yantrikdb/embedded.py
@@ -21,8 +21,11 @@ Lifecycle / threading model (per yantrikdb-core guidance):
 
 from __future__ import annotations
 
+import glob
 import logging
+import os
 import re
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -215,6 +218,123 @@ def _default_db_path() -> str:
         return str(Path.home() / ".yantrikdb-hermes-memory.db")
 
 
+_ENGINE_EXT_SUFFIXES = (".so", ".pyd", ".dylib")
+
+
+def find_engine_ext_path() -> str | None:
+    """Absolute path to the engine's ``_yantrikdb_rust`` compiled extension,
+    resolved WITHOUT importing the shadowed ``yantrikdb`` name (issue #50).
+
+    ``None`` when the engine distribution is not installed. The engine's PyPI
+    distribution is named ``yantrikdb``; this plugin's is
+    ``yantrikdb-hermes-plugin`` — so ``importlib.metadata`` disambiguates them
+    even though both expose a top-level package literally named ``yantrikdb``.
+    """
+    from importlib import metadata as _ilm
+
+    # Preferred: read the engine distribution's own file list (no import, so
+    # the plugin's shadowing ``yantrikdb`` package can't interfere).
+    try:
+        dist = _ilm.distribution("yantrikdb")
+    except _ilm.PackageNotFoundError:
+        dist = None
+    if dist is not None:
+        for f in (dist.files or []):
+            name = os.path.basename(str(f))
+            if name.startswith("_yantrikdb_rust") and name.endswith(
+                _ENGINE_EXT_SUFFIXES,
+            ):
+                located = os.path.abspath(str(dist.locate_file(f)))
+                if os.path.exists(located):
+                    return located
+
+    # Fallback: scan ``sys.path`` for a ``yantrikdb`` package dir that carries
+    # the extension and is NOT this plugin's own directory (the shadow).
+    our_dir = os.path.dirname(os.path.abspath(__file__))
+    for entry in sys.path:
+        try:
+            cand = os.path.join(entry or ".", "yantrikdb")
+            if not os.path.isdir(cand) or os.path.abspath(cand) == our_dir:
+                continue
+            for suf in _ENGINE_EXT_SUFFIXES:
+                hits = glob.glob(os.path.join(cand, "_yantrikdb_rust*" + suf))
+                if hits:
+                    return os.path.abspath(hits[0])
+        except OSError:
+            continue
+    return None
+
+
+def load_engine_yantrikdb_class() -> Any:
+    """Return the engine's ``YantrikDB`` class, resilient to the package-name
+    collision of issue #50.
+
+    This plugin package is itself named ``yantrikdb`` (to match ``plugin.yaml``
+    ``name: yantrikdb`` and the ``hermes plugins install`` layout). When the
+    plugin directory is ahead of the installed engine on ``sys.path`` — the
+    ``hermes plugins install`` path, or any run from a source checkout — a plain
+    ``from yantrikdb._yantrikdb_rust import YantrikDB`` resolves against THIS
+    package (which has no ``_yantrikdb_rust``) and raises ``ImportError``, even
+    though the real engine is installed and importable on its own. We recover by
+    loading the engine's compiled extension directly from its installed
+    distribution, and cache it so later plain imports resolve the engine too.
+    """
+    # Fast path — correct whenever the engine wins name resolution: the
+    # pip-installed plugin imports as ``yantrikdb_hermes_plugin`` (no clash), or
+    # the engine simply sits first on ``sys.path``.
+    try:
+        from yantrikdb._yantrikdb_rust import YantrikDB  # type: ignore
+        return YantrikDB
+    except ImportError:
+        pass
+
+    # Collision (or genuinely-missing) path.
+    import importlib.util as _ilu
+
+    ext_path = find_engine_ext_path()
+    if ext_path is None:
+        raise YantrikDBError(
+            "embedded mode requires the `yantrikdb` engine, which is not "
+            "installed in this environment. Install it with: "
+            "pip install --upgrade yantrikdb",
+        )
+
+    try:
+        spec = _ilu.spec_from_file_location("yantrikdb._yantrikdb_rust", ext_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"no import spec for {ext_path}")
+        module = _ilu.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except Exception as e:  # noqa: BLE001 — re-raised as a truthful engine error
+        raise YantrikDBError(
+            "the `yantrikdb` engine is installed but this plugin package "
+            f"(also named `yantrikdb`) is shadowing it on sys.path, and the "
+            f"engine's native extension at {ext_path} could not be loaded "
+            f"directly: {e}. Installing the plugin via "
+            "`pip install yantrikdb-hermes-plugin` (which imports as "
+            "`yantrikdb_hermes_plugin`) avoids the collision entirely. "
+            "See https://github.com/yantrikos/yantrikdb-hermes-plugin/issues/50",
+        ) from e
+
+    # Cache the loaded extension so subsequent plain imports (e.g. the
+    # availability probe) resolve the engine despite the shadowing package.
+    try:
+        sys.modules.setdefault("yantrikdb._yantrikdb_rust", module)
+        shadow = sys.modules.get("yantrikdb")
+        if shadow is not None and not hasattr(shadow, "_yantrikdb_rust"):
+            shadow._yantrikdb_rust = module  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 — caching is best-effort, never fatal
+        pass
+
+    try:
+        return module.YantrikDB
+    except AttributeError as e:
+        raise YantrikDBError(
+            "the loaded `yantrikdb` native extension exposes no `YantrikDB` "
+            "class; the installed engine may be too old (need >= 0.7.4).",
+        ) from e
+
+
 class EmbeddedYantrikDBClient:
     """Adapter wrapping ``yantrikdb._yantrikdb_rust.YantrikDB`` to the
     same surface as ``YantrikDBClient`` (HTTP).
@@ -227,13 +347,7 @@ class EmbeddedYantrikDBClient:
     def __init__(self, config: YantrikDBConfig) -> None:
         self.config = config
 
-        try:
-            from yantrikdb._yantrikdb_rust import YantrikDB
-        except ImportError as e:
-            raise YantrikDBError(
-                "embedded mode requires `yantrikdb >= 0.7.4`. "
-                "Install with: pip install --upgrade yantrikdb"
-            ) from e
+        YantrikDB = load_engine_yantrikdb_class()
 
         db_path = config.db_path or _default_db_path()
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.9.1
+version: 0.9.2
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.10.0


### PR DESCRIPTION
Fixes #50 (reported by @AtheIIa — thorough, accurate write-up).

## The bug
This plugin's own top-level package is named `yantrikdb`, identical to the engine distribution it depends on. When the plugin directory wins `sys.path` resolution — the `hermes plugins install` layout, or any run from a source checkout — `from yantrikdb._yantrikdb_rust import YantrikDB` in `embedded.py` binds to the **plugin** (which has no `_yantrikdb_rust`) and raises `ModuleNotFoundError`, surfaced misleadingly as *"requires yantrikdb >= 0.7.4"* even though the engine is installed and importable on its own.

- `pip install yantrikdb-hermes-plugin` was **never** affected (setuptools imports it as `yantrikdb_hermes_plugin`).
- `hermes plugins install` (our README's recommended path) and source-tree runs **were**.

Reproduced the reporter's exact `ModuleNotFoundError: No module named 'yantrikdb._yantrikdb_rust'` locally, and confirmed the fix recovers.

## Layer 1 — collision-proof engine load
`embedded.py` now loads the engine via `load_engine_yantrikdb_class()`:
1. fast-path plain import (correct for pip installs / engine-first `sys.path`);
2. on failure, locate the real `yantrikdb` **distribution** via `importlib.metadata` (unambiguous — the plugin's distribution is `yantrikdb-hermes-plugin`), load its `_yantrikdb_rust` extension directly regardless of path order, and cache it so later plain imports resolve the engine too;
3. truthful errors: *engine not installed* vs. *engine installed but shadowed — install via pip to avoid the collision*.

## Layer 2 — no more silent success
The reporter's second finding: on init failure the write mirror silently no-ops while Hermes' `memory add` still reports success, and the agent confabulated saved memories.
- A dropped mirror (`_client is None`) is now **loud + counted** — `ERROR` logged once, `_dropped_writes` tally — instead of a silent `return`.
- `is_available()` reports the truth under the shadow (locates the engine without importing the shadowed name), so `hermes memory status` isn't phantom-absent.
- The NOT-AVAILABLE system-prompt block now explicitly tells the model **not** to claim memories were saved, and names the collision as a likely cause.

## Not in this PR (deliberately)
The permanent rename (`yantrikdb` → `yantrikdb_hermes_plugin`) that eliminates the collision class entirely changes the `hermes plugins install` registration path and is breaking for existing installs — deferred to a later minor.

## Tests
8 new CI-safe tests (`tests/test_issue50_collision.py`) simulate the shadow with no native engine (fast-path `ImportError` → recovery), plus the dropped-write signal and truthful availability. Full suite **339 pass / 3 skip**; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)