### PR TITLE
fix(v0.12.2): recalibrate the gap threshold for engine 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Tests](https://img.shields.io/badge/tests-128%20passing-brightgreen)](https://github.com/yantrikos/yantrikdb-hermes-plugin/actions)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://github.com/yantrikos/yantrikdb-hermes-plugin)
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
-[![YantrikDB](https://img.shields.io/badge/yantrikdb-%E2%89%A50.11.3,%3C0.13-orange)](https://github.com/yantrikos/yantrikdb-server)
+[![YantrikDB](https://img.shields.io/badge/yantrikdb-%E2%89%A50.12.1,%3C0.13-orange)](https://github.com/yantrikos/yantrikdb-server)
 [![Hermes Agent](https://img.shields.io/badge/hermes--agent-plugin-8a2be2)](https://github.com/NousResearch/hermes-agent)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![mypy](https://img.shields.io/badge/mypy-checked-2a6db2)](https://mypy-lang.org/)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.12.1
+version: 0.12.2
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the
@@ -7,7 +7,7 @@ version: 0.12.1
 # `yantrikdb-hermes install <hermes>`. Both should declare the same version.
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.11.3,<0.13.0
+  - yantrikdb>=0.12.1,<0.13.0
   - requests>=2.31,<3.0.0
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.12.1"
+version = "0.12.2"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -42,7 +42,7 @@ classifiers = [
 # shipped 2.0.0 against an unbounded pin. tests/test_dependency_pins.py enforces
 # this; raise a ceiling only after testing against the new major.
 dependencies = [
-  "yantrikdb>=0.11.3,<0.13.0",
+  "yantrikdb>=0.12.1,<0.13.0",
   "requests>=2.31,<3.0.0",
 ]
 

--- a/tests/test_gap_calibration.py
+++ b/tests/test_gap_calibration.py
@@ -1,0 +1,111 @@
+"""The gap threshold is a calibration, and calibrations expire silently.
+
+`gap_max_avg_top_score` decides which queries the self-directing loop turns
+into tasks — and it is an ABSOLUTE score, so it only means what it meant while
+the engine composes scores the same way.
+
+Engine 0.12.1 changed exactly that: recency used to ADD up to +0.5 to every
+fresh record and now MULTIPLIES relevance, bounded to +12.5%. Retrieval got
+*better* (benchmark MRR 0.928 -> 0.946) while absolute scores roughly halved
+(avg-top3 median 1.138 -> 0.510 on the same corpus). Our 0.5 default went from
+flagging 0/37 benchmark queries as gaps to flagging 17/37 — so the loop, on by
+default since v0.10, would have minted tasks for questions the memory answers
+correctly at rank 1.
+
+Nothing crashed. No test failed. The whole suite stayed green, because every
+test asserted behaviour and none asserted calibration.
+
+This measures the default against a corpus of questions the memory demonstrably
+CAN answer. If a future scoring change makes those look like gaps again, this
+fails instead of quietly filling somebody's agenda with work that is already
+done.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_DATASET = _ROOT / "benchmarks" / "dataset.json"
+
+
+def _engine():
+    """The real engine, or skip — this cannot be mocked.
+
+    A mock returns whatever scores we tell it to, which would make this test
+    assert our own assumption rather than the engine's behaviour.
+    """
+    sys.path.insert(0, str(_ROOT / "benchmarks"))
+    try:
+        from _bootstrap import _pin_engine_import
+        _pin_engine_import()
+        from yantrikdb._yantrikdb_rust import YantrikDB
+    except Exception:  # noqa: BLE001 - no native wheel in this environment
+        pytest.skip("native yantrikdb engine not installed")
+    return YantrikDB
+
+
+@pytest.fixture(scope="module")
+def answered_scores():
+    """avg-top-3 score for every benchmark query, all of which are answerable."""
+    if not _DATASET.exists():
+        pytest.skip("benchmark dataset missing")
+    engine = _engine()
+    data = json.loads(_DATASET.read_text(encoding="utf-8"))
+    db = engine.with_default(os.path.join(tempfile.mkdtemp(), "calib.db"))
+    for m in data["corpus"]:
+        db.record_text(m["text"], memory_type="semantic", namespace="calib",
+                       importance=m.get("importance", 0.6))
+    out = []
+    for q in data["queries"]:
+        hits = db.recall_text(q["q"], top_k=5, namespace="calib")
+        if hits:
+            out.append(statistics.mean([(h.get("score") or 0.0) for h in hits[:3]]))
+    if not out:
+        pytest.skip("engine returned no hits for the benchmark corpus")
+    return out
+
+
+def _default_threshold(client_module) -> float:
+    return client_module.YantrikDBConfig().gap_max_avg_top_score
+
+
+class TestGapThresholdCalibration:
+    def test_answerable_questions_are_not_called_gaps(
+        self, answered_scores, client_module,
+    ):
+        """Every benchmark query has a gold answer in the corpus. If the
+        default calls them gaps, the loop invents work that is already done —
+        and the user sees an agenda full of questions their memory can answer.
+        """
+        threshold = _default_threshold(client_module)
+        flagged = [s for s in answered_scores if s <= threshold]
+        ratio = len(flagged) / len(answered_scores)
+        assert ratio <= 0.10, (
+            f"gap_max_avg_top_score={threshold} flags {len(flagged)}/"
+            f"{len(answered_scores)} ANSWERABLE benchmark queries as knowledge "
+            f"gaps (avg-top3 median {statistics.median(answered_scores):.3f}). "
+            "The engine's score composition has probably changed — recalibrate "
+            "the default against the current scale rather than shipping a loop "
+            "that mints tasks for questions the memory answers correctly."
+        )
+
+    def test_threshold_still_has_headroom_below_answered_scores(
+        self, answered_scores, client_module,
+    ):
+        """A threshold that sits just under the answered distribution will trip
+        on the first corpus that is slightly harder than the benchmark. Keep
+        real distance, not a hairline pass."""
+        threshold = _default_threshold(client_module)
+        worst_answered = min(answered_scores)
+        assert threshold < worst_answered, (
+            f"threshold {threshold} is at or above the WORST answered query "
+            f"({worst_answered:.3f}) — no headroom at all"
+        )

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.12.2] — 2026-08-04 — Recalibrate the gap threshold for engine 0.12.1
+
+Engine 0.12.1 changed how recall scores are composed, and one of our defaults silently inverted because of it. Nothing crashed, no test failed, and the whole suite stayed green — every test asserted *behaviour*, none asserted *calibration*.
+
+**What changed upstream.** Recency used to **add** up to +0.5 to every fresh record; it now **multiplies** relevance, bounded to +12.5%. Retrieval got better — on our benchmark corpus MRR rose 0.928 → 0.946 and recall@1 0.865 → 0.892 — but absolute scores roughly halved: avg-top-3 median **1.138 → 0.510**.
+
+**Why that mattered here.** `gap_max_avg_top_score` is an absolute score, so it only means what it meant while the engine composes scores the same way. Measured on the same corpus, the old 0.5 default flagged **0/37 queries as knowledge gaps on 0.11.3 and 17/37 on 0.12.1** — and the self-directing loop has been on by default since v0.10. A user upgrading their engine would have found an agenda filling up with "resolve knowledge gap" tasks for questions their memory answers correctly at rank 1.
+
+**The new default is measured, not guessed.** 0.30 flags 0/37 well-answered queries while still catching genuinely unanswerable ones. The distributions overlap (answered min 0.320, unanswerable max 0.441), so no threshold separates them cleanly; this errs toward missing a gap rather than inventing one, because a missed gap costs nothing visible while a false task costs the user's attention. The recurrence requirement (`gap_task_min_count`, default 3) remains the second filter behind it.
+
+**`auto_recall_min_score` was left at 0.4** — deliberately. The obvious move was to scale it down with everything else, but measuring said no: at 0.4 it drops 0/37 relevant hits, and lowering it only admits more noise.
+
+**Engine floor raised to `>=0.12.1`.** One absolute threshold cannot serve both scoring scales — 0.30 would go nearly silent on 0.11.3, and 0.5 mints junk on 0.12.1. Rather than ship a default that is wrong on one of them, the floor moves to the line the calibration was measured against.
+
+New `tests/test_gap_calibration.py` re-measures the default against the benchmark corpus and fails if it starts flagging answerable questions as gaps. Verified it rejects the old value (46% → FAIL) and accepts the new one (0% → pass), because a guard that cannot fail is not a guard.
+
 ## [0.12.1] — 2026-08-04 — Bounded dependencies, and engine 0.12.0
 
 ### Every dependency now has a ceiling

--- a/yantrikdb/client.py
+++ b/yantrikdb/client.py
@@ -361,12 +361,29 @@ class YantrikDBConfig:
     auto_gap_tasks: bool = True
     gap_task_max: int = 3            # cap new gap-tasks created per session
     gap_task_min_count: int = 3      # a gap must recur >= this to become a task
-    # Max average top recall score for a query to count as a "gap". The
-    # engine default is 0.4; that's strict for the bundled dim-64 potion-2M
-    # (unanswered queries still score ~0.5-0.6), so the plugin default is a
-    # touch more lenient. Tune per embedder: larger models separate better,
-    # so a lower value avoids false-positive gaps.
-    gap_max_avg_top_score: float = 0.5
+    # Max average top recall score for a query to count as a "gap".
+    #
+    # RECALIBRATED in v0.12.2 for engine 0.12.1, which changed how scores are
+    # composed: recency used to ADD up to +0.5 to every fresh record, and now
+    # MULTIPLIES relevance bounded to +12.5%. Retrieval got better (benchmark
+    # MRR 0.928 -> 0.946) but absolute scores roughly halved — avg-top3 median
+    # 1.138 -> 0.510 on the same corpus. The old 0.5 default flagged 0/37
+    # benchmark queries as gaps on 0.11.3 and **17/37 on 0.12.1**, so the
+    # self-directing loop (on by default since v0.10) would have minted tasks
+    # for questions the memory answers correctly at rank 1.
+    #
+    # 0.30 is measured, not guessed: on 0.12.1 it flags 0/37 well-answered
+    # queries while still catching genuinely unanswerable ones. The two
+    # distributions overlap (answered min 0.320, unanswerable max 0.441), so
+    # no threshold separates them cleanly — this errs toward missing a gap
+    # rather than inventing one, because a missed gap costs nothing visible
+    # while a false task costs the user's attention and trust. The recurrence
+    # requirement (gap_task_min_count) is the second filter behind it.
+    #
+    # tests/test_gap_calibration.py re-measures this against the benchmark
+    # corpus, so the next scoring change fails loudly instead of silently
+    # filling somebody's agenda.
+    gap_max_avg_top_score: float = 0.30
     # surface_agenda: prepend a compact "## Your memory's agenda" block to
     # system_prompt_block — top open tasks + unresolved knowledge gaps — so
     # every session opens with what the memory still needs.
@@ -512,7 +529,7 @@ class YantrikDBConfig:
                 os.environ.get("YANTRIKDB_GAP_TASK_MIN_COUNT"), 3,
             ),
             gap_max_avg_top_score=_parse_float(
-                os.environ.get("YANTRIKDB_GAP_MAX_AVG_TOP_SCORE"), 0.5,
+                os.environ.get("YANTRIKDB_GAP_MAX_AVG_TOP_SCORE"), 0.30,
             ),
             surface_agenda=_parse_bool(
                 os.environ.get("YANTRIKDB_SURFACE_AGENDA"), default=True,

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,8 +1,8 @@
 name: yantrikdb
-version: 0.12.1
+version: 0.12.2
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.11.3,<0.13.0
+  - yantrikdb>=0.12.1,<0.13.0
   - requests>=2.31,<3.0.0
 hooks:
   - on_session_end


### PR DESCRIPTION
Engine 0.12.1 changed how recall scores are composed, and one of our defaults **silently inverted**. Nothing crashed, no test failed, the suite stayed green — every test asserted *behaviour*, none asserted *calibration*.

## What changed upstream
Recency used to **add** up to +0.5 to every fresh record; it now **multiplies** relevance, bounded to +12.5%. Retrieval genuinely improved:

| | 0.11.3 | 0.12.1 |
|---|---|---|
| MRR | 0.928 | **0.946** |
| recall@1 | 0.865 | **0.892** |
| avg-top-3 score (median) | 1.138 | **0.510** |

## Why it mattered here
`gap_max_avg_top_score` is an **absolute** score, so it only means what it meant while the engine composes scores the same way. Measured on the same corpus:

| threshold | flags as "knowledge gap" on 0.11.3 | on 0.12.1 |
|---|---|---|
| 0.5 (old default) | **0/37** | **17/37** |

The self-directing loop has been **on by default since v0.10**. A user upgrading their engine would have watched their agenda fill with *"Resolve knowledge gap: what indentation style does the user want"* — for a question the memory answers correctly at rank 1.

## The new default is measured, not guessed
**0.30** flags 0/37 well-answered queries while still catching genuinely unanswerable ones. The distributions overlap (answered min 0.320, unanswerable max 0.441), so nothing separates them cleanly — this errs toward *missing* a gap rather than *inventing* one, because a missed gap costs nothing visible while a false task costs the user's attention. `gap_task_min_count` remains the second filter behind it.

**`auto_recall_min_score` was left at 0.4** — deliberately. Scaling it down with everything else was the obvious move, and measuring said no: at 0.4 it drops 0/37 relevant hits, and lowering it only admits more noise.

## Engine floor raised to `>=0.12.1`
One absolute threshold can't serve both scales — 0.30 goes nearly silent on 0.11.3, 0.5 mints junk on 0.12.1. Rather than ship a default that's wrong on one of them, the floor moves to the line the calibration was measured against.

## The guard
`tests/test_gap_calibration.py` re-measures the default against the benchmark corpus and fails if it starts calling answerable questions gaps. I verified it **rejects the old value (46% → FAIL)** and accepts the new one (0% → pass) — a guard that can't fail isn't a guard.

**419 pass / 3 skip** on engine 0.12.1; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)