### PR TITLE
release(v0.10.1): require yantrikdb>=0.11.3 (index could lose recall)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Tests](https://img.shields.io/badge/tests-128%20passing-brightgreen)](https://github.com/yantrikos/yantrikdb-hermes-plugin/actions)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://github.com/yantrikos/yantrikdb-hermes-plugin)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![YantrikDB](https://img.shields.io/badge/yantrikdb-%E2%89%A50.10.1-orange)](https://github.com/yantrikos/yantrikdb-server)
+[![YantrikDB](https://img.shields.io/badge/yantrikdb-%E2%89%A50.11.3-orange)](https://github.com/yantrikos/yantrikdb-server)
 [![Hermes Agent](https://img.shields.io/badge/hermes--agent-plugin-8a2be2)](https://github.com/NousResearch/hermes-agent)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![mypy](https://img.shields.io/badge/mypy-checked-2a6db2)](https://mypy-lang.org/)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.10.0
+version: 0.10.1
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the
@@ -7,7 +7,7 @@ version: 0.10.0
 # `yantrikdb-hermes install <hermes>`. Both should declare the same version.
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.10.1
+  - yantrikdb>=0.11.3
   - requests>=2.31
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.10.0"
+version = "0.10.1"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -35,7 +35,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-  "yantrikdb>=0.10.1",
+  "yantrikdb>=0.11.3",
   "requests>=2.31",
 ]
 

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.10.1] — 2026-08-01 — Require the engine release that can't lose recall
+
+Pin raised to **`yantrikdb>=0.11.3`**. No plugin behaviour changes; the full suite passes unmodified against 0.11.3 (376 pass / 3 skip) and every engine method this plugin calls is unchanged.
+
+The floor moves because engine 0.11.3 fixes a defect in the vector index that could **accept a write and then make the record unreachable by every possible query — including a search for its own exact text**. The victim changed on each index build (graph construction seeds from entropy), so the same database could serve a different subset each time it opened. Upstream's summary is blunt about the blast radius: *"Any deployment on an earlier version can be holding memories it cannot return."*
+
+Our previous floor (`>=0.10.1`) allowed a fresh install to resolve to an affected engine, which meant a user could store a memory successfully and later fail to recall it, with nothing anywhere reporting a problem. Raising the floor closes that window rather than documenting it.
+
+**No migration.** The index rebuilds from SQLite on open and the repair runs there, so an affected database heals itself the first time it is opened on 0.11.3. If yours was affected you'll see `vec index rebuild reconnected unreachable nodes` in the logs, and the count is how many records were rescued.
+
 ## [0.10.0] — 2026-07-25 — The install is the product
 
 What you get by running `pip install` should be what the plugin is actually *for*, it shouldn't cost more context than it's worth, and it should use what Hermes actually offers.

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,8 +1,8 @@
 name: yantrikdb
-version: 0.10.0
+version: 0.10.1
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.10.1
+  - yantrikdb>=0.11.3
   - requests>=2.31
 hooks:
   - on_session_end


### PR DESCRIPTION
No plugin behaviour changes. This raises the engine floor.

## Why
Engine **0.11.3** fixes a defect where the vector index could accept a write and then make the record **unreachable by every possible query — including a search for its own exact text**. Graph construction seeds from entropy, so the victim changed on each index build; the same database could serve a different subset each time it opened. Upstream is blunt about the blast radius:

> *"Any deployment on an earlier version can be holding memories it cannot return."*

Our floor was `>=0.10.1`, so a **fresh install today could still resolve to an affected engine** — meaning a user stores a memory successfully and later can't recall it, with nothing anywhere reporting a fault. That's the failure mode we've spent two releases eliminating, so the floor moves rather than the docs gaining a caveat.

## No migration
The index rebuilds from SQLite on open and the repair runs there, so an affected database heals itself on first open under 0.11.3. Watch for `vec index rebuild reconnected unreachable nodes` — the count is how many records were rescued.

## Verification
Ran the full suite **unmodified** against engine 0.11.3 in a clean venv: **376 pass / 3 skip**. Confirmed every engine method the plugin calls still exists on 0.11.3 (133 methods now, up from 111 — the additions are the pack API). Record + recall smoke-tested directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)