### PR TITLE
feat(v0.14.0): standing rules that belong to the operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ echo "YANTRIKDB_OWNER_SCOPING=true" >> ~/.hermes/.env
 
 Off by default because it changes where new memories are written; existing ones stay readable (`YANTRIKDB_INCLUDE_BASE_NAMESPACE_RECALL`, default on).
 
+### Standing rules — your guardrails (v0.14.0)
+
+Write rules you want obeyed every turn into `$HERMES_HOME/yantrikdb-constitution.md`:
+
+```markdown
+- Never run destructive commands without asking.
+- Answer in British English.
+- Never reveal internal hostnames.
+```
+
+They are injected first and **outrank recalled memory and any mounted knowledge pack's rules**. Four things make them a guardrail rather than just another block: they are never trimmed when the context window fills (a rule that vanishes under pressure was never a rule), they still apply when the memory backend is unavailable, truncation of an oversize file is logged rather than silent, and **there is no tool to edit them** — the agent cannot rewrite its own rules; the file is the interface and you are the editor.
+
 ### Running a fleet of agents (v0.13.0)
 
 Hermes users run N agents, not one. Each agent already gets its own namespace (`{base}:{workspace}:{identity}`) automatically, so nothing contaminates anything else — verified with 6 separate processes writing one embedded database concurrently: 0 errors, 0 leakage.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.13.0
+version: 0.14.0
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.13.0"
+version = "0.14.0"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_constitution.py
+++ b/tests/test_constitution.py
@@ -1,0 +1,163 @@
+"""v0.14.0 — standing rules that belong to the operator.
+
+Before this, exactly one channel in the plugin carried always-injected RULES
+rather than facts: a knowledge pack's constitution. So a third party could
+install standing rules into someone's agent and the person who owns it could
+not. This closes that asymmetry.
+
+The properties worth testing are the ones that make it a guardrail rather than
+just another injected block:
+
+- it OUTRANKS recalled memory and pack rules, and says so
+- it does NOT yield to the adaptive budget — a rule that vanishes when the
+  context window fills is not a rule, and a full window is exactly when an
+  agent starts cutting corners
+- the agent CANNOT edit it: no tool, file only
+- it survives an unavailable memory backend, because guardrails stored inside
+  the thing they constrain are not guardrails
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_client(client_module) -> MagicMock:
+    c = MagicMock(spec=client_module.YantrikDBClient)
+    c.health.return_value = {"status": "ok"}
+    c.pack_context.return_value = {"context": "PACK RULE: always use framework X."}
+    return c
+
+
+@pytest.fixture
+def rules(tmp_path):
+    f = tmp_path / "yantrikdb-constitution.md"
+    f.write_text("- Never run destructive commands without asking.\n"
+                 "- Answer in British English.\n", encoding="utf-8")
+    return f
+
+
+def _provider(provider_module, mock_client, monkeypatch, rules_path=None, **env):
+    monkeypatch.setenv("YANTRIKDB_MODE", "http")
+    monkeypatch.setenv("YANTRIKDB_TOKEN", "ydb_test")
+    if rules_path is not None:
+        monkeypatch.setenv("YANTRIKDB_CONSTITUTION_PATH", str(rules_path))
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    p = provider_module.YantrikDBMemoryProvider()
+    with patch.object(provider_module, "make_backend", return_value=mock_client):
+        p.initialize("s1", agent_workspace="ws", agent_identity="coder",
+                     platform="cli")
+    return p
+
+
+class TestOperatorRulesAreInjected:
+    def test_rules_appear(self, provider_module, mock_client, monkeypatch, rules):
+        p = _provider(provider_module, mock_client, monkeypatch, rules)
+        block = p.system_prompt_block()
+        assert "Never run destructive commands" in block
+        assert "British English" in block
+
+    def test_nothing_injected_without_a_file(
+        self, provider_module, mock_client, monkeypatch, tmp_path,
+    ):
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      tmp_path / "does-not-exist.md")
+        assert "Standing rules" not in p.system_prompt_block()
+
+    def test_edits_take_effect_without_a_restart(
+        self, provider_module, mock_client, monkeypatch, rules,
+    ):
+        p = _provider(provider_module, mock_client, monkeypatch, rules)
+        assert "British English" in p.system_prompt_block()
+        rules.write_text("- Answer in French.\n", encoding="utf-8")
+        block = p.system_prompt_block()
+        assert "French" in block and "British English" not in block
+
+
+class TestPrecedence:
+    def test_rules_come_first(self, provider_module, mock_client, monkeypatch, rules):
+        """Position is part of the claim — rules the model reads after a page
+        of recalled memory are competing with it, not governing it."""
+        p = _provider(provider_module, mock_client, monkeypatch, rules)
+        block = p.system_prompt_block()
+        assert block.lstrip().startswith("# Standing rules from the operator")
+
+    def test_states_that_it_outranks_memory_and_packs(
+        self, provider_module, mock_client, monkeypatch, rules,
+    ):
+        p = _provider(provider_module, mock_client, monkeypatch, rules,
+                      YANTRIKDB_PACKS_ENABLED="true")
+        block = p.system_prompt_block()
+        head = block.split("# YantrikDB Memory")[0].lower()
+        assert "outrank" in head
+        assert "pack" in head and "memory" in head
+
+    def test_operator_rules_precede_pack_rules(
+        self, provider_module, mock_client, monkeypatch, rules,
+    ):
+        """A third party's rules must not be able to override the owner's."""
+        p = _provider(provider_module, mock_client, monkeypatch, rules,
+                      YANTRIKDB_PACKS_ENABLED="true")
+        block = p.system_prompt_block()
+        assert block.index("Standing rules") < block.index("PACK RULE")
+
+
+class TestRulesDoNotYield:
+    def test_survives_a_nearly_full_context_window(
+        self, provider_module, mock_client, monkeypatch, rules,
+    ):
+        """Every other block scales down as context fills. This one must not:
+        a tight window is exactly when corners get cut."""
+        p = _provider(provider_module, mock_client, monkeypatch, rules)
+        p.on_turn_start(99, "msg", remaining_tokens=500)
+        block = p.system_prompt_block()
+        assert "Never run destructive commands" in block
+        assert "British English" in block
+
+    def test_survives_an_unavailable_backend(
+        self, provider_module, monkeypatch, rules,
+    ):
+        """Guardrails stored inside the thing they constrain are not
+        guardrails — rules must hold when memory is down."""
+        monkeypatch.setenv("YANTRIKDB_CONSTITUTION_PATH", str(rules))
+        p = provider_module.YantrikDBMemoryProvider()
+        p._config = provider_module.YantrikDBConfig.from_env()
+        p._client = None
+        p._init_error = "engine unavailable"
+        assert "Never run destructive commands" in p.system_prompt_block()
+
+    def test_oversize_file_is_capped_and_warns(
+        self, provider_module, mock_client, monkeypatch, tmp_path, caplog,
+    ):
+        """Truncating rules silently would leave an operator believing rules
+        are in force that are not."""
+        import logging
+        f = tmp_path / "big.md"
+        f.write_text("- rule\n" * 2000, encoding="utf-8")
+        p = _provider(provider_module, mock_client, monkeypatch, f,
+                      YANTRIKDB_CONSTITUTION_MAX_CHARS="200")
+        with caplog.at_level(logging.WARNING):
+            block = p.system_prompt_block()
+        rules_section = block.split("# YantrikDB Memory")[0]
+        assert len(rules_section) < 600, "the rules themselves must be capped"
+        assert any("truncated" in r.getMessage().lower() for r in caplog.records)
+
+
+class TestAgentCannotRewriteItsOwnRules:
+    def test_no_tool_exposes_the_constitution(
+        self, provider_module, monkeypatch, rules,
+    ):
+        """A tool to edit standing rules is precisely the capability an agent
+        must not have. The file is the interface; the operator is the editor."""
+        monkeypatch.setenv("YANTRIKDB_CONSTITUTION_PATH", str(rules))
+        monkeypatch.setenv("YANTRIKDB_TOOL_PROFILE", "full")
+        monkeypatch.setenv("YANTRIKDB_PACKS_ENABLED", "true")
+        monkeypatch.setenv("YANTRIKDB_FLEET_VIEW", "true")
+        p = provider_module.YantrikDBMemoryProvider()
+        blob = str(p.get_tool_schemas()).lower()
+        assert "constitution" not in blob
+        assert not any("rule" in s["name"] for s in p.get_tool_schemas())

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.14.0] — 2026-08-05 — Standing rules that belong to the operator
+
+Until now exactly one channel in this plugin carried always-injected **rules** rather than facts: a knowledge pack's constitution. Which meant **a third party could install standing rules into someone's agent and the person who owns it could not.** That asymmetry was the wrong way round.
+
+### `yantrikdb-constitution.md`
+
+Write your rules in a markdown file — `$HERMES_HOME/yantrikdb-constitution.md`, or set `YANTRIKDB_CONSTITUTION_PATH`:
+
+```markdown
+- Never run destructive commands without asking.
+- Answer in British English.
+- Never reveal internal hostnames.
+```
+
+They are injected **first**, and stated to outrank recalled memory, mounted packs, and everything else in the prompt.
+
+### Four properties that make it a guardrail rather than another block
+
+- **It never yields to the adaptive budget.** Every other injected block scales down as the context window fills; this one is bounded but never shrunk. A nearly-full window is exactly when an agent starts cutting corners, and a rule that disappears under pressure was never a rule.
+- **It survives an unavailable backend.** Writing the tests caught a real bug here: the memory-unavailable path returned early, so rules vanished precisely when memory was broken. Fixed — rules are prepended to every return path. Guardrails stored inside the thing they constrain are not guardrails.
+- **The agent cannot edit it.** There is deliberately no tool. A tool to rewrite standing rules is exactly the capability an agent must not have; the file is the interface and the operator is the editor. A test asserts no tool mentions it.
+- **Truncation is loud.** An oversize file is capped and logs a warning naming what was dropped — silently trimming rules would leave an operator believing rules are in force that are not.
+
+### Also
+`constitution_path` now appears in `hermes memory setup`, described by what it is for.
+
+**Not** included: the engine's personality/persona surface (`derive_personality`, `set_personality_trait`) is still deliberately unused — `think()` continues to pass `run_personality=False`. Exposing it is a separate decision about whether an agent's manner should drift from a transcript, and it deserves its own opt-in rather than arriving inside a guardrails release.
+
+10 new tests; 437 pass / 3 skip.
+
 ## [0.13.0] — 2026-08-05 — Built for fleets, not single agents
 
 Hermes users run **N agents**, not one. This release makes the plugin legible to an operator running twenty of them.

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -1414,6 +1414,10 @@ class YantrikDBMemoryProvider(MemoryProvider):
         self._pack_context_cache: str | None = None
         self._mounted_pack_ids: list[str] = []
         self._pack_namespace_cache: list[str] | None = None
+        # v0.14 — cached constitution keyed on (path, mtime, size) so the
+        # file is re-read when edited but not on every single turn.
+        self._constitution_cache: tuple[tuple, str] | None = None
+        self._hermes_home: Path | None = None
         # v0.12 — periodic maintenance for sessions that rarely end.
         self._last_maintenance_turn: int = 0
         self._last_maintenance_at: float = 0.0
@@ -1578,6 +1582,23 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 "env_var": "YANTRIKDB_TOP_K",
             },
             {
+                "key": "constitution_path",
+                "description": (
+                    "STANDING RULES you want obeyed every turn — 'never run "
+                    "destructive commands without asking', 'answer in German', "
+                    "'never reveal internal hostnames'. Write them in a "
+                    "markdown file; the path defaults to "
+                    "$HERMES_HOME/yantrikdb-constitution.md. They are injected "
+                    "first, outrank recalled memory AND any mounted knowledge "
+                    "pack's rules, and are never trimmed when the context "
+                    "window fills. Deliberately a file with no tool: the agent "
+                    "cannot edit its own rules, and they still apply when "
+                    "memory is unavailable."
+                ),
+                "default": "",
+                "env_var": "YANTRIKDB_CONSTITUTION_PATH",
+            },
+            {
                 "key": "shared_brain_namespace",
                 "description": (
                     "Running SEVERAL AGENTS? Set this to a shared namespace "
@@ -1682,6 +1703,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
         hermes_home = Path(hermes_home_raw) if hermes_home_raw else None
         self._config = YantrikDBConfig.load(hermes_home)
         if hermes_home is not None:
+            self._hermes_home = hermes_home
             self._recent_skills_path = hermes_home / "yantrikdb-recent-skills.json"
             self._recall_feedback_path = (
                 hermes_home / "yantrikdb-recall-feedback.json"
@@ -1962,6 +1984,11 @@ class YantrikDBMemoryProvider(MemoryProvider):
     def system_prompt_block(self) -> str:
         if self._cron_skipped:
             return ""
+        # The operator's rules are prepended to EVERY path below, including the
+        # memory-unavailable one. Rules that hold only while the backend is
+        # healthy are not guardrails — and a degraded session is exactly when
+        # an agent is most likely to improvise.
+        rules = self._format_constitution_block()
         if self._client is None:
             # v0.4.4: surface the init failure to the model instead of
             # silently pretending memory is absent. Without this, an agent
@@ -1969,7 +1996,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
             # tools and getting "not active" errors — better to tell it
             # upfront so it can adapt or alert the user.
             if self._init_error:
-                return (
+                return rules + (
                     "# YantrikDB Memory — NOT AVAILABLE\n"
                     f"The plugin failed to initialize: {self._init_error}\n"
                     "Memory tools (`yantrikdb_*`) will not work this session, "
@@ -1986,7 +2013,7 @@ class YantrikDBMemoryProvider(MemoryProvider):
                     "See https://github.com/yantrikos/yantrikdb-hermes-plugin/issues "
                     "for diagnostics."
                 )
-            return ""
+            return rules
         scope_line = (
             "Owner scoping enabled; memories are isolated by resolved owner namespace.\n"
             if self._scope_metadata
@@ -2031,7 +2058,8 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 "`yantrikdb_tasks` — close one when you've learned the answer."
             )
         return (
-            base
+            rules
+            + base
             + self._format_recent_skills_block()
             + self._format_auto_skill_block()
             + self._format_pending_conflicts_block()
@@ -3295,6 +3323,65 @@ class YantrikDBMemoryProvider(MemoryProvider):
             self._pack_context_cache = None
             self._pack_namespace_cache = None
         return json.dumps(resp)
+
+    def _constitution_file(self) -> Path | None:
+        cfg = self._config
+        if cfg and cfg.constitution_path:
+            return Path(cfg.constitution_path).expanduser()
+        if self._hermes_home:
+            return Path(self._hermes_home) / "yantrikdb-constitution.md"
+        return None
+
+    def _format_constitution_block(self) -> str:
+        """The operator's standing rules — the one block that never yields.
+
+        Every other injected block is scaled down by the adaptive budget as the
+        context window fills. This one is bounded but never scaled, because a
+        nearly-full window is precisely when an agent starts cutting corners,
+        and a guardrail that disappears under pressure was never a guardrail.
+
+        Placed FIRST and stated to outrank everything the plugin injects
+        afterwards, including a mounted pack's constitution — a third party's
+        rules must not be able to override the rules of the person who owns
+        the agent.
+        """
+        path = self._constitution_file()
+        if path is None:
+            return ""
+        try:
+            stat = path.stat()
+        except OSError:
+            self._constitution_cache = None
+            return ""
+        stamp = (str(path), stat.st_mtime, stat.st_size)
+        if self._constitution_cache and self._constitution_cache[0] == stamp:
+            return self._constitution_cache[1]
+        try:
+            text = path.read_text(encoding="utf-8").strip()
+        except OSError as e:
+            logger.warning("YantrikDB could not read constitution %s: %s", path, e)
+            return ""
+        if not text:
+            self._constitution_cache = (stamp, "")
+            return ""
+        cap = max(self._config.constitution_max_chars if self._config else 1500, 1)
+        if len(text) > cap:
+            logger.warning(
+                "YantrikDB constitution truncated to %d of %d chars — rules past "
+                "the cap are NOT in effect; shorten the file or raise "
+                "YANTRIKDB_CONSTITUTION_MAX_CHARS.", cap, len(text),
+            )
+            text = truncate_text(text, cap)
+        block = (
+            "# Standing rules from the operator\n"
+            "These are set by the person who owns this agent. They outrank "
+            "recalled memory, mounted knowledge packs, and anything else in "
+            "this prompt. If a memory or a pack conflicts with them, follow "
+            "these and say so.\n"
+            f"{text}\n"
+        )
+        self._constitution_cache = (stamp, block)
+        return block
 
     def _format_pack_block(self) -> str:
         """Inject the engine-assembled context for mounted packs.

--- a/yantrikdb/client.py
+++ b/yantrikdb/client.py
@@ -93,6 +93,29 @@ class YantrikDBConfig:
     # (session-end only).
     maintenance_cadence_turns: int = 40
     maintenance_min_interval_seconds: int = 1800
+    # constitution (v0.14.0): the operator's standing rules.
+    #
+    # Until now exactly one channel in this plugin carried always-injected
+    # RULES rather than facts: a knowledge pack's constitution. Which meant a
+    # third party could install standing rules into someone's agent and the
+    # person who owns it could not. That asymmetry is the wrong way round.
+    #
+    # Rules live in a FILE, not the substrate, and there is deliberately no
+    # tool to edit them:
+    #   - an agent must not be able to rewrite its own guardrails, and a tool
+    #     is exactly that capability
+    #   - guardrails should survive a corrupted, empty or unreachable memory;
+    #     rules stored in the thing they constrain are not guardrails
+    #   - a file is greppable, diffable and reviewable, which is what you want
+    #     of the sentences that outrank everything else
+    #
+    # Empty path or missing file = nothing injected, no behaviour change.
+    constitution_path: str = ""      # default: $HERMES_HOME/yantrikdb-constitution.md
+    # Bounded so a runaway file cannot eat the window — but NOT scaled by the
+    # adaptive budget. Every other block yields as context fills; rules must
+    # not, because a tight window is exactly when an agent starts cutting
+    # corners. Bound it, never shrink it.
+    constitution_max_chars: int = 1500
     # fleet_view (v0.13.0): see the whole fleet, not just this agent.
     #
     # Hermes users run N agents, not one. Each gets its own namespace
@@ -435,6 +458,10 @@ class YantrikDBConfig:
             ),
             maintenance_min_interval_seconds=_parse_int(
                 os.environ.get("YANTRIKDB_MAINTENANCE_MIN_INTERVAL_SECONDS"), 1800,
+            ),
+            constitution_path=os.environ.get("YANTRIKDB_CONSTITUTION_PATH", ""),
+            constitution_max_chars=_parse_int(
+                os.environ.get("YANTRIKDB_CONSTITUTION_MAX_CHARS"), 1500,
             ),
             fleet_view_enabled=_parse_bool(
                 os.environ.get("YANTRIKDB_FLEET_VIEW"), default=False,

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.13.0
+version: 0.14.0
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.12.1,<0.13.0


### PR DESCRIPTION
Exactly one channel in this plugin carried always-injected **rules** rather than facts: a knowledge pack's constitution. Which meant:

> **A third party could install standing rules into someone's agent. The person who owns it could not.**

That asymmetry was the wrong way round.

## `yantrikdb-constitution.md`

```markdown
- Never run destructive commands without asking.
- Answer in British English.
- Never reveal internal hostnames.
```

Injected **first**, stated to outrank recalled memory, mounted packs, and everything else in the prompt.

## Four properties that make it a guardrail, not just another block

**It never yields to the adaptive budget.** Every other injected block scales down as the context window fills. This one is bounded but never shrunk — a nearly-full window is exactly when an agent starts cutting corners, and a rule that disappears under pressure was never a rule.

**It survives an unavailable backend.** Writing this test caught a **real bug**: the memory-unavailable path returned early, so the rules vanished precisely when memory was broken. Fixed — rules are prepended to every return path. Guardrails stored inside the thing they constrain are not guardrails.

**The agent cannot edit it.** Deliberately no tool. A tool to rewrite standing rules is exactly the capability an agent must not have; the file is the interface and the operator is the editor. A test asserts no tool mentions it.

**Truncation is loud.** An oversize file is capped *with a warning naming what was dropped* — silently trimming rules would leave an operator believing rules are in force that are not.

## Not included, deliberately

The engine's persona surface (`derive_personality`, `get_personality`, `set_personality_trait`) stays unused — `think()` still passes `run_personality=False`, so a fresh database and one with 10,000 memories both return flat 0.5 traits.

Whether an agent's *manner* should drift from a transcript is a real question, but it's a different one from guardrails, and it deserves its own opt-in rather than arriving bundled inside a security-shaped release.

**10 new tests; 437 pass / 3 skip**; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)