### PR TITLE
feat(v0.11.0): attachable expertise — knowledge packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ This is the substrate yantrikdb already ships: temporal context graph via `relat
 
 The loop no other Hermes memory provider can do — the memory **notices what it doesn't know, queues the work, hands the agent its own agenda, and closes the loop** when the gap is answered. **On by default since v0.10.0** (it was opt-in through v0.9.x, which meant most installs never saw it); bounded to `gap_task_max` new tasks per session and `agenda_max_items` prompt lines, and gated on *recurring* poorly-answered queries so one weak recall can't mint a task. Disable with `YANTRIKDB_AUTO_GAP_TASKS=false` / `YANTRIKDB_SURFACE_AGENDA=false`. Runnable via `python demos/self_directing_memory.py`. Details: **[assets/demos/self-directing/](./assets/demos/self-directing/)**.
 
+### Attachable expertise — knowledge packs (v0.11.0)
+
+A **pack** is a sealed, signed knowledge file. Mount it to gain its knowledge and rules for a task; unmount to give them back, leaving your own memory byte-for-byte unchanged. No other Hermes memory provider can do this.
+
+```bash
+echo "YANTRIKDB_PACKS_ENABLED=true" >> ~/.hermes/.env
+# optional: mount packs for every session (transient - unmounted on shutdown)
+echo "YANTRIKDB_AUTO_MOUNT_PACKS=wordpress-expert-0.2.0.ydbpack" >> ~/.hermes/.env
+```
+
+The agent drives it with `yantrikdb_packs`: `inspect` a pack's manifest before trusting it, `mount` for the session, `install` to keep it across restarts, `unmount` / `uninstall` to reverse. While mounted, the pack's constitution and coverage are injected into the system prompt (capped, and scaled by the adaptive budget) and **recall reaches the pack's records**, not just its rules.
+
+Mounting is refused when a pack's vectors come from a different embedding space — that refusal is what stops confidently wrong answers, so it's reported rather than forced. Packs are embedded-mode only; in HTTP mode the database lives on the server and packs are the operator's business there.
+
 ### Context cost
 
 Tool schemas are re-sent on every request, so the tool surface is a per-turn cost. Since v0.10.0 the default profile is `core` — 7 tools, ~1.7k tokens — instead of all 18 (~3.6k):

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.10.1
+version: 0.11.0
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.10.1"
+version = "0.11.0"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -1,0 +1,240 @@
+"""v0.11.0 — attachable expertise (engine packs).
+
+A pack is a sealed, signed knowledge file: mount it to gain its knowledge and
+rules, unmount to give them back leaving the host database byte-for-byte as it
+was. The engine's own framing drives two design choices tested here:
+
+- `mount` is transient and never writes to the database, so auto-mount uses it
+  and shutdown gives the packs back. `install` is the deliberate, durable
+  counterpart and is never implicit.
+- `pack_context()` is assembled BY THE ENGINE so every consumer injects the
+  same block; we pass it through verbatim rather than reformatting it.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_client(client_module) -> MagicMock:
+    c = MagicMock(spec=client_module.YantrikDBClient)
+    c.health.return_value = {"status": "ok"}
+    c.pack_action.return_value = {"pack_id": "wordpress-expert@0.2.0"}
+    c.pack_context.return_value = {"context": "PACK RULES: prefer block themes."}
+    return c
+
+
+def _provider(provider_module, mock_client, monkeypatch, **env):
+    monkeypatch.setenv("YANTRIKDB_MODE", "http")
+    monkeypatch.setenv("YANTRIKDB_TOKEN", "ydb_test")
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    p = provider_module.YantrikDBMemoryProvider()
+    with patch.object(provider_module, "make_backend", return_value=mock_client):
+        p.initialize("s1", agent_workspace="ws", agent_identity="coder",
+                     platform="cli")
+    return p
+
+
+class TestPackToolGating:
+    def test_hidden_by_default(self, provider_module):
+        p = provider_module.YantrikDBMemoryProvider()
+        names = {s["name"] for s in p.get_tool_schemas()}
+        assert "yantrikdb_packs" not in names
+
+    def test_visible_in_core_profile_when_enabled(
+        self, provider_module, monkeypatch,
+    ):
+        """Enabling packs and then being unable to reach them because the
+        profile is `core` would be a trap — the flag is the opt-in."""
+        monkeypatch.setenv("YANTRIKDB_PACKS_ENABLED", "true")
+        monkeypatch.setenv("YANTRIKDB_TOOL_PROFILE", "core")
+        p = provider_module.YantrikDBMemoryProvider()
+        names = {s["name"] for s in p.get_tool_schemas()}
+        assert "yantrikdb_packs" in names
+
+    def test_call_refused_when_disabled(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        p = _provider(provider_module, mock_client, monkeypatch)
+        out = json.loads(p.handle_tool_call("yantrikdb_packs", {"action": "list"}))
+        assert "error" in out
+        mock_client.pack_action.assert_not_called()
+
+
+class TestPackDispatch:
+    def test_actions_reach_the_backend(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_PACKS_ENABLED="true")
+        p.handle_tool_call("yantrikdb_packs",
+                           {"action": "mount", "path": "wp.ydbpack"})
+        args, kwargs = mock_client.pack_action.call_args
+        assert args[0] == "mount"
+        assert kwargs["path"] == "wp.ydbpack"
+
+    def test_defaults_to_list(self, provider_module, mock_client, monkeypatch):
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_PACKS_ENABLED="true")
+        p.handle_tool_call("yantrikdb_packs", {})
+        assert mock_client.pack_action.call_args.args[0] == "list"
+
+    def test_mount_invalidates_cached_context(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        """The injected block is built from the mounted set, so it is stale the
+        instant that set changes."""
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_PACKS_ENABLED="true")
+        p._pack_context_cache = "stale"
+        p.handle_tool_call("yantrikdb_packs",
+                           {"action": "mount", "path": "wp.ydbpack"})
+        assert p._pack_context_cache is None
+
+
+class TestPackContextBlock:
+    def test_injected_verbatim(self, provider_module, mock_client, monkeypatch):
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_PACKS_ENABLED="true")
+        block = p.system_prompt_block()
+        assert "Mounted knowledge packs" in block
+        assert "prefer block themes" in block
+
+    def test_absent_when_packs_disabled(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        p = _provider(provider_module, mock_client, monkeypatch)
+        assert "Mounted knowledge packs" not in p.system_prompt_block()
+
+    def test_absent_when_no_pack_declares_context(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        mock_client.pack_context.return_value = {"context": None}
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_PACKS_ENABLED="true")
+        assert "Mounted knowledge packs" not in p.system_prompt_block()
+
+    def test_capped(self, provider_module, mock_client, monkeypatch):
+        mock_client.pack_context.return_value = {"context": "X" * 20000}
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_PACKS_ENABLED="true",
+                      YANTRIKDB_PACK_CONTEXT_MAX_CHARS="300")
+        assert len(p.system_prompt_block()) < 2000
+
+    def test_yields_to_a_tight_context_window(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        """Attached expertise is worth nothing if it crowds out the
+        conversation that needed it."""
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_PACKS_ENABLED="true")
+        roomy = len(p.system_prompt_block())
+        p.on_turn_start(9, "msg", remaining_tokens=2000)
+        assert len(p.system_prompt_block()) < roomy
+
+
+class TestAutoMountLifecycle:
+    def test_mounts_declared_packs_transiently(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        """`mount`, never `install`: a session that opens with packs must
+        leave nothing behind when it ends."""
+        _provider(provider_module, mock_client, monkeypatch,
+                  YANTRIKDB_PACKS_ENABLED="true",
+                  YANTRIKDB_AUTO_MOUNT_PACKS="a.ydbpack, b.ydbpack")
+        actions = [c.args[0] for c in mock_client.pack_action.call_args_list]
+        assert actions == ["mount", "mount"]
+
+    def test_one_bad_pack_does_not_break_the_session(
+        self, provider_module, mock_client, monkeypatch, client_module,
+    ):
+        mock_client.pack_action.side_effect = [
+            client_module.YantrikDBClientError("pack refused: embedder mismatch"),
+            {"pack_id": "good@1.0"},
+        ]
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_PACKS_ENABLED="true",
+                      YANTRIKDB_AUTO_MOUNT_PACKS="bad.ydbpack,good.ydbpack")
+        assert p._mounted_pack_ids == ["good@1.0"]
+
+    def test_shutdown_gives_the_packs_back(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_PACKS_ENABLED="true",
+                      YANTRIKDB_AUTO_MOUNT_PACKS="a.ydbpack")
+        mock_client.pack_action.reset_mock()
+        p.shutdown()
+        unmounts = [c for c in mock_client.pack_action.call_args_list
+                    if c.args[0] == "unmount"]
+        assert len(unmounts) == 1
+
+    def test_nothing_mounted_when_flag_off(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        _provider(provider_module, mock_client, monkeypatch,
+                  YANTRIKDB_AUTO_MOUNT_PACKS="a.ydbpack")
+        mock_client.pack_action.assert_not_called()
+
+
+class TestRecallReachesPackKnowledge:
+    """The half that is easy to ship broken.
+
+    Mounting brings a pack's RULES in via `pack_context()`, but its RECORDS
+    land in whatever namespace the author sealed them under. Recall is scoped
+    to the agent's own namespace, so without widening, a mount delivers the
+    constitution and none of the knowledge — and every surface still looks
+    healthy. Caught on a real sealed pack: recall returned 0 hits while the
+    pack was mounted and the prompt block was present.
+    """
+
+    def test_pack_namespaces_join_the_recall_set(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        mock_client.pack_namespaces.return_value = ["wp"]
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_PACKS_ENABLED="true")
+        assert "wp" in p._fallback_recall_namespaces()
+
+    def test_not_widened_when_packs_disabled(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        mock_client.pack_namespaces.return_value = ["wp"]
+        p = _provider(provider_module, mock_client, monkeypatch)
+        assert "wp" not in p._fallback_recall_namespaces()
+
+    def test_cache_invalidated_on_mount(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        """A pack mounted mid-session must become recallable immediately."""
+        mock_client.pack_namespaces.return_value = []
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_PACKS_ENABLED="true")
+        assert p._fallback_recall_namespaces() == []
+        mock_client.pack_namespaces.return_value = ["wp"]
+        p.handle_tool_call("yantrikdb_packs", {"action": "mount", "path": "w.ydbpack"})
+        assert "wp" in p._fallback_recall_namespaces()
+
+    def test_probe_failure_never_breaks_recall(
+        self, provider_module, mock_client, monkeypatch, client_module,
+    ):
+        mock_client.pack_namespaces.side_effect = client_module.YantrikDBServerError("x")
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_PACKS_ENABLED="true")
+        assert p._fallback_recall_namespaces() == []
+
+
+class TestHttpModeIsHonest:
+    def test_http_refuses_rather_than_returning_empty(self, client_module):
+        """Returning an empty list would read as 'no packs are mounted' — a
+        different and misleading claim from 'packs are unavailable here'."""
+        cfg = client_module.YantrikDBConfig(mode="http", url="http://x", token="t")
+        c = client_module.YantrikDBClient(cfg)
+        with pytest.raises(client_module.YantrikDBClientError, match="embedded"):
+            c.pack_action("list")
+        assert c.pack_context()["context"] is None

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -246,6 +246,7 @@ EXPECTED_TOOL_NAMES = {
     "yantrikdb_knowledge_gaps",
     "yantrikdb_recent_turns",
     "yantrikdb_tasks",
+    "yantrikdb_packs",
 }
 
 
@@ -254,6 +255,8 @@ class TestToolSchemas:
         # The full profile must still expose every schema — `core` narrows
         # what the model SEES, it never removes a capability.
         monkeypatch.setenv("YANTRIKDB_TOOL_PROFILE", "full")
+        monkeypatch.setenv("YANTRIKDB_SKILLS_ENABLED", "true")
+        monkeypatch.setenv("YANTRIKDB_PACKS_ENABLED", "true")
         provider._config = None  # force re-read from env
         names = {s["name"] for s in provider.get_tool_schemas()}
         assert names == EXPECTED_TOOL_NAMES
@@ -279,9 +282,10 @@ class TestToolSchemas:
         monkeypatch.setenv("YANTRIKDB_TOOL_PROFILE", "full")
         p = provider_module.YantrikDBMemoryProvider()
         names = {s["name"] for s in p.get_tool_schemas()}
+        # Skills and packs follow their own flags, not the profile.
         assert names == EXPECTED_TOOL_NAMES - {
             "yantrikdb_skill_search", "yantrikdb_skill_define",
-            "yantrikdb_skill_outcome",
+            "yantrikdb_skill_outcome", "yantrikdb_packs",
         }
         assert len(names) == 18
 

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.11.0] — 2026-08-02 — Attachable expertise (knowledge packs)
+
+A **pack** is a sealed, signed knowledge file: mount it to gain its knowledge and rules, unmount to give them back leaving your own memory byte-for-byte as it was. Engine 0.11.0 added the primitive; this release makes a Hermes agent able to use it. No other Hermes memory provider can attach expertise.
+
+- **New tool `yantrikdb_packs`** — `list` (mounted + installed, and flags any installed pack that failed to re-mount), `inspect` (read a pack's manifest **without** mounting it), `mount` / `install`, `unmount` / `uninstall` / `unmount_all`. A bare filename resolves against the engine's pack directory, so an agent needn't know where the host keeps packs.
+- **Rules injected into the system prompt.** `pack_context()` — each mounted pack's coverage index and constitution — is assembled *by the engine* so every consumer injects identical text; we pass it through verbatim, capped by `pack_context_max_chars` and scaled by the v0.10 adaptive budget. Attached expertise is worth nothing if it crowds out the conversation that needed it.
+- **Knowledge actually reachable.** A pack's records live in the namespace its author sealed them under, while recall is scoped to the agent's own namespace — so a naive implementation delivers the pack's *rules* and none of its *knowledge*, with every surface still looking healthy. Recall is now widened into the namespaces of mounted packs, resolved precisely from each pack's manifest rather than by recalling unscoped (which would also expose every other namespace in the database).
+- **Auto-mount is transient.** `YANTRIKDB_AUTO_MOUNT_PACKS` mounts on `initialize` and unmounts on `shutdown`, because `mount` never writes to the database and a session that opens with packs should leave nothing behind. `install` — the durable counterpart — stays an explicit, deliberate action. One unreadable or embedder-mismatched pack is logged and skipped rather than taking memory down for the session.
+- **Refusals are reported, not forced.** Mounting is refused when a pack's vectors are provably from a different embedding space; the tool description tells the agent to report that rather than retry with `allow_unverified_embedder`, because the refusal is what prevents confidently wrong answers.
+- **HTTP mode refuses honestly.** Packs are an embedded capability — the database lives on the server there, and `yantrikdb-server` exposes no pack endpoints. The client says so instead of returning an empty list, which would read as "no packs are mounted" — a different and misleading claim.
+
+**Off by default** (`YANTRIKDB_PACKS_ENABLED=true`): mounting somebody else's knowledge is a decision an operator makes, not one they discover. Like skills, the flag is orthogonal to `tool_profile` — enabling packs and then being unable to reach them because the profile is `core` would be a trap.
+
+Verified end-to-end against engine 0.11.3 with a real sealed pack: recall for a pack topic returned **0 hits → mount → 3 hits** with the constitution injected → **unmount → 0 hits** and the block gone. 20 new tests; 396 pass / 3 skip.
+
 ## [0.10.1] — 2026-08-01 — Require the engine release that can't lose recall
 
 Pin raised to **`yantrikdb>=0.11.3`**. No plugin behaviour changes; the full suite passes unmodified against 0.11.3 (376 pass / 3 skip) and every engine method this plugin calls is unchanged.

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -844,6 +844,57 @@ RECENT_TURNS_SCHEMA = {
     },
 }
 
+PACKS_SCHEMA = {
+    "name": "yantrikdb_packs",
+    "description": (
+        "v0.11 — attachable expertise. A pack is a sealed, signed knowledge "
+        "file: mount it to gain its knowledge and rules for this session, "
+        "unmount to give them back leaving your own memory byte-for-byte "
+        "unchanged. Use when a task needs domain knowledge you don't have "
+        "(e.g. a framework's conventions) rather than guessing. "
+        "`action=\"list\"` (default) shows mounted + installed packs, and "
+        "flags any installed pack that failed to mount; `inspect` reads a "
+        "pack's manifest WITHOUT mounting it — do this before mounting "
+        "something you haven't used before; `mount` attaches it for this "
+        "session only (never writes to your memory); `install` also copies "
+        "it beside the database so it re-mounts on every future open; "
+        "`unmount` / `uninstall` reverse those. Mounting can be refused when "
+        "a pack's vectors were built in a different embedding space — that "
+        "refusal prevents confidently wrong answers, so report it rather "
+        "than retrying with allow_unverified_embedder."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["list", "inspect", "mount", "install", "unmount",
+                         "uninstall", "unmount_all"],
+                "description": "Defaults to 'list'.",
+            },
+            "path": {
+                "type": "string",
+                "description": (
+                    "Pack file for inspect/mount/install. A bare filename is "
+                    "resolved against the host's pack directory."
+                ),
+            },
+            "pack_id": {
+                "type": "string",
+                "description": "Pack id (`origin@version`) for unmount/uninstall.",
+            },
+            "allow_unverified_embedder": {
+                "type": "boolean",
+                "description": (
+                    "Only for packs whose embedder compatibility is UNPROVEN. "
+                    "Never use it to force past a proven mismatch."
+                ),
+            },
+        },
+        "required": [],
+    },
+}
+
 TASKS_SCHEMA = {
     "name": "yantrikdb_tasks",
     "description": (
@@ -918,6 +969,7 @@ ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
     KNOWLEDGE_GAPS_SCHEMA,
     RECENT_TURNS_SCHEMA,
     TASKS_SCHEMA,
+    PACKS_SCHEMA,
 ]
 
 
@@ -1325,6 +1377,11 @@ class YantrikDBMemoryProvider(MemoryProvider):
         # tells us, which is the signal to behave exactly as pre-0.10.
         self._turn_number: int = 0
         self._remaining_tokens: int | None = None
+        # v0.11 — cached pack_context(); invalidated whenever the mounted set
+        # changes, since the block is assembled from it.
+        self._pack_context_cache: str | None = None
+        self._mounted_pack_ids: list[str] = []
+        self._pack_namespace_cache: list[str] | None = None
 
         self._prefetch_results: dict[str, str] = {}
         self._prefetch_lock = threading.Lock()
@@ -1621,7 +1678,53 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 "YantrikDB health check failed (%s) — will retry on demand.", e,
             )
 
+        self._auto_mount_packs()
+
+    def _auto_mount_packs(self) -> None:
+        """Mount the operator's declared packs for this session (v0.11).
+
+        Uses `mount` rather than `install` on purpose: mounting is transient
+        and never writes to the database, so a session that opens with packs
+        leaves nothing behind when it ends. An operator who wants a pack to
+        persist installs it once, deliberately, via the tool.
+
+        Fail-soft per pack — one unreadable or embedder-mismatched pack must
+        not take down memory for the whole session, and the reason is logged
+        at warning because a pack that silently didn't mount would leave the
+        agent confidently missing knowledge it believes it has.
+        """
+        cfg = self._config
+        if not cfg or not cfg.packs_enabled or not cfg.auto_mount_packs:
+            return
+        if self._client is None:
+            return
+        wanted = [p.strip() for p in cfg.auto_mount_packs.split(",") if p.strip()]
+        for path in wanted:
+            try:
+                resp = self._client.pack_action("mount", path=path)
+                self._mounted_pack_ids.append(str(resp.get("pack_id") or path))
+                logger.info("YantrikDB mounted pack %s", resp.get("pack_id") or path)
+            except YantrikDBError as e:
+                logger.warning("YantrikDB could not mount pack %s: %s", path, e)
+        if self._mounted_pack_ids:
+            self._pack_context_cache = None
+            self._pack_namespace_cache = None
+
     def shutdown(self) -> None:
+        # Give back anything this session mounted, before the client closes.
+        # `unmount` leaves the host database byte-for-byte unchanged, which is
+        # the whole promise of a transient mount — so honouring it on the way
+        # out is not cleanup, it's the contract.
+        if self._mounted_pack_ids and self._client is not None:
+            for pack_id in self._mounted_pack_ids:
+                try:
+                    self._client.pack_action("unmount", pack_id=pack_id)
+                except YantrikDBError as e:
+                    logger.debug("YantrikDB unmount %s failed: %s", pack_id, e)
+            self._mounted_pack_ids = []
+            self._pack_context_cache = None
+            self._pack_namespace_cache = None
+
         for t in (self._prefetch_thread, self._sync_thread):
             if t and t.is_alive():
                 t.join(timeout=_SYNC_JOIN_SECS)
@@ -1735,7 +1838,28 @@ class YantrikDBMemoryProvider(MemoryProvider):
         shared = self._shared_brain_namespace()
         if shared and shared != self._namespace and shared not in namespaces:
             namespaces.append(shared)
+        # v0.11 — a mounted pack's records live in the namespace its author
+        # sealed them under, so without this a mount delivers the pack's rules
+        # and none of its knowledge. Cached because it costs a manifest read
+        # per pack and only changes when the mounted set does.
+        for namespace in self._pack_namespaces():
+            if namespace != self._namespace and namespace not in namespaces:
+                namespaces.append(namespace)
         return namespaces
+
+    def _pack_namespaces(self) -> list[str]:
+        if not (self._config and self._config.packs_enabled):
+            return []
+        if self._client is None:
+            return []
+        if self._pack_namespace_cache is None:
+            try:
+                self._pack_namespace_cache = list(
+                    self._client.pack_namespaces() or [],
+                )
+            except (YantrikDBError, AttributeError):
+                self._pack_namespace_cache = []
+        return self._pack_namespace_cache
 
     def _recall_with_base_fallback(
         self,
@@ -1845,6 +1969,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
             + self._format_pending_conflicts_block()
             + self._format_hygiene_block()
             + self._format_conversation_block()
+            + self._format_pack_block()
             + self._format_agenda_block()
         )
 
@@ -2160,13 +2285,20 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 s for s in schemas
                 if s["name"] in CORE_TOOL_NAMES
                 or s["name"].startswith("yantrikdb_skill_")
+                or s["name"] == "yantrikdb_packs"
             ]
 
+        # Skills and packs are orthogonal to the profile: turning either on is
+        # itself the explicit opt-in, so the tool follows the flag rather than
+        # the profile. Enabling packs and then not being able to reach them
+        # because the profile is `core` would be a trap.
         if not cfg.skills_enabled:
             schemas = [
                 s for s in schemas
                 if not s["name"].startswith("yantrikdb_skill_")
             ]
+        if not cfg.packs_enabled:
+            schemas = [s for s in schemas if s["name"] != "yantrikdb_packs"]
         return schemas
 
     def handle_tool_call(
@@ -2218,6 +2350,8 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 raw = self._do_observability(args)
             elif tool_name == "yantrikdb_hygiene":
                 raw = self._do_hygiene(args)
+            elif tool_name == "yantrikdb_packs":
+                raw = self._do_packs(args)
             elif tool_name == "yantrikdb_knowledge_gaps":
                 raw = self._do_knowledge_gaps(args)
             elif tool_name == "yantrikdb_recent_turns":
@@ -2968,6 +3102,58 @@ class YantrikDBMemoryProvider(MemoryProvider):
         "tasks need yantrikdb>=0.9.0 (embedded) or a yantrikdb-server "
         "exposing /v1/tasks — not available in this mode/version."
     )
+
+    def _do_packs(self, args: dict[str, Any]) -> str:
+        """Mount / inspect / install sealed knowledge packs (v0.11)."""
+        client = self._require_client()
+        if not (self._config and self._config.packs_enabled):
+            return tool_error(
+                "packs are disabled. Set YANTRIKDB_PACKS_ENABLED=true to let "
+                "this agent mount knowledge packs.",
+            )
+        action = (args.get("action") or "list").strip().lower()
+        resp = client.pack_action(
+            action,
+            path=(args.get("path") or None),
+            pack_id=(args.get("pack_id") or None),
+            allow_unverified_embedder=bool(
+                args.get("allow_unverified_embedder", False),
+            ),
+        )
+        if action in ("mount", "install", "unmount", "uninstall", "unmount_all"):
+            # The prompt block is built from mounted packs, so it is stale the
+            # moment the set changes.
+            self._pack_context_cache = None
+            self._pack_namespace_cache = None
+        return json.dumps(resp)
+
+    def _format_pack_block(self) -> str:
+        """Inject the engine-assembled context for mounted packs.
+
+        The engine assembles this so every consumer injects identical text and
+        a pack behaves the same wherever it is mounted — so it is passed
+        through verbatim, only truncated. Subject to the adaptive budget like
+        every other optional block: attached expertise is worth nothing if it
+        crowds out the conversation that needed it.
+        """
+        if not (self._config and self._config.packs_enabled
+                and self._config.surface_pack_context):
+            return ""
+        if self._client is None:
+            return ""
+        ctx = self._pack_context_cache
+        if ctx is None:
+            try:
+                ctx = (self._client.pack_context() or {}).get("context")
+            except YantrikDBError:
+                return ""
+            self._pack_context_cache = ctx or ""
+        if not ctx:
+            return ""
+        cap = self._budgeted(max(self._config.pack_context_max_chars, 1))
+        if cap <= 0:
+            return ""
+        return "\n\n## Mounted knowledge packs\n" + truncate_text(str(ctx), cap)
 
     def _do_tasks(self, args: dict[str, Any]) -> str:
         """Durable namespace-scoped task store (action-dispatched)."""

--- a/yantrikdb/client.py
+++ b/yantrikdb/client.py
@@ -72,6 +72,29 @@ class YantrikDBConfig:
     embedder_model2vec: str = ""    # HF model id for built-in Model2VecEmbedder loader (v0.4.2+); dim auto-probed
     embedder_huggingface: str = ""  # HF model id for built-in SentenceTransformerEmbedder loader (v0.4.2+); dim auto-probed
     embedding_dim: int = 0          # output dim; required for embedder_name and embedder_class paths, ignored for the two auto-probe paths above (bundled potion-2M is dim=64)
+    # packs (v0.11.0): attachable expertise. Engine 0.11.0+.
+    #
+    # A pack is a sealed, signed database of knowledge and rules that a host
+    # mounts to gain and unmounts to give back, leaving the host byte-for-byte
+    # as it was. `mount_pack` is deliberately transient — merely mounting never
+    # writes to your database — while `install_pack` copies it beside the db
+    # and re-mounts on every open.
+    #
+    # OFF by default. This is a new capability that changes what the agent
+    # knows, and mounting somebody else's knowledge is a decision an operator
+    # makes, not a default they discover. Same precedent as skills_enabled.
+    packs_enabled: bool = False
+    # Packs to mount on initialize, comma-separated paths or bare filenames
+    # resolved against the engine's pack directory. Mounted transiently and
+    # unmounted on shutdown, so a session that ends leaves nothing behind.
+    auto_mount_packs: str = ""
+    # `pack_context()` returns each mounted pack's coverage index and
+    # constitution rules — the block the engine wants every consumer to inject
+    # verbatim so packs behave identically everywhere. It goes in the system
+    # prompt, which means it competes with the conversation: cap it, and let
+    # the adaptive budget scale it like every other optional block.
+    surface_pack_context: bool = True
+    pack_context_max_chars: int = 2000
     # adaptive_prompt_budget (v0.10.0): inject less when context is tight.
     #
     # Hermes calls on_turn_start(turn, message, **kwargs) every turn and passes
@@ -350,6 +373,16 @@ class YantrikDBConfig:
             ),
             capture_delegations=_parse_bool(
                 os.environ.get("YANTRIKDB_CAPTURE_DELEGATIONS"), default=True,
+            ),
+            packs_enabled=_parse_bool(
+                os.environ.get("YANTRIKDB_PACKS_ENABLED"), default=False,
+            ),
+            auto_mount_packs=os.environ.get("YANTRIKDB_AUTO_MOUNT_PACKS", ""),
+            surface_pack_context=_parse_bool(
+                os.environ.get("YANTRIKDB_SURFACE_PACK_CONTEXT"), default=True,
+            ),
+            pack_context_max_chars=_parse_int(
+                os.environ.get("YANTRIKDB_PACK_CONTEXT_MAX_CHARS"), 2000,
             ),
             adaptive_prompt_budget=_parse_bool(
                 os.environ.get("YANTRIKDB_ADAPTIVE_PROMPT_BUDGET"), default=True,
@@ -964,6 +997,38 @@ class YantrikDBClient:
     # but answered poorly (avg top score <= max_avg_top_score). Engine-
     # global (not namespace-scoped). HTTP mode depends on yantrikdb-server
     # exposing /v1/knowledge_gaps; older servers 404 → "not available."
+
+    def pack_action(
+        self,
+        action: str,
+        *,
+        path: str | None = None,
+        pack_id: str | None = None,
+        allow_unverified_embedder: bool = False,
+    ) -> dict[str, Any]:
+        """Packs are an embedded-mode capability (v0.11.0).
+
+        A pack is a file mounted into a local database. In http mode the
+        database lives on the server, so mounting is an operator action there,
+        not something a client can do down the wire — yantrikdb-server has no
+        pack endpoints. Refuse clearly instead of pretending: silently
+        returning empty would read as "no packs are mounted", which is a
+        different and misleading claim.
+        """
+        raise YantrikDBClientError(
+            "packs are only available in embedded mode; this session is in "
+            "http mode, where packs are mounted on the server by its operator "
+            "(yantrikdb-server exposes no pack endpoints).",
+        )
+
+    def pack_context(self) -> dict[str, Any]:
+        """No packs over HTTP — see ``pack_action``. ``None`` is honest here:
+        this client has no mounted packs and cannot mount any."""
+        return {"context": None}
+
+    def pack_namespaces(self) -> list[str]:
+        """No packs over HTTP, so nothing to widen recall into."""
+        return []
 
     def knowledge_gaps(
         self,

--- a/yantrikdb/embedded.py
+++ b/yantrikdb/embedded.py
@@ -888,6 +888,169 @@ class EmbeddedYantrikDBClient:
 
     # -- Knowledge gaps (engine 0.9+) ---------------------------------
 
+    # -- Packs (v0.11.0, engine 0.11.0+) ----------------------------------
+
+    def pack_action(
+        self,
+        action: str,
+        *,
+        path: str | None = None,
+        pack_id: str | None = None,
+        allow_unverified_embedder: bool = False,
+    ) -> dict[str, Any]:
+        """Mount / install / unmount / inspect sealed knowledge packs.
+
+        One method rather than nine because the provider dispatches a single
+        action-based tool, and because these operations share one failure
+        mode worth handling in exactly one place: an engine older than 0.11.0
+        has none of them, which must read as "upgrade" and not as a crash.
+        """
+        db = self._db
+        try:
+            if action == "list":
+                mounted = list(db.mounted_packs() or [])
+                installed = list(db.installed_packs() or [])
+                mounted_ids = {
+                    (p.get("pack_id") if isinstance(p, dict) else str(p))
+                    for p in mounted
+                }
+                # An installed pack missing from `mounted` failed to re-mount
+                # this session — the engine documents this comparison as the
+                # way to notice, so surface it rather than making callers
+                # diff two lists themselves.
+                failed = [
+                    p for p in installed
+                    if (p.get("pack_id") if isinstance(p, dict) else str(p))
+                    not in mounted_ids
+                ]
+                return {
+                    "mounted": mounted,
+                    "installed": installed,
+                    "failed_to_mount": failed,
+                    "pack_dir": db.pack_dir(),
+                }
+            if action == "inspect":
+                if not path:
+                    raise YantrikDBClientError("pack inspect requires `path`")
+                from yantrikdb._yantrikdb_rust import (  # noqa: PLC0415
+                    YantrikDB as _Engine,
+                )
+                return {
+                    "manifest": _Engine.read_pack_manifest(
+                        self._resolve_pack_path(path),
+                    ),
+                }
+            if action in ("mount", "install"):
+                if not path:
+                    raise YantrikDBClientError(f"pack {action} requires `path`")
+                resolved = self._resolve_pack_path(path)
+                if action == "install":
+                    pid = db.install_pack(resolved)
+                else:
+                    pid = db.mount_pack(
+                        resolved,
+                        allow_unverified_embedder=allow_unverified_embedder,
+                    )
+                return {"pack_id": pid, "action": action, "path": resolved}
+            if action in ("unmount", "uninstall"):
+                if not pack_id:
+                    raise YantrikDBClientError(f"pack {action} requires `pack_id`")
+                fn = db.unmount_pack if action == "unmount" else db.uninstall_pack
+                return {"pack_id": pack_id, "action": action, "ok": bool(fn(pack_id))}
+            if action == "unmount_all":
+                return {"unmounted": int(db.unmount_all_packs() or 0)}
+            raise YantrikDBClientError(
+                f"unknown pack action {action!r}; expected list, inspect, mount, "
+                "install, unmount, uninstall, unmount_all",
+            )
+        except AttributeError as e:
+            raise YantrikDBClientError(
+                "packs need yantrikdb>=0.11.0 (embedded). "
+                "Upgrade with: pip install --upgrade 'yantrikdb>=0.11.3'",
+            ) from e
+        except YantrikDBError:
+            raise
+        except Exception as e:  # noqa: BLE001 — engine typed excs vary by version
+            # PackEmbedderMismatch is a REFUSAL, not a failure: the pack's
+            # vectors are provably in a different embedding space, so mounting
+            # it would return confidently wrong results. Keep the engine's own
+            # wording, which explains why forcing it is the wrong instinct.
+            if type(e).__name__ == "PackEmbedderMismatch":
+                raise YantrikDBClientError(f"pack refused: {e}") from e
+            raise _map_engine_error(f"pack {action}", e) from e
+
+    def _resolve_pack_path(self, path: str) -> str:
+        """Absolute path for a pack given a path or a bare filename.
+
+        A bare name is resolved against the engine's pack directory so an
+        agent can say `wordpress-expert-0.2.0.ydbpack` without knowing where
+        the host keeps packs.
+        """
+        p = Path(path).expanduser()
+        if p.is_absolute() or p.exists():
+            return str(p)
+        try:
+            pack_dir = self._db.pack_dir()
+        except AttributeError:
+            pack_dir = None
+        if pack_dir:
+            candidate = Path(pack_dir) / path
+            if candidate.exists():
+                return str(candidate)
+        return str(p)
+
+    def pack_namespaces(self) -> list[str]:
+        """Namespaces holding the records of currently-mounted packs.
+
+        Mounting brings a pack's rules in via ``pack_context()``, but its
+        *records* land in the namespace the author sealed them under — so an
+        agent recalling within its own namespace gets the pack's constitution
+        and none of its knowledge, which is the least useful half. Recall has
+        to be widened to these namespaces for a mount to mean anything.
+
+        ``mounted_packs()`` does not report the namespace, but it does report
+        each pack's ``path``, and the manifest does — so resolve it there
+        rather than recalling unscoped, which would also expose every other
+        namespace in the database.
+        """
+        try:
+            mounted = list(self._db.mounted_packs() or [])
+        except AttributeError:
+            return []
+        except Exception:  # noqa: BLE001 — never break recall over a pack probe
+            return []
+        from yantrikdb._yantrikdb_rust import YantrikDB as _Engine  # noqa: PLC0415
+
+        out: list[str] = []
+        for entry in mounted:
+            if not isinstance(entry, dict):
+                continue
+            path = entry.get("path")
+            if not path:
+                continue
+            try:
+                manifest = _Engine.read_pack_manifest(str(path)) or {}
+            except Exception:  # noqa: BLE001
+                continue
+            ns = manifest.get("namespace")
+            if ns and ns not in out:
+                out.append(str(ns))
+        return out
+
+    def pack_context(self) -> dict[str, Any]:
+        """The engine-assembled context block for all mounted packs.
+
+        Assembled engine-side deliberately so every consumer injects the same
+        text and a pack behaves identically wherever it is mounted; we pass it
+        through verbatim rather than reformatting it.
+        """
+        try:
+            return {"context": self._db.pack_context()}
+        except AttributeError:
+            return {"context": None}
+        except Exception as e:  # noqa: BLE001
+            raise _map_engine_error("pack_context", e) from e
+
     def knowledge_gaps(
         self,
         *,

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.10.1
+version: 0.11.0
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.11.3


### PR DESCRIPTION
A **pack** is a sealed, signed knowledge file: mount it to gain its knowledge and rules, unmount to give them back leaving your own memory byte-for-byte as it was. Engine 0.11.0 shipped the primitive; this makes a Hermes agent able to use it.

## What an agent gets
New **`yantrikdb_packs`** tool: `list` / `inspect` / `mount` / `install` / `unmount` / `uninstall` / `unmount_all`. `inspect` reads a pack's manifest **without mounting it**, so an agent can look before it trusts. Bare filenames resolve against the engine's pack directory.

While mounted, the pack's **constitution and coverage** are injected into the system prompt — `pack_context()` is assembled *by the engine* so every consumer injects identical text, so we pass it through verbatim, capped and scaled by the v0.10 adaptive budget.

## The half that's easy to ship broken
A pack's **records** live in the namespace its author sealed them under, while recall is scoped to the agent's own namespace. So a naive implementation delivers the pack's *rules* and **none of its knowledge** — and every surface still looks healthy: the tool returns a pack id, `list` shows it mounted, the prompt block renders.

I only caught it by sealing a real pack and mounting it: **0 recall hits** with the block correctly present. Recall is now widened into mounted packs' namespaces, resolved from each pack's **manifest** (`mounted_packs()` omits the namespace; the manifest has it) rather than by recalling unscoped — which would have "worked" while also exposing every other namespace in the database.

## Design choices worth flagging
- **Auto-mount is transient.** `YANTRIKDB_AUTO_MOUNT_PACKS` uses `mount`, never `install`, because mounting never writes to the database — a session that opens with packs leaves nothing behind. `install` stays explicit.
- **Refusals are reported, not forced.** Embedder mismatch is surfaced with the engine's own wording, and the tool description tells the agent to report it rather than retry with `allow_unverified_embedder` — that refusal is what prevents confidently wrong answers.
- **HTTP refuses honestly.** Packs are embedded-only; returning an empty list would read as *"no packs are mounted"*, a different and misleading claim.
- **Off by default**, and orthogonal to `tool_profile` — enabling packs then being unable to reach them because the profile is `core` would be a trap.

## Verification
End-to-end against engine 0.11.3 with a **real sealed pack** (built via `seal_pack`, 3 records, constitution + coverage):

```
BEFORE mount : recall hits = 0 | pack section: False
MOUNT        : demo.local@0.1.0
AFTER mount  : recall hits = 3 | pack section: True
               "Topics it covers: wordpress theming; theme.json…"
UNMOUNT      : ok = True
AFTER unmount: recall hits = 0 | pack section: False
```

Mount to gain, unmount to give back — the whole promise, measured. **20 new tests; 396 pass / 3 skip**; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)