### PR TITLE
release(v0.12.1): bound every dependency; verify engine 0.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 .ruff_cache/
 .venv/
 venv/
+venv*/   # stray probe venvs (venv113x etc) must never be committed
 env/
 *.egg-info/
 dist/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Tests](https://img.shields.io/badge/tests-128%20passing-brightgreen)](https://github.com/yantrikos/yantrikdb-hermes-plugin/actions)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://github.com/yantrikos/yantrikdb-hermes-plugin)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![YantrikDB](https://img.shields.io/badge/yantrikdb-%E2%89%A50.11.3-orange)](https://github.com/yantrikos/yantrikdb-server)
+[![YantrikDB](https://img.shields.io/badge/yantrikdb-%E2%89%A50.11.3,%3C0.13-orange)](https://github.com/yantrikos/yantrikdb-server)
 [![Hermes Agent](https://img.shields.io/badge/hermes--agent-plugin-8a2be2)](https://github.com/NousResearch/hermes-agent)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![mypy](https://img.shields.io/badge/mypy-checked-2a6db2)](https://mypy-lang.org/)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.12.0
+version: 0.12.1
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the
@@ -7,8 +7,8 @@ version: 0.12.0
 # `yantrikdb-hermes install <hermes>`. Both should declare the same version.
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.11.3
-  - requests>=2.31
+  - yantrikdb>=0.11.3,<0.13.0
+  - requests>=2.31,<3.0.0
 hooks:
   - on_session_end
   - on_pre_compress

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.12.0"
+version = "0.12.1"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -34,9 +34,16 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
+# Every runtime dependency carries an UPPER BOUND. An unbounded `>=` lets a
+# future major silently break releases that are already published: nothing in
+# this repo changes, upstream cuts a new major, and a fresh `pip install`
+# resolves into it. The failure looks like our bug and arrives without warning.
+# yantrikdb-mcp lost their published v0.10.0 exactly this way when the MCP SDK
+# shipped 2.0.0 against an unbounded pin. tests/test_dependency_pins.py enforces
+# this; raise a ceiling only after testing against the new major.
 dependencies = [
-  "yantrikdb>=0.11.3",
-  "requests>=2.31",
+  "yantrikdb>=0.11.3,<0.13.0",
+  "requests>=2.31,<3.0.0",
 ]
 
 [project.optional-dependencies]
@@ -53,10 +60,10 @@ dev = [
 # for the broader HF ecosystem). Both can be installed together if you
 # want to A/B different embedders without uninstalling.
 model2vec = [
-  "model2vec>=0.3",
+  "model2vec>=0.3,<1.0.0",
 ]
 sentence-transformers = [
-  "sentence-transformers>=2.7",
+  "sentence-transformers>=2.7,<6.0.0",
 ]
 
 [project.urls]

--- a/tests/test_dependency_pins.py
+++ b/tests/test_dependency_pins.py
@@ -1,0 +1,100 @@
+"""Every runtime dependency must carry an upper bound.
+
+An unbounded `>=` lets a future major silently break releases that are ALREADY
+PUBLISHED: nothing in this repo changes, upstream cuts a new major, a fresh
+`pip install` resolves into it, and the failure looks like our bug. There is no
+signal — no CI run, no diff, no notification — because from our side nothing
+happened.
+
+This is not hypothetical. yantrikdb-mcp lost their published v0.10.0 exactly
+this way when the MCP SDK shipped 2.0.0 against `mcp[cli]>=1.2.0`: the release
+re-shipped itself broken. This plugin has also had to move its engine floor
+twice for defects that a ceiling would have contained.
+
+A ceiling is a claim about what has been TESTED. Raise one only after running
+the suite against the new major — which is the same rule the plugin applies to
+engine upgrades.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_UPPER_BOUND = re.compile(r"[<!=]=?\s*\d")
+
+
+def _requirements() -> dict[str, list[str]]:
+    data = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    out = {"dependencies": list(project.get("dependencies", []))}
+    for extra, reqs in (project.get("optional-dependencies") or {}).items():
+        out[f"optional:{extra}"] = list(reqs)
+    return out
+
+
+def _has_upper_bound(spec: str) -> bool:
+    """True when the specifier constrains the upper end at all.
+
+    Accepts `<`, `<=`, `==`, `!=`-style ceilings and `~=`; rejects a bare
+    `>=x` or a name with no specifier.
+    """
+    if "~=" in spec:
+        return True
+    return bool(_UPPER_BOUND.search(spec.split(";", 1)[0].replace(">=", "").replace(">", "")))
+
+
+class TestRuntimeDependencies:
+    def test_every_runtime_dependency_has_an_upper_bound(self):
+        missing = [
+            spec for spec in _requirements()["dependencies"]
+            if not _has_upper_bound(spec)
+        ]
+        assert not missing, (
+            f"unbounded runtime dependencies: {missing}. An unbounded `>=` lets a "
+            "future major break already-published releases with no signal on our "
+            "side. Add a ceiling you have actually tested against."
+        )
+
+    @pytest.mark.parametrize("extra", ["optional:model2vec",
+                                       "optional:sentence-transformers"])
+    def test_optional_feature_extras_are_bounded_too(self, extra):
+        """Extras install into the user's environment exactly like runtime deps
+        do — a broken embedder loader is not less broken for being optional."""
+        missing = [s for s in _requirements()[extra] if not _has_upper_bound(s)]
+        assert not missing, f"unbounded in {extra}: {missing}"
+
+    def test_engine_ceiling_matches_what_we_tested(self):
+        """The engine ceiling is a claim about tested ground, so it should not
+        drift ahead of the floor by more than the line we verify."""
+        spec = next(s for s in _requirements()["dependencies"]
+                    if s.startswith("yantrikdb"))
+        assert "<" in spec, spec
+        assert ">=" in spec, "keep a floor too — old engines lack current APIs"
+
+
+class TestManifestsAgreeWithPyproject:
+    """Hermes installs from plugin.yaml, pip installs from pyproject. A ceiling
+    present in one and absent in the other protects only half the users."""
+
+    @pytest.mark.parametrize("manifest", ["plugin.yaml", "yantrikdb/plugin.yaml"])
+    def test_manifest_pins_match(self, manifest):
+        text = (_ROOT / manifest).read_text(encoding="utf-8")
+        declared = re.findall(r"^\s*-\s*(\S+)\s*$", text, re.MULTILINE)
+        pinned = {d.split(">=")[0].split("<")[0].strip(): d
+                  for d in declared if ">=" in d or "<" in d}
+        for name, spec in pinned.items():
+            assert _has_upper_bound(spec), f"{manifest}: {name} is unbounded ({spec})"
+
+        pyproject = {s.split(">=")[0].split("<")[0].strip(): s
+                     for s in _requirements()["dependencies"]}
+        for name, spec in pyproject.items():
+            assert name in pinned, f"{manifest} is missing {name}"
+            assert pinned[name] == spec, (
+                f"{manifest} declares {name} as {pinned[name]!r} but pyproject "
+                f"says {spec!r} — the two install paths would resolve differently"
+            )

--- a/tests/test_packs.py
+++ b/tests/test_packs.py
@@ -238,3 +238,34 @@ class TestHttpModeIsHonest:
         with pytest.raises(client_module.YantrikDBClientError, match="embedded"):
             c.pack_action("list")
         assert c.pack_context()["context"] is None
+
+
+class TestPackHitsAreMarkedInRecall:
+    """A pack's records are recallable alongside the agent's own memories
+    (v0.11). Rendered as identical bullets, the agent cannot tell a stranger's
+    claim from something the user told it — the same conflation v0.12 fixed at
+    the block level, one layer deeper. Engine 0.12.0 returning `namespace` on
+    recall hits is what makes the distinction possible.
+    """
+
+    def test_pack_sourced_hit_is_labelled(self, provider_module):
+        block = provider_module._format_recall_block(
+            [{"text": "Prefer block themes.", "score": 0.9, "namespace": "wp"}],
+            third_party_namespaces=("wp",),
+        )
+        assert "third-party" in block.lower()
+
+    def test_own_memory_is_not_labelled(self, provider_module):
+        block = provider_module._format_recall_block(
+            [{"text": "The user prefers dark mode.", "score": 0.9,
+              "namespace": "hermes:ws:coder"}],
+            third_party_namespaces=("wp",),
+        )
+        assert "third-party" not in block.lower()
+
+    def test_no_labelling_without_mounted_packs(self, provider_module):
+        """Never spend prompt tokens on a distinction that cannot apply."""
+        block = provider_module._format_recall_block(
+            [{"text": "x", "score": 0.9, "namespace": "wp"}],
+        )
+        assert "third-party" not in block.lower()

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,28 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.12.1] — 2026-08-04 — Bounded dependencies, and engine 0.12.0
+
+### Every dependency now has a ceiling
+
+Both runtime dependencies were unbounded (`yantrikdb>=0.11.3`, `requests>=2.31`), as were the embedder extras. An unbounded `>=` lets a future major **break releases that are already published**: nothing in this repo changes, upstream cuts a new major, a fresh `pip install` resolves into it, and the failure looks like our bug. There is no signal — no CI run, no diff, no notification — because from our side nothing happened.
+
+Not hypothetical. `yantrikdb-mcp` lost their published v0.10.0 exactly this way when the MCP SDK shipped 2.0.0 against `mcp[cli]>=1.2.0`; the release re-shipped itself broken and they flagged it ecosystem-wide. This plugin has also moved its engine floor twice for defects a ceiling would have contained.
+
+Now: `yantrikdb>=0.11.3,<0.13.0`, `requests>=2.31,<3.0.0`, `model2vec>=0.3,<1.0.0`, `sentence-transformers>=2.7,<6.0.0`. New `tests/test_dependency_pins.py` enforces it — including that both `plugin.yaml` manifests match `pyproject.toml`, since a ceiling present in one install path and absent in the other protects only half the users. **A ceiling is a claim about tested ground**; raise one only after running the suite against the new major, which is what happened here.
+
+**On the MCP SDK specifically:** this plugin does not use it. Verified by grep across all shipped code and both manifests — the plugin talks to Hermes through its `MemoryProvider` interface, not MCP, so the 2.0.0 breakage cannot reach it.
+
+### Engine 0.12.0 verified, ceiling set to admit it
+
+Full suite passes **unmodified** against 0.12.0 (417 pass / 3 skip), and recall still returns every field the plugin reads.
+
+0.12.0 also **closes an API gap this plugin reported**: recall results now carry `metadata` (plus `namespace`, `source`, `current_status`, `superseded_by`). Provenance stamps were previously write-only on the path agents actually use — readable via `list_records`, absent from `recall`.
+
+### Knowledge-pack hits are marked in recalled memory
+
+Now that recall reports `namespace`, a hit that came from a mounted pack is labelled *"from a knowledge pack — third-party, not your memory"*. Since v0.11 a pack's records are recallable alongside the agent's own, and rendered as identical bullets the agent could not tell a stranger's claim from something the user told it — the same conflation v0.12.0 fixed at the block level, one layer deeper. Nothing is labelled when no pack is mounted, so the distinction costs no tokens where it cannot apply.
+
 ## [0.12.0] — 2026-08-03 — What always-on agents actually needed
 
 Three fixes from researching how Hermes is really used — its community story set (237 entries, 45 of which mention memory), its issue tracker, and the v0.15.1 source. Each closes a gap that looked fine from inside this repo.

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -1201,8 +1201,22 @@ def _derive_namespace(base: str, kwargs: dict[str, Any]) -> str:
     return ":".join(parts)
 
 
-def _format_recall_block(results: list[dict[str, Any]], limit: int = 8) -> str:
-    """Markdown bullet list of recalled memories for prompt injection."""
+def _format_recall_block(
+    results: list[dict[str, Any]],
+    limit: int = 8,
+    *,
+    third_party_namespaces: tuple[str, ...] = (),
+) -> str:
+    """Markdown bullet list of recalled memories for prompt injection.
+
+    Hits that came from a mounted knowledge pack are marked. Since v0.11 a
+    pack's records are recallable alongside the agent's own memories, and once
+    both are rendered as plain bullets the agent cannot tell a stranger's
+    claim from something the user told it — which is the same conflation
+    v0.12 fixed at the block level, one layer further in. Engine 0.12.0
+    returning `namespace` on recall hits is what makes the distinction
+    available at all.
+    """
     if not results:
         return ""
     lines: list[str] = []
@@ -1212,7 +1226,10 @@ def _format_recall_block(results: list[dict[str, Any]], limit: int = 8) -> str:
             continue
         score = r.get("score")
         tag = f" _(score {score:.2f})_" if isinstance(score, (int, float)) else ""
-        lines.append(f"- {text}{tag}")
+        origin = ""
+        if third_party_namespaces and r.get("namespace") in third_party_namespaces:
+            origin = " _(from a knowledge pack — third-party, not your memory)_"
+        lines.append(f"- {text}{tag}{origin}")
     return "\n".join(lines)
 
 
@@ -2037,7 +2054,10 @@ class YantrikDBMemoryProvider(MemoryProvider):
                         r for r in results
                         if (r.get("score") or 0.0) >= cfg.auto_recall_min_score
                     ]
-                block = _format_recall_block(results, limit=5)
+                block = _format_recall_block(
+                    results, limit=5,
+                    third_party_namespaces=tuple(self._pack_namespaces()),
+                )
                 if block and cfg is not None:
                     # Rough token cap: ~4 chars per token.
                     char_cap = cfg.auto_recall_token_budget * 4

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,9 +1,9 @@
 name: yantrikdb
-version: 0.12.0
+version: 0.12.1
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.11.3
-  - requests>=2.31
+  - yantrikdb>=0.11.3,<0.13.0
+  - requests>=2.31,<3.0.0
 hooks:
   - on_session_end
   - on_pre_compress


### PR DESCRIPTION
## Every dependency now has a ceiling

Both runtime deps were unbounded (`yantrikdb>=0.11.3`, `requests>=2.31`), as were the embedder extras. An unbounded `>=` lets a future major **break releases that are already published**: nothing in this repo changes, upstream cuts a new major, a fresh `pip install` resolves into it, and the failure looks like our bug. **There is no signal** — no CI run, no diff, no notification — because from our side nothing happened.

Not hypothetical. `yantrikdb-mcp` lost their published v0.10.0 exactly this way when the MCP SDK shipped 2.0.0 against `mcp[cli]>=1.2.0`; the release re-shipped itself broken, and they flagged it ecosystem-wide. This plugin has also moved its engine floor twice for defects a ceiling would have contained.

Now `yantrikdb>=0.11.3,<0.13.0`, `requests>=2.31,<3.0.0`, `model2vec<1.0.0`, `sentence-transformers<6.0.0`, with `tests/test_dependency_pins.py` enforcing it — including that **both `plugin.yaml` manifests agree with `pyproject.toml`**, since a ceiling in one install path and not the other protects only half the users.

I verified the guard actually *fails* on the exact spec that broke them (`mcp[cli]>=1.2.0` → unbounded), because a guard that can't detect its own target is worse than none.

**A ceiling is a claim about tested ground** — raise one only after running the suite against the new major, which is what happened here.

## On the MCP SDK specifically

**This plugin doesn't use it.** Verified by grep across all shipped code and both manifests: we talk to Hermes through its `MemoryProvider` interface, not MCP. The 2.0.0 breakage can't reach us.

## Engine 0.12.0 verified

Full suite passes **unmodified** on 0.12.0 — **417 pass / 3 skip on both 0.11.3 and 0.12.0** — and recall still returns every field the plugin reads.

0.12.0 also closes **the API gap this plugin reported**: recall results now carry `metadata` (plus `namespace`, `source`, `current_status`, `superseded_by`). Provenance stamps were previously write-only on the path agents actually use.

## Knowledge-pack hits are now marked in recall

Now that recall reports `namespace`, a hit from a mounted pack is labelled *"from a knowledge pack — third-party, not your memory"*. Since v0.11 pack records are recallable beside the agent's own, and as identical bullets the agent couldn't tell a stranger's claim from something the user told it — the same conflation v0.12.0 fixed at the block level, one layer deeper. Nothing is labelled when no pack is mounted, so it costs nothing where it can't apply.

## Housekeeping
Removed a stray probe venv that an earlier mis-rooted command committed into the repo root, and hardened `.gitignore` against the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)