### PR TITLE
feat(v0.13.0): built for fleets, not single agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ echo "YANTRIKDB_OWNER_SCOPING=true" >> ~/.hermes/.env
 
 Off by default because it changes where new memories are written; existing ones stay readable (`YANTRIKDB_INCLUDE_BASE_NAMESPACE_RECALL`, default on).
 
+### Running a fleet of agents (v0.13.0)
+
+Hermes users run N agents, not one. Each agent already gets its own namespace (`{base}:{workspace}:{identity}`) automatically, so nothing contaminates anything else — verified with 6 separate processes writing one embedded database concurrently: 0 errors, 0 leakage.
+
+Two things make a fleet legible rather than just isolated:
+
+```bash
+# agents learn from each other: explicit `remember` writes become shared
+echo "YANTRIKDB_SHARED_BRAIN_NAMESPACE=team-brain" >> ~/.hermes/.env
+# an agent can see its siblings: memory counts, last activity, open tasks
+echo "YANTRIKDB_FLEET_VIEW=true" >> ~/.hermes/.env
+```
+
+The fleet view is read-only, never crosses workspaces, declares truncation rather than implying full coverage, and is **refused outright when `YANTRIKDB_OWNER_SCOPING` is on** — under owner scoping siblings are people, not agents, and enumerating them would break the isolation you turned on.
+
+For a fleet at scale, point every agent at one `yantrikdb-server` (`YANTRIKDB_MODE=http`): one engine and one corpus instead of N. Note that packs are embedded-only today, so that path trades attachable expertise for shared scale — server-side pack endpoints are requested upstream.
+
 ### Attachable expertise — knowledge packs (v0.11.0)
 
 A **pack** is a sealed, signed knowledge file. Mount it to gain its knowledge and rules for a task; unmount to give them back, leaving your own memory byte-for-byte unchanged. No other Hermes memory provider can do this.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.12.2
+version: 0.13.0
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.12.2"
+version = "0.13.0"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,6 +220,8 @@ def _clean_yantrikdb_env(monkeypatch):
         "YANTRIKDB_SURFACE_AGENDA",
         "YANTRIKDB_AGENDA_MAX_ITEMS",
         "YANTRIKDB_TOOL_PROFILE",
+        "YANTRIKDB_FLEET_VIEW",
+        "YANTRIKDB_PACKS_ENABLED",
         "YANTRIKDB_SHARE_ENGINE",
     ):
         monkeypatch.delenv(var, raising=False)

--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -1,0 +1,140 @@
+"""v0.13.0 — a view across the fleet, without breaking what it isolates.
+
+Hermes users run N agents, not one. Each gets `{base}:{workspace}:{identity}`
+so nothing contaminates anything else — which also means every surface this
+plugin offers is single-agent. An operator running twenty agents cannot ask
+"what is my fleet working on", "which agent is stuck", or "has anyone already
+learned this".
+
+The isolation is right; the missing thing is a view ACROSS it. That makes the
+boundary conditions the important tests, not the happy path: a fleet view that
+leaks across the wrong boundary is worse than no fleet view.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_client(client_module) -> MagicMock:
+    c = MagicMock(spec=client_module.YantrikDBClient)
+    c.health.return_value = {"status": "ok"}
+    c.list_records.return_value = {"records": [
+        {"namespace": "hermes:acme:coder", "created_at": 100.0},
+        {"namespace": "hermes:acme:coder", "created_at": 200.0},
+        {"namespace": "hermes:acme:researcher", "created_at": 150.0},
+        {"namespace": "hermes:acme:triage", "created_at": 50.0},
+        {"namespace": "hermes:OTHERWORKSPACE:coder", "created_at": 999.0},
+    ]}
+    c.task_list.return_value = {"tasks": [{"id": "t1"}, {"id": "t2"}]}
+    return c
+
+
+def _provider(provider_module, mock_client, monkeypatch, **env):
+    monkeypatch.setenv("YANTRIKDB_MODE", "http")
+    monkeypatch.setenv("YANTRIKDB_TOKEN", "ydb_test")
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    p = provider_module.YantrikDBMemoryProvider()
+    with patch.object(provider_module, "make_backend", return_value=mock_client):
+        p.initialize("s1", agent_workspace="acme", agent_identity="coder",
+                     platform="cli")
+    return p
+
+
+def _fleet(p):
+    return json.loads(p.handle_tool_call("yantrikdb_fleet", {}))
+
+
+class TestFleetBoundaries:
+    """The tests that matter. A fleet view is only acceptable if it cannot
+    become a privacy leak."""
+
+    def test_refuses_under_owner_scoping(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        """Under owner scoping, sibling namespaces are PEOPLE, not agents.
+        Enumerating them would be exactly the identity-contamination failure
+        that scoping exists to prevent."""
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_FLEET_VIEW="true", YANTRIKDB_OWNER_SCOPING="true")
+        out = _fleet(p)
+        assert "error" in out
+        assert "owner_scoping" in out["error"]
+        mock_client.list_records.assert_not_called()
+
+    def test_does_not_cross_workspaces(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        """Siblings are agents of the SAME workspace. Reaching across
+        workspaces would pull in unrelated deployments that merely share a
+        tenant prefix."""
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_FLEET_VIEW="true")
+        seen = {a["namespace"] for a in _fleet(p)["sibling_agents"]}
+        assert not any("OTHERWORKSPACE" in ns for ns in seen)
+
+    def test_disabled_by_default(self, provider_module, mock_client, monkeypatch):
+        p = _provider(provider_module, mock_client, monkeypatch)
+        out = _fleet(p)
+        assert "error" in out
+        mock_client.list_records.assert_not_called()
+
+    def test_tool_hidden_unless_enabled(self, provider_module, monkeypatch):
+        p = provider_module.YantrikDBMemoryProvider()
+        assert "yantrikdb_fleet" not in {s["name"] for s in p.get_tool_schemas()}
+        monkeypatch.setenv("YANTRIKDB_FLEET_VIEW", "true")
+        p2 = provider_module.YantrikDBMemoryProvider()
+        assert "yantrikdb_fleet" in {s["name"] for s in p2.get_tool_schemas()}
+
+
+class TestFleetOverview:
+    def test_lists_sibling_agents_not_itself(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_FLEET_VIEW="true")
+        out = _fleet(p)
+        names = {a["namespace"] for a in out["sibling_agents"]}
+        assert "hermes:acme:researcher" in names
+        assert "hermes:acme:triage" in names
+        assert out["this_agent"] not in names, "an agent is not its own sibling"
+
+    def test_reports_activity_and_open_work(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_FLEET_VIEW="true")
+        agent = next(a for a in _fleet(p)["sibling_agents"]
+                     if a["namespace"] == "hermes:acme:researcher")
+        assert agent["memories"] == 1
+        assert agent["last_seen"] == 150.0
+        assert agent["open_tasks"] == 2
+
+    def test_truncation_is_declared(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        """A capped scan that reports itself as complete is a silent lie about
+        coverage — the operator would read a partial fleet as the whole one."""
+        mock_client.list_records.return_value = {"records": [
+            {"namespace": "hermes:acme:x", "created_at": 1.0} for _ in range(5)
+        ]}
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_FLEET_VIEW="true", YANTRIKDB_FLEET_SCAN_LIMIT="5")
+        assert _fleet(p)["truncated"] is True
+
+    def test_one_unreachable_sibling_does_not_blank_the_view(
+        self, provider_module, mock_client, monkeypatch, client_module,
+    ):
+        mock_client.task_list.side_effect = client_module.YantrikDBServerError("down")
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_FLEET_VIEW="true")
+        out = _fleet(p)
+        assert out["sibling_agents"], "agents should still be listed"
+        assert all(a["open_tasks"] is None for a in out["sibling_agents"]), (
+            "unknown must read as unknown, never as zero open tasks"
+        )

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -247,6 +247,7 @@ EXPECTED_TOOL_NAMES = {
     "yantrikdb_recent_turns",
     "yantrikdb_tasks",
     "yantrikdb_packs",
+    "yantrikdb_fleet",
 }
 
 
@@ -257,6 +258,7 @@ class TestToolSchemas:
         monkeypatch.setenv("YANTRIKDB_TOOL_PROFILE", "full")
         monkeypatch.setenv("YANTRIKDB_SKILLS_ENABLED", "true")
         monkeypatch.setenv("YANTRIKDB_PACKS_ENABLED", "true")
+        monkeypatch.setenv("YANTRIKDB_FLEET_VIEW", "true")
         provider._config = None  # force re-read from env
         names = {s["name"] for s in provider.get_tool_schemas()}
         assert names == EXPECTED_TOOL_NAMES
@@ -285,7 +287,7 @@ class TestToolSchemas:
         # Skills and packs follow their own flags, not the profile.
         assert names == EXPECTED_TOOL_NAMES - {
             "yantrikdb_skill_search", "yantrikdb_skill_define",
-            "yantrikdb_skill_outcome", "yantrikdb_packs",
+            "yantrikdb_skill_outcome", "yantrikdb_packs", "yantrikdb_fleet",
         }
         assert len(names) == 18
 

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.13.0] — 2026-08-05 — Built for fleets, not single agents
+
+Hermes users run **N agents**, not one. This release makes the plugin legible to an operator running twenty of them.
+
+### The fleet was already isolated — and invisible
+
+Each agent gets `{base}:{workspace}:{identity}` automatically, so nothing contaminates anything else. Verified under real load: **6 separate processes writing one embedded database, 720 concurrent writes — 0 errors, 0 backpressure, 0 namespace leakage**, each agent reading only its own memories.
+
+But that isolation meant every surface here was single-agent. An operator could not ask *"what is my fleet working on"*, *"which agent is stuck"*, or *"has another agent already learned this"*.
+
+**New `yantrikdb_fleet` tool** (opt-in, `YANTRIKDB_FLEET_VIEW=true`) reports each sibling agent's memory count, last activity, and open task count — read-only.
+
+Its boundaries matter more than its output, so they are the tests:
+- **Refused entirely when `owner_scoping` is on.** Under owner scoping sibling namespaces are *people*, not agents; a "fleet overview" that quietly enumerated a user's family would be the exact identity-contamination failure that scoping exists to prevent.
+- **Never crosses workspaces** — siblings are agents of the same `{base}:{workspace}`, not everything sharing a tenant prefix.
+- **Truncation is declared.** A capped scan reporting itself as complete would be a silent lie about coverage.
+- **An unreachable sibling reads as unknown, never as zero open tasks.**
+
+### Cross-agent learning is findable now
+
+`shared_brain_namespace` has existed since v0.5 — set it and what one agent is explicitly told to remember becomes recallable by all of them, tagged with which agent contributed. It was in no config schema at all, so `hermes memory setup` never mentioned it and an operator running a fleet would never discover it existed. Both it and the fleet view are now described in `hermes memory setup` by the problem they solve.
+
+### Known gap, raised upstream
+
+Packs are embedded-only, so the fleet's best deployment (one shared `yantrikdb-server`, agents isolated by namespace) currently **cannot mount a pack** — an operator picks isolation-and-scale or attachable expertise, never both. That needs pack endpoints on the server; requested from the engine team with the surface and the two design constraints that matter.
+
+8 new tests; 427 pass / 3 skip.
+
 ## [0.12.2] — 2026-08-04 — Recalibrate the gap threshold for engine 0.12.1
 
 Engine 0.12.1 changed how recall scores are composed, and one of our defaults silently inverted because of it. Nothing crashed, no test failed, and the whole suite stayed green — every test asserted *behaviour*, none asserted *calibration*.

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -844,6 +844,20 @@ RECENT_TURNS_SCHEMA = {
     },
 }
 
+FLEET_SCHEMA = {
+    "name": "yantrikdb_fleet",
+    "description": (
+        "v0.13 — see the OTHER agents sharing this workspace, not just "
+        "yourself. Each agent owns its own memory namespace, so nothing here "
+        "is visible by default; this reports, per sibling agent, how many "
+        "memories it holds, when it was last active, and how many open tasks "
+        "it has. Use it to answer 'has another agent already worked on this?' "
+        "or 'which of my agents is stuck?' before duplicating effort. Read-"
+        "only, and never available when per-user scoping is on."
+    ),
+    "input_schema": {"type": "object", "properties": {}, "required": []},
+}
+
 PACKS_SCHEMA = {
     "name": "yantrikdb_packs",
     "description": (
@@ -970,6 +984,7 @@ ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
     RECENT_TURNS_SCHEMA,
     TASKS_SCHEMA,
     PACKS_SCHEMA,
+    FLEET_SCHEMA,
 ]
 
 
@@ -1561,6 +1576,34 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 "description": "Default max results for recall.",
                 "default": "10",
                 "env_var": "YANTRIKDB_TOP_K",
+            },
+            {
+                "key": "shared_brain_namespace",
+                "description": (
+                    "Running SEVERAL AGENTS? Set this to a shared namespace "
+                    "(e.g. 'team-brain') and what one agent is explicitly told "
+                    "to remember becomes recallable by all of them — your "
+                    "coding agent learns a preference, your chat agent knows "
+                    "it. Each agent keeps its own private memory as well; only "
+                    "explicit `remember` writes are shared, tagged with which "
+                    "agent contributed. Empty (default) = every agent is an "
+                    "island."
+                ),
+                "default": "",
+                "env_var": "YANTRIKDB_SHARED_BRAIN_NAMESPACE",
+            },
+            {
+                "key": "fleet_view",
+                "description": (
+                    "Running several agents and want to SEE across them? Adds "
+                    "a read-only `yantrikdb_fleet` tool reporting each sibling "
+                    "agent's memory count, last activity and open tasks — so "
+                    "an agent can check whether another already did the work. "
+                    "Off by default, and refused entirely when owner_scoping "
+                    "is on, since siblings are people there rather than agents."
+                ),
+                "default": "false",
+                "env_var": "YANTRIKDB_FLEET_VIEW",
             },
             {
                 "key": "owner_scoping",
@@ -2329,7 +2372,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 s for s in schemas
                 if s["name"] in CORE_TOOL_NAMES
                 or s["name"].startswith("yantrikdb_skill_")
-                or s["name"] == "yantrikdb_packs"
+                or s["name"] in ("yantrikdb_packs", "yantrikdb_fleet")
             ]
 
         # Skills and packs are orthogonal to the profile: turning either on is
@@ -2343,6 +2386,8 @@ class YantrikDBMemoryProvider(MemoryProvider):
             ]
         if not cfg.packs_enabled:
             schemas = [s for s in schemas if s["name"] != "yantrikdb_packs"]
+        if not cfg.fleet_view_enabled:
+            schemas = [s for s in schemas if s["name"] != "yantrikdb_fleet"]
         return schemas
 
     def handle_tool_call(
@@ -2396,6 +2441,8 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 raw = self._do_hygiene(args)
             elif tool_name == "yantrikdb_packs":
                 raw = self._do_packs(args)
+            elif tool_name == "yantrikdb_fleet":
+                raw = self._do_fleet(args)
             elif tool_name == "yantrikdb_knowledge_gaps":
                 raw = self._do_knowledge_gaps(args)
             elif tool_name == "yantrikdb_recent_turns":
@@ -3146,6 +3193,84 @@ class YantrikDBMemoryProvider(MemoryProvider):
         "tasks need yantrikdb>=0.9.0 (embedded) or a yantrikdb-server "
         "exposing /v1/tasks — not available in this mode/version."
     )
+
+    def _do_fleet(self, args: dict[str, Any]) -> str:
+        """What the whole fleet knows and is stuck on (v0.13).
+
+        Every other surface here is single-agent by design — each agent owns
+        `{base}:{workspace}:{identity}`. That isolation is right, but it leaves
+        an operator running twenty agents with no way to see across them.
+        """
+        client = self._require_client()
+        cfg = self._config
+        if not cfg or not cfg.fleet_view_enabled:
+            return tool_error(
+                "fleet view is disabled. Set YANTRIKDB_FLEET_VIEW=true to let "
+                "this agent see its sibling agents' namespaces.",
+            )
+        if cfg.owner_scoping:
+            # Under owner scoping, siblings are PEOPLE. Enumerating them would
+            # be the identity-contamination failure that scoping exists to
+            # prevent — refuse rather than quietly hand one user a summary of
+            # everyone else's memory.
+            return tool_error(
+                "fleet view is unavailable while owner_scoping is on: sibling "
+                "namespaces are other people there, not other agents, and "
+                "listing them would break the isolation you enabled.",
+            )
+
+        prefix = self._fleet_prefix()
+        if not prefix:
+            return tool_error(
+                "cannot determine this agent's fleet: no workspace in the "
+                "namespace. Pass agent_workspace when initializing.",
+            )
+        resp = client.list_records(limit=max(cfg.fleet_scan_limit, 1))
+        records = (resp.get("records") if isinstance(resp, dict) else resp) or []
+
+        agents: dict[str, dict[str, Any]] = {}
+        for r in records:
+            ns = (r.get("namespace") or "").strip()
+            if not ns.startswith(prefix) or ns == self._namespace:
+                continue
+            entry = agents.setdefault(ns, {"namespace": ns, "memories": 0,
+                                           "last_seen": None, "open_tasks": None})
+            entry["memories"] += 1
+            ts = r.get("created_at")
+            if ts and (entry["last_seen"] is None or ts > entry["last_seen"]):
+                entry["last_seen"] = ts
+
+        # Open tasks are the "what is it stuck on" half, and they live per
+        # namespace — so they need one call each rather than falling out of the
+        # scan. Fail-soft per agent: one unreachable sibling must not blank the
+        # whole overview.
+        for ns, entry in agents.items():
+            try:
+                listed = client.task_list(namespace=ns, status="open")
+                tasks = (listed.get("tasks") if isinstance(listed, dict) else listed) or []
+                entry["open_tasks"] = len(tasks)
+            except (YantrikDBError, AttributeError):
+                entry["open_tasks"] = None
+
+        return json.dumps({
+            "fleet_prefix": prefix,
+            "this_agent": self._namespace,
+            "sibling_agents": sorted(agents.values(),
+                                     key=lambda a: -(a["memories"] or 0)),
+            "scanned_records": len(records),
+            "truncated": len(records) >= max(cfg.fleet_scan_limit, 1),
+        })
+
+    def _fleet_prefix(self) -> str:
+        """`{base}:{workspace}:` — siblings are agents of the same workspace.
+
+        Deliberately not `{base}:`, which would reach across workspaces into
+        deployments that merely share a tenant prefix.
+        """
+        parts = (self._namespace or "").split(":")
+        if len(parts) < 2 or not parts[1]:
+            return ""
+        return f"{parts[0]}:{parts[1]}:"
 
     def _do_packs(self, args: dict[str, Any]) -> str:
         """Mount / inspect / install sealed knowledge packs (v0.11)."""

--- a/yantrikdb/client.py
+++ b/yantrikdb/client.py
@@ -93,6 +93,24 @@ class YantrikDBConfig:
     # (session-end only).
     maintenance_cadence_turns: int = 40
     maintenance_min_interval_seconds: int = 1800
+    # fleet_view (v0.13.0): see the whole fleet, not just this agent.
+    #
+    # Hermes users run N agents, not one. Each gets its own namespace
+    # ({base}:{workspace}:{identity}) so nothing contaminates anything else —
+    # but that also means every surface this plugin offers is single-agent.
+    # An operator running twenty agents has no way to ask "what is my fleet
+    # working on", "which agent is stuck", or "has anyone already learned
+    # this". The isolation is right; the missing thing is a view ACROSS it.
+    #
+    # OFF by default, and deliberately: reading sibling namespaces crosses the
+    # boundary this plugin otherwise defends, so it is an operator's decision.
+    # It also REFUSES to run when owner_scoping is on — under owner scoping
+    # sibling namespaces are other PEOPLE, not other agents, and a "fleet
+    # overview" that quietly enumerates a user's family members would be the
+    # exact identity-contamination failure the scoping exists to prevent.
+    fleet_view_enabled: bool = False
+    # Records scanned per overview. The scan is the cost, so bound it.
+    fleet_scan_limit: int = 400
     # packs (v0.11.0): attachable expertise. Engine 0.11.0+.
     #
     # A pack is a sealed, signed database of knowledge and rules that a host
@@ -417,6 +435,12 @@ class YantrikDBConfig:
             ),
             maintenance_min_interval_seconds=_parse_int(
                 os.environ.get("YANTRIKDB_MAINTENANCE_MIN_INTERVAL_SECONDS"), 1800,
+            ),
+            fleet_view_enabled=_parse_bool(
+                os.environ.get("YANTRIKDB_FLEET_VIEW"), default=False,
+            ),
+            fleet_scan_limit=_parse_int(
+                os.environ.get("YANTRIKDB_FLEET_SCAN_LIMIT"), 400,
             ),
             packs_enabled=_parse_bool(
                 os.environ.get("YANTRIKDB_PACKS_ENABLED"), default=False,

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.12.2
+version: 0.13.0
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.12.1,<0.13.0


### PR DESCRIPTION
Hermes users run **N agents**, not one — that's the deployment shape VCs and the community both describe. Every surface in this plugin was single-agent, so an operator running twenty couldn't ask *"what is my fleet working on"*, *"which agent is stuck"*, or *"has another agent already learned this"*.

## Measured first: the isolation already works

Before building anything I tested the actual fleet shape — **6 separate processes writing one embedded database, 720 concurrent writes**:

```
alpha   ok=120 backpressure=0 errors=0 foreign_leaked=0
bravo   ok=120 backpressure=0 errors=0 foreign_leaked=0
charlie ok=120 backpressure=0 errors=0 foreign_leaked=0
delta   ok=120 backpressure=0 errors=0 foreign_leaked=0
echo    ok=120 backpressure=0 errors=0 foreign_leaked=0
foxtrot ok=120 backpressure=0 errors=0 foreign_leaked=0
```

Each agent read only its own namespace. **This is a visibility gap, not a bug** — which is why the release adds a view rather than a fix.

## New `yantrikdb_fleet` tool (opt-in)

Reports each sibling agent's memory count, last activity, and open task count. Read-only.

**Its boundaries are the point**, and they're what the tests cover:

- **Refused entirely when `owner_scoping` is on.** There, sibling namespaces are *people*, not agents — a "fleet overview" quietly enumerating a user's family would be exactly the identity-contamination failure that scoping exists to prevent.
- **Never crosses workspaces** — siblings share `{base}:{workspace}`, not merely a tenant prefix.
- **Truncation is declared** — a capped scan reporting itself as complete is a silent lie about coverage.
- **An unreachable sibling reads as unknown**, never as zero open tasks.

## Cross-agent learning is findable now

`shared_brain_namespace` has existed since v0.5 — set it and what one agent is explicitly told to remember becomes recallable by all of them, tagged with which agent contributed. It appeared in **no config schema at all**, so `hermes memory setup` never mentioned it and a fleet operator would never discover it existed.

Both it and the fleet view are now described there **by the problem they solve** rather than the mechanism they use — the same fix v0.12.0 applied to `owner_scoping`.

## Known gap, raised upstream

Packs are **embedded-only**, so the fleet's best deployment (one shared `yantrikdb-server`, agents isolated by namespace) cannot mount a pack. An operator picks isolation-and-scale *or* attachable expertise, never both. I've asked the engine team for pack endpoints, with the surface and the two constraints that matter: mount is an operator action on a shared server, and `pack_context` must stay engine-assembled so packs behave identically wherever mounted.

**8 new tests; 427 pass / 3 skip**; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)