### PR TITLE
feat(v0.15.0): engine 0.13.x, and a feature switched off on the evidence

### DIFF
--- a/benchmarks/gap_floor_check.py
+++ b/benchmarks/gap_floor_check.py
@@ -1,0 +1,136 @@
+"""Convict your own copy of the composite-threshold bug, in one command.
+
+A threshold compared against a COMPOSITE recall score inherits an unstated
+assumption: that the composite discriminates "memory has something near this"
+from "memory has nothing." It does not have to. The composite folds in terms —
+importance, recency, decay — that describe how much a result should be weighted
+ONCE you've decided to return it, not whether it should have been returned. On
+corpora where those terms carry little variance, composite scores cluster high
+and a threshold set for a "low score" is never crossed. The detector doesn't
+misfire; it goes silent, and silence reads as good news.
+
+This measures the actual distribution on YOUR database and probes it with
+deliberate nonsense, which is the case such a detector exists for.
+
+    python gap_floor_check.py <db_path> [--namespace NS] [--threshold 0.30]
+
+Exit 1 if nonsense queries score above your threshold, so it can gate CI.
+
+NOTE ON METHOD: this reports OBSERVED distributions only. It does not compute a
+lower bound on the composite, because the returned per-component contributions
+do NOT sum to the composite score — verified: they differ by ~0.2, and a
+composite can land below the sum of its own non-similarity contributions. Any
+tool claiming a derived "floor" from those contributions is measuring something
+that isn't there. Ask what the detector DID, not what the arithmetic suggests
+it must do.
+
+Uses the direct binding because it needs the `scores` breakdown; over MCP the
+composite is visible but its composition is not, which is one reason this can
+hide in production.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+
+# Deliberate nonsense. A working detector flags all of these. Any that score
+# above the threshold are being reported as confidently answered.
+NONSENSE = [
+    "zzqx wobble frangible",
+    "quantum tarpaulin metric",
+    "grommet fitzwilliam parsnip protocol",
+    "vermillion sprocket abeyance clause",
+]
+
+# Ordinary queries, used only to sample the score distribution on real content.
+PROBES = [
+    "what did the user decide",
+    "recent architecture choice",
+    "what is the current configuration",
+    "who is responsible for this",
+]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("db_path")
+    ap.add_argument("--namespace", default=None)
+    ap.add_argument("--threshold", type=float, default=0.30,
+                    help="the value you calibrated against the composite score")
+    ap.add_argument("--top-k", type=int, default=5)
+    args = ap.parse_args()
+
+    from yantrikdb._yantrikdb_rust import YantrikDB
+    db = YantrikDB.with_default(args.db_path)
+
+    def recall(q):
+        kw = {"top_k": args.top_k}
+        if args.namespace:
+            kw["namespace"] = args.namespace
+        return db.recall(q, **kw)
+
+    def sample(queries):
+        out = []
+        for q in queries:
+            hits = recall(q)
+            if not hits:
+                continue
+            out.append({
+                "query": q,
+                "avg": statistics.mean(h["score"] for h in hits),
+                "min": min(h["score"] for h in hits),
+                "max_similarity": max(
+                    (h.get("scores") or {}).get("similarity", 0.0) for h in hits),
+            })
+        return out
+
+    real, junk = sample(PROBES), sample(NONSENSE)
+    if not real and not junk:
+        print("No results for any probe — nothing to measure.", file=sys.stderr)
+        return 2
+
+    every = real + junk
+    evaded = [r for r in junk if r["avg"] >= args.threshold]
+    real_flagged = [r for r in real if r["avg"] < args.threshold]
+
+    print(json.dumps({
+        "threshold_under_test": args.threshold,
+        "observed_avg_score": {
+            "min": round(min(r["avg"] for r in every), 4),
+            "max": round(max(r["avg"] for r in every), 4)},
+        "lowest_single_result_score": round(min(r["min"] for r in every), 4),
+        "max_similarity_seen": {
+            "real_queries": round(max((r["max_similarity"] for r in real), default=0), 4),
+            "nonsense_queries": round(max((r["max_similarity"] for r in junk), default=0), 4)},
+        "nonsense_avg_scores": {r["query"]: round(r["avg"], 4) for r in junk},
+        "nonsense_queries_NOT_flagged": f"{len(evaded)}/{len(junk)}",
+        "real_queries_flagged_as_gap": f"{len(real_flagged)}/{len(real)}",
+        "verdict": (
+            "BROKEN — nonsense scores above your threshold and is reported as "
+            "answered; this detector's silence carries no information"
+            if evaded else "threshold discriminates nonsense on this corpus"),
+        "similarity_separates_nonsense": (
+            max((r["max_similarity"] for r in real), default=0)
+            > max((r["max_similarity"] for r in junk), default=0)),
+        "read_this_before_switching_to_similarity": (
+            "Compare the two max_similarity figures. If nonsense scores as high "
+            "as real queries, thresholding similarity will NOT fix the detector "
+            "either — the embedder is assigning arbitrary strings real "
+            "neighbours, and no scalar cut over that signal can separate them. "
+            "Measure before adopting; do not assume similarity is the answer "
+            "just because the composite is not."),
+    }, indent=2))
+
+    if evaded:
+        print(f"\n{len(evaded)} nonsense quer{'y' if len(evaded)==1 else 'ies'} "
+              f"would be reported as answered:", file=sys.stderr)
+        for r in evaded:
+            print(f"  {r['query']!r}  avg={r['avg']:.4f}", file=sys.stderr)
+    return 1 if evaded else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.14.0
+version: 0.15.0
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the
@@ -7,7 +7,7 @@ version: 0.14.0
 # `yantrikdb-hermes install <hermes>`. Both should declare the same version.
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.12.1,<0.13.0
+  - yantrikdb>=0.12.1,<0.14.0
   - requests>=2.31,<3.0.0
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.14.0"
+version = "0.15.0"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -42,7 +42,7 @@ classifiers = [
 # shipped 2.0.0 against an unbounded pin. tests/test_dependency_pins.py enforces
 # this; raise a ceiling only after testing against the new major.
 dependencies = [
-  "yantrikdb>=0.12.1,<0.13.0",
+  "yantrikdb>=0.12.1,<0.14.0",
   "requests>=2.31,<3.0.0",
 ]
 
@@ -156,7 +156,7 @@ exclude = ["reference/", "tests/", "^__init__\\.py$"]
 # matching `## [X.Y.Z] — YYYY-MM-DD — Summary` header. The CI `version-sync`
 # job blocks merge if the three sources drift.
 [tool.bumpversion]
-current_version = "0.5.0"
+current_version = "0.15.0"
 commit = false       # let the human author the commit message + body
 tag = false          # tag via `gh release create`, not on bump
 allow_dirty = true

--- a/tests/comparison/fixtures/corpus_4353_gate_v1.json
+++ b/tests/comparison/fixtures/corpus_4353_gate_v1.json
@@ -1,0 +1,20425 @@
+{
+ "built_from": {
+  "base": "corpus_1k.json",
+  "generator": "generate_corpus._build_real",
+  "seed_start": 500,
+  "size": 4353
+ },
+ "facts": [
+  {
+   "category": "preference",
+   "id": 1,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 13pt as their font size in alacritty."
+  },
+  {
+   "category": "preference",
+   "id": 2,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in Terminal.app."
+  },
+  {
+   "category": "preference",
+   "id": 3,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers never as their auto-format in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 4,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 2 spaces as their tab width in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 5,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers LF as their line endings in fish shell."
+  },
+  {
+   "category": "preference",
+   "id": 6,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 7,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers never as their auto-format in bash."
+  },
+  {
+   "category": "preference",
+   "id": 8,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Cascadia Code as their font in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 9,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Source Code Pro as their font in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 10,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers LF as their line endings in bash."
+  },
+  {
+   "category": "preference",
+   "id": 11,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers high-contrast as their color scheme in bash."
+  },
+  {
+   "category": "preference",
+   "id": 12,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers GitKraken as their git GUI in Terminal.app."
+  },
+  {
+   "category": "preference",
+   "id": 13,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in Vim."
+  },
+  {
+   "category": "preference",
+   "id": 14,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 2 spaces as their tab width in Emacs."
+  },
+  {
+   "category": "preference",
+   "id": 15,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 14pt as their font size in tmux."
+  },
+  {
+   "category": "preference",
+   "id": 16,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers never as their auto-format in fish shell."
+  },
+  {
+   "category": "preference",
+   "id": 17,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 12pt as their font size in Warp."
+  },
+  {
+   "category": "preference",
+   "id": 18,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 16pt as their font size in alacritty."
+  },
+  {
+   "category": "preference",
+   "id": 19,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 12pt as their font size in kitty."
+  },
+  {
+   "category": "preference",
+   "id": 20,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Iosevka as their font in Windsurf."
+  },
+  {
+   "category": "preference",
+   "id": 21,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers JetBrains Mono as their font in kitty."
+  },
+  {
+   "category": "preference",
+   "id": 22,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tabs as their tab width in Emacs."
+  },
+  {
+   "category": "preference",
+   "id": 23,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Hack as their font in Cursor."
+  },
+  {
+   "category": "preference",
+   "id": 24,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers GitKraken as their git GUI in bash."
+  },
+  {
+   "category": "preference",
+   "id": 25,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Iosevka as their font in Windsurf."
+  },
+  {
+   "category": "preference",
+   "id": 26,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers never as their auto-format in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 27,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Fork as their git GUI in Zed."
+  },
+  {
+   "category": "preference",
+   "id": 28,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Fira Code as their font in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 29,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tig as their git GUI in zsh."
+  },
+  {
+   "category": "preference",
+   "id": 30,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Hack as their font in PyCharm."
+  },
+  {
+   "category": "preference",
+   "id": 31,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers on save as their auto-format in Cursor."
+  },
+  {
+   "category": "preference",
+   "id": 32,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers nord as their color scheme in Emacs."
+  },
+  {
+   "category": "preference",
+   "id": 33,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers lazygit as their git GUI in bash."
+  },
+  {
+   "category": "preference",
+   "id": 34,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in fish shell."
+  },
+  {
+   "category": "preference",
+   "id": 35,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 13pt as their font size in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 36,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers GitKraken as their git GUI in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 37,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tabs as their tab width in fish shell."
+  },
+  {
+   "category": "preference",
+   "id": 38,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 16pt as their font size in Neovim."
+  },
+  {
+   "category": "preference",
+   "id": 39,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Source Code Pro as their font in Cursor."
+  },
+  {
+   "category": "preference",
+   "id": 40,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers on save as their auto-format in tmux."
+  },
+  {
+   "category": "preference",
+   "id": 41,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers command line only as their git GUI in tmux."
+  },
+  {
+   "category": "preference",
+   "id": 42,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers lazygit as their git GUI in tmux."
+  },
+  {
+   "category": "preference",
+   "id": 43,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 15pt as their font size in Vim."
+  },
+  {
+   "category": "preference",
+   "id": 44,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 2 spaces as their tab width in Warp."
+  },
+  {
+   "category": "preference",
+   "id": 45,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers light mode as their color scheme in zsh."
+  },
+  {
+   "category": "preference",
+   "id": 46,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers JetBrains Mono as their font in tmux."
+  },
+  {
+   "category": "preference",
+   "id": 47,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 2 spaces as their tab width in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 48,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 12pt as their font size in bash."
+  },
+  {
+   "category": "preference",
+   "id": 49,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 16pt as their font size in Neovim."
+  },
+  {
+   "category": "preference",
+   "id": 50,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 13pt as their font size in kitty."
+  },
+  {
+   "category": "preference",
+   "id": 51,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers lazygit as their git GUI in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 52,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in alacritty."
+  },
+  {
+   "category": "preference",
+   "id": 53,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers CRLF as their line endings in Neovim."
+  },
+  {
+   "category": "preference",
+   "id": 54,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers gruvbox as their color scheme in PyCharm."
+  },
+  {
+   "category": "preference",
+   "id": 55,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 16pt as their font size in Vim."
+  },
+  {
+   "category": "preference",
+   "id": 56,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers high-contrast as their color scheme in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 57,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 4 spaces as their tab width in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 58,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tabs as their tab width in tmux."
+  },
+  {
+   "category": "preference",
+   "id": 59,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 15pt as their font size in Zed."
+  },
+  {
+   "category": "preference",
+   "id": 60,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 14pt as their font size in fish shell."
+  },
+  {
+   "category": "preference",
+   "id": 61,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers LF as their line endings in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 62,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in PyCharm."
+  },
+  {
+   "category": "preference",
+   "id": 63,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Fork as their git GUI in Warp."
+  },
+  {
+   "category": "preference",
+   "id": 64,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Source Code Pro as their font in Cursor."
+  },
+  {
+   "category": "preference",
+   "id": 65,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers GitKraken as their git GUI in Windsurf."
+  },
+  {
+   "category": "preference",
+   "id": 66,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Cascadia Code as their font in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 67,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tig as their git GUI in Windsurf."
+  },
+  {
+   "category": "preference",
+   "id": 68,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers light mode as their color scheme in Terminal.app."
+  },
+  {
+   "category": "preference",
+   "id": 69,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 2 spaces as their tab width in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 70,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers command line only as their git GUI in PyCharm."
+  },
+  {
+   "category": "preference",
+   "id": 71,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 14pt as their font size in Cursor."
+  },
+  {
+   "category": "preference",
+   "id": 72,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers never as their auto-format in Vim."
+  },
+  {
+   "category": "preference",
+   "id": 73,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 12pt as their font size in Warp."
+  },
+  {
+   "category": "preference",
+   "id": 74,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers never as their auto-format in kitty."
+  },
+  {
+   "category": "preference",
+   "id": 75,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers CRLF as their line endings in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 76,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 13pt as their font size in bash."
+  },
+  {
+   "category": "preference",
+   "id": 77,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Source Code Pro as their font in Warp."
+  },
+  {
+   "category": "preference",
+   "id": 78,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Iosevka as their font in Warp."
+  },
+  {
+   "category": "preference",
+   "id": 79,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 4 spaces as their tab width in zsh."
+  },
+  {
+   "category": "preference",
+   "id": 80,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers lazygit as their git GUI in fish shell."
+  },
+  {
+   "category": "preference",
+   "id": 81,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers solarized dark as their color scheme in bash."
+  },
+  {
+   "category": "preference",
+   "id": 82,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 4 spaces as their tab width in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 83,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers JetBrains Mono as their font in fish shell."
+  },
+  {
+   "category": "preference",
+   "id": 84,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers JetBrains Mono as their font in bash."
+  },
+  {
+   "category": "preference",
+   "id": 85,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Cascadia Code as their font in zsh."
+  },
+  {
+   "category": "preference",
+   "id": 86,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 2 spaces as their tab width in Vim."
+  },
+  {
+   "category": "preference",
+   "id": 87,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers on save as their auto-format in Emacs."
+  },
+  {
+   "category": "preference",
+   "id": 88,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers never as their auto-format in kitty."
+  },
+  {
+   "category": "preference",
+   "id": 89,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Fork as their git GUI in Emacs."
+  },
+  {
+   "category": "preference",
+   "id": 90,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers command line only as their git GUI in Zed."
+  },
+  {
+   "category": "preference",
+   "id": 91,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Source Code Pro as their font in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 92,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers CRLF as their line endings in Windsurf."
+  },
+  {
+   "category": "preference",
+   "id": 93,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in Terminal.app."
+  },
+  {
+   "category": "preference",
+   "id": 94,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tokyo night as their color scheme in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 95,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers dark mode as their color scheme in Terminal.app."
+  },
+  {
+   "category": "preference",
+   "id": 96,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers catppuccin as their color scheme in Sublime Text."
+  },
+  {
+   "category": "preference",
+   "id": 97,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Iosevka as their font in zsh."
+  },
+  {
+   "category": "preference",
+   "id": 98,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers lazygit as their git GUI in tmux."
+  },
+  {
+   "category": "preference",
+   "id": 99,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in Terminal.app."
+  },
+  {
+   "category": "preference",
+   "id": 100,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 14pt as their font size in Sublime Text."
+  },
+  {
+   "category": "preference",
+   "id": 101,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tokyo night as their color scheme in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 102,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 4 spaces as their tab width in VS Code."
+  },
+  {
+   "category": "preference",
+   "id": 103,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers high-contrast as their color scheme in zsh."
+  },
+  {
+   "category": "preference",
+   "id": 104,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Hack as their font in fish shell."
+  },
+  {
+   "category": "preference",
+   "id": 105,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers LF as their line endings in Zed."
+  },
+  {
+   "category": "preference",
+   "id": 106,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in Cursor."
+  },
+  {
+   "category": "preference",
+   "id": 107,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Source Code Pro as their font in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 108,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers light mode as their color scheme in Sublime Text."
+  },
+  {
+   "category": "preference",
+   "id": 109,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers CRLF as their line endings in Windsurf."
+  },
+  {
+   "category": "preference",
+   "id": 110,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers LF as their line endings in kitty."
+  },
+  {
+   "category": "preference",
+   "id": 111,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers CRLF as their line endings in Vim."
+  },
+  {
+   "category": "preference",
+   "id": 112,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers command line only as their git GUI in Neovim."
+  },
+  {
+   "category": "preference",
+   "id": 113,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tokyo night as their color scheme in Cursor."
+  },
+  {
+   "category": "preference",
+   "id": 114,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in Cursor."
+  },
+  {
+   "category": "preference",
+   "id": 115,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers light mode as their color scheme in Warp."
+  },
+  {
+   "category": "preference",
+   "id": 116,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 4 spaces as their tab width in Vim."
+  },
+  {
+   "category": "preference",
+   "id": 117,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Fork as their git GUI in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 118,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Hack as their font in PyCharm."
+  },
+  {
+   "category": "preference",
+   "id": 119,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers nord as their color scheme in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 120,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 2 spaces as their tab width in kitty."
+  },
+  {
+   "category": "preference",
+   "id": 121,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 12pt as their font size in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 122,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Cascadia Code as their font in Zed."
+  },
+  {
+   "category": "preference",
+   "id": 123,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Fork as their git GUI in Vim."
+  },
+  {
+   "category": "preference",
+   "id": 124,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tabs as their tab width in Zed."
+  },
+  {
+   "category": "preference",
+   "id": 125,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Fork as their git GUI in VS Code."
+  },
+  {
+   "category": "preference",
+   "id": 126,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers solarized dark as their color scheme in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 127,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers gruvbox as their color scheme in Zed."
+  },
+  {
+   "category": "preference",
+   "id": 128,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tabs as their tab width in VS Code."
+  },
+  {
+   "category": "preference",
+   "id": 129,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Source Code Pro as their font in zsh."
+  },
+  {
+   "category": "preference",
+   "id": 130,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers JetBrains Mono as their font in bash."
+  },
+  {
+   "category": "preference",
+   "id": 131,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 132,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers never as their auto-format in Windsurf."
+  },
+  {
+   "category": "preference",
+   "id": 133,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 16pt as their font size in Terminal.app."
+  },
+  {
+   "category": "preference",
+   "id": 134,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 2 spaces as their tab width in zsh."
+  },
+  {
+   "category": "preference",
+   "id": 135,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tabs as their tab width in Windsurf."
+  },
+  {
+   "category": "preference",
+   "id": 136,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers LF as their line endings in Neovim."
+  },
+  {
+   "category": "preference",
+   "id": 137,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 4 spaces as their tab width in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 138,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers on save as their auto-format in fish shell."
+  },
+  {
+   "category": "preference",
+   "id": 139,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers nord as their color scheme in Terminal.app."
+  },
+  {
+   "category": "preference",
+   "id": 140,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers nord as their color scheme in kitty."
+  },
+  {
+   "category": "preference",
+   "id": 141,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers JetBrains Mono as their font in bash."
+  },
+  {
+   "category": "preference",
+   "id": 142,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers never as their auto-format in bash."
+  },
+  {
+   "category": "preference",
+   "id": 143,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers on save as their auto-format in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 144,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Cascadia Code as their font in Zed."
+  },
+  {
+   "category": "preference",
+   "id": 145,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers JetBrains Mono as their font in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 146,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 16pt as their font size in Terminal.app."
+  },
+  {
+   "category": "preference",
+   "id": 147,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers on save as their auto-format in Neovim."
+  },
+  {
+   "category": "preference",
+   "id": 148,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers GitKraken as their git GUI in Windsurf."
+  },
+  {
+   "category": "preference",
+   "id": 149,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Hack as their font in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 150,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers lazygit as their git GUI in Cursor."
+  },
+  {
+   "category": "preference",
+   "id": 151,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers LF as their line endings in Hyper."
+  },
+  {
+   "category": "preference",
+   "id": 152,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers lazygit as their git GUI in Sublime Text."
+  },
+  {
+   "category": "preference",
+   "id": 153,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers GitKraken as their git GUI in Warp."
+  },
+  {
+   "category": "preference",
+   "id": 154,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers on save as their auto-format in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 155,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Cascadia Code as their font in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 156,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 4 spaces as their tab width in fish shell."
+  },
+  {
+   "category": "preference",
+   "id": 157,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers gruvbox as their color scheme in Sublime Text."
+  },
+  {
+   "category": "preference",
+   "id": 158,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 13pt as their font size in bash."
+  },
+  {
+   "category": "preference",
+   "id": 159,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers CRLF as their line endings in VS Code."
+  },
+  {
+   "category": "preference",
+   "id": 160,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers nord as their color scheme in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 161,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Fork as their git GUI in Warp."
+  },
+  {
+   "category": "preference",
+   "id": 162,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tig as their git GUI in kitty."
+  },
+  {
+   "category": "preference",
+   "id": 163,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers solarized dark as their color scheme in Zed."
+  },
+  {
+   "category": "preference",
+   "id": 164,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 12pt as their font size in bash."
+  },
+  {
+   "category": "preference",
+   "id": 165,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers LF as their line endings in Terminal.app."
+  },
+  {
+   "category": "preference",
+   "id": 166,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Source Code Pro as their font in Emacs."
+  },
+  {
+   "category": "preference",
+   "id": 167,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers LF as their line endings in alacritty."
+  },
+  {
+   "category": "preference",
+   "id": 168,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers on save as their auto-format in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 169,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers lazygit as their git GUI in Windsurf."
+  },
+  {
+   "category": "preference",
+   "id": 170,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 16pt as their font size in tmux."
+  },
+  {
+   "category": "preference",
+   "id": 171,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers light mode as their color scheme in Cursor."
+  },
+  {
+   "category": "preference",
+   "id": 172,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 15pt as their font size in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 173,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in Windsurf."
+  },
+  {
+   "category": "preference",
+   "id": 174,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 4 spaces as their tab width in VS Code."
+  },
+  {
+   "category": "preference",
+   "id": 175,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in kitty."
+  },
+  {
+   "category": "preference",
+   "id": 176,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers CRLF as their line endings in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 177,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tokyo night as their color scheme in tmux."
+  },
+  {
+   "category": "preference",
+   "id": 178,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Source Code Pro as their font in Warp."
+  },
+  {
+   "category": "preference",
+   "id": 179,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tabs as their tab width in PyCharm."
+  },
+  {
+   "category": "preference",
+   "id": 180,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers on save as their auto-format in PyCharm."
+  },
+  {
+   "category": "preference",
+   "id": 181,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers lazygit as their git GUI in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 182,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers on save as their auto-format in VS Code."
+  },
+  {
+   "category": "preference",
+   "id": 183,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers never as their auto-format in Warp."
+  },
+  {
+   "category": "preference",
+   "id": 184,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 15pt as their font size in Emacs."
+  },
+  {
+   "category": "preference",
+   "id": 185,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in Vim."
+  },
+  {
+   "category": "preference",
+   "id": 186,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tabs as their tab width in Sublime Text."
+  },
+  {
+   "category": "preference",
+   "id": 187,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 15pt as their font size in Emacs."
+  },
+  {
+   "category": "preference",
+   "id": 188,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers GitKraken as their git GUI in Neovim."
+  },
+  {
+   "category": "preference",
+   "id": 189,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 12pt as their font size in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 190,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers never as their auto-format in VS Code."
+  },
+  {
+   "category": "preference",
+   "id": 191,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 12pt as their font size in zsh."
+  },
+  {
+   "category": "preference",
+   "id": 192,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers manually only as their auto-format in alacritty."
+  },
+  {
+   "category": "preference",
+   "id": 193,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers LF as their line endings in IntelliJ."
+  },
+  {
+   "category": "preference",
+   "id": 194,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers gruvbox as their color scheme in PyCharm."
+  },
+  {
+   "category": "preference",
+   "id": 195,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers Source Code Pro as their font in Vim."
+  },
+  {
+   "category": "preference",
+   "id": 196,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers 16pt as their font size in VS Code."
+  },
+  {
+   "category": "preference",
+   "id": 197,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers tabs as their tab width in VS Code."
+  },
+  {
+   "category": "preference",
+   "id": 198,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers lazygit as their git GUI in Emacs."
+  },
+  {
+   "category": "preference",
+   "id": 199,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers JetBrains Mono as their font in iTerm2."
+  },
+  {
+   "category": "preference",
+   "id": 200,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The user prefers on save as their auto-format in bash."
+  },
+  {
+   "category": "project",
+   "id": 201,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project nexus supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 202,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project beacon targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 203,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project prism launches in September 2027."
+  },
+  {
+   "category": "project",
+   "id": 204,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project atlas uses Kafka for event streaming."
+  },
+  {
+   "category": "project",
+   "id": 205,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 206,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project lattice uses TypeScript for the client."
+  },
+  {
+   "category": "project",
+   "id": 207,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge launches in March 2026."
+  },
+  {
+   "category": "project",
+   "id": 208,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project tundra uses Python for data pipelines."
+  },
+  {
+   "category": "project",
+   "id": 209,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project monolith uses FastAPI for the API layer."
+  },
+  {
+   "category": "project",
+   "id": 210,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge supports 42 locales."
+  },
+  {
+   "category": "project",
+   "id": 211,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project harbor targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 212,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project tundra supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 213,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit uses Tailwind for styling."
+  },
+  {
+   "category": "project",
+   "id": 214,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project kestrel targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 215,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project summit uses Kubernetes for orchestration."
+  },
+  {
+   "category": "project",
+   "id": 216,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project kestrel uses TypeScript for the client."
+  },
+  {
+   "category": "project",
+   "id": 217,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project delta launches in June 2026."
+  },
+  {
+   "category": "project",
+   "id": 218,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project nexus supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 219,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project kestrel supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 220,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project monolith launches in September 2027."
+  },
+  {
+   "category": "project",
+   "id": 221,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo uses Tailwind for styling."
+  },
+  {
+   "category": "project",
+   "id": 222,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge launches in September 2026."
+  },
+  {
+   "category": "project",
+   "id": 223,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project atlas launches in September 2026."
+  },
+  {
+   "category": "project",
+   "id": 224,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit supports 5 locales."
+  },
+  {
+   "category": "project",
+   "id": 225,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project prism launches in September 2026."
+  },
+  {
+   "category": "project",
+   "id": 226,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project nexus uses Go for the orchestrator."
+  },
+  {
+   "category": "project",
+   "id": 227,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project quartz launches in September 2027."
+  },
+  {
+   "category": "project",
+   "id": 228,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project delta uses Rust for performance-critical paths."
+  },
+  {
+   "category": "project",
+   "id": 229,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project fjord supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 230,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project beacon uses Tailwind for styling."
+  },
+  {
+   "category": "project",
+   "id": 231,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project nexus uses Python for data pipelines."
+  },
+  {
+   "category": "project",
+   "id": 232,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project junction launches in November 2027."
+  },
+  {
+   "category": "project",
+   "id": 233,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo uses Tailwind for styling."
+  },
+  {
+   "category": "project",
+   "id": 234,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project glacier uses Next.js for server-side rendering."
+  },
+  {
+   "category": "project",
+   "id": 235,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project monolith targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 236,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project nexus supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 237,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project quartz uses Grafana for dashboards."
+  },
+  {
+   "category": "project",
+   "id": 238,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project monolith launches in March 2027."
+  },
+  {
+   "category": "project",
+   "id": 239,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project summit targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 240,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project delta supports 5 locales."
+  },
+  {
+   "category": "project",
+   "id": 241,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project iris launches in September 2026."
+  },
+  {
+   "category": "project",
+   "id": 242,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project glacier uses Sentry for error tracking."
+  },
+  {
+   "category": "project",
+   "id": 243,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project kestrel targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 244,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project fjord supports 27 locales."
+  },
+  {
+   "category": "project",
+   "id": 245,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit launches in November 2027."
+  },
+  {
+   "category": "project",
+   "id": 246,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project iris targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 247,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit supports 42 locales."
+  },
+  {
+   "category": "project",
+   "id": 248,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 249,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project fjord supports 5 locales."
+  },
+  {
+   "category": "project",
+   "id": 250,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project monolith uses React for the frontend."
+  },
+  {
+   "category": "project",
+   "id": 251,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project prism supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 252,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project atlas targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 253,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project fjord launches in November 2027."
+  },
+  {
+   "category": "project",
+   "id": 254,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project iris supports 27 locales."
+  },
+  {
+   "category": "project",
+   "id": 255,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project junction uses Rust for performance-critical paths."
+  },
+  {
+   "category": "project",
+   "id": 256,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project quartz uses Rust for performance-critical paths."
+  },
+  {
+   "category": "project",
+   "id": 257,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project monolith supports 5 locales."
+  },
+  {
+   "category": "project",
+   "id": 258,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 259,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge uses Prometheus for metrics."
+  },
+  {
+   "category": "project",
+   "id": 260,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge launches in March 2026."
+  },
+  {
+   "category": "project",
+   "id": 261,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project prism supports 42 locales."
+  },
+  {
+   "category": "project",
+   "id": 262,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project iris launches in June 2027."
+  },
+  {
+   "category": "project",
+   "id": 263,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project delta uses Docker for containerization."
+  },
+  {
+   "category": "project",
+   "id": 264,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project harbor launches in March 2027."
+  },
+  {
+   "category": "project",
+   "id": 265,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project harbor launches in November 2026."
+  },
+  {
+   "category": "project",
+   "id": 266,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project quartz targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 267,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge uses Kafka for event streaming."
+  },
+  {
+   "category": "project",
+   "id": 268,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project monolith supports 42 locales."
+  },
+  {
+   "category": "project",
+   "id": 269,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo supports 42 locales."
+  },
+  {
+   "category": "project",
+   "id": 270,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 271,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project kestrel uses React for the frontend."
+  },
+  {
+   "category": "project",
+   "id": 272,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo launches in September 2026."
+  },
+  {
+   "category": "project",
+   "id": 273,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project quartz targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 274,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project beacon supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 275,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project quartz launches in September 2026."
+  },
+  {
+   "category": "project",
+   "id": 276,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit supports 5 locales."
+  },
+  {
+   "category": "project",
+   "id": 277,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo launches in March 2026."
+  },
+  {
+   "category": "project",
+   "id": 278,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project kestrel uses Kafka for event streaming."
+  },
+  {
+   "category": "project",
+   "id": 279,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project summit targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 280,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project fjord launches in November 2027."
+  },
+  {
+   "category": "project",
+   "id": 281,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge supports 27 locales."
+  },
+  {
+   "category": "project",
+   "id": 282,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project delta launches in March 2027."
+  },
+  {
+   "category": "project",
+   "id": 283,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project lattice supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 284,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project delta supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 285,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project tundra supports 42 locales."
+  },
+  {
+   "category": "project",
+   "id": 286,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project atlas targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 287,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project summit targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 288,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project beacon launches in March 2027."
+  },
+  {
+   "category": "project",
+   "id": 289,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge uses PostgreSQL for primary storage."
+  },
+  {
+   "category": "project",
+   "id": 290,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project glacier supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 291,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project junction launches in March 2026."
+  },
+  {
+   "category": "project",
+   "id": 292,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project nexus supports 5 locales."
+  },
+  {
+   "category": "project",
+   "id": 293,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project beacon targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 294,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit targets 10,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 295,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass launches in September 2026."
+  },
+  {
+   "category": "project",
+   "id": 296,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project atlas targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 297,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project lattice launches in June 2027."
+  },
+  {
+   "category": "project",
+   "id": 298,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project harbor targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 299,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 300,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project iris supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 301,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project glacier supports 27 locales."
+  },
+  {
+   "category": "project",
+   "id": 302,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project beacon supports 42 locales."
+  },
+  {
+   "category": "project",
+   "id": 303,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo uses PostgreSQL for primary storage."
+  },
+  {
+   "category": "project",
+   "id": 304,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 305,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass launches in November 2026."
+  },
+  {
+   "category": "project",
+   "id": 306,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 307,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit uses PostgreSQL for primary storage."
+  },
+  {
+   "category": "project",
+   "id": 308,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project fjord targets 10,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 309,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project monolith supports 5 locales."
+  },
+  {
+   "category": "project",
+   "id": 310,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass launches in November 2026."
+  },
+  {
+   "category": "project",
+   "id": 311,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project harbor launches in November 2026."
+  },
+  {
+   "category": "project",
+   "id": 312,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project atlas supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 313,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project prism supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 314,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo uses Go for the orchestrator."
+  },
+  {
+   "category": "project",
+   "id": 315,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 316,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project quartz supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 317,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge launches in March 2027."
+  },
+  {
+   "category": "project",
+   "id": 318,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 319,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 320,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project beacon supports 42 locales."
+  },
+  {
+   "category": "project",
+   "id": 321,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge launches in September 2026."
+  },
+  {
+   "category": "project",
+   "id": 322,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project nexus uses Kafka for event streaming."
+  },
+  {
+   "category": "project",
+   "id": 323,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project fjord targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 324,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project quartz targets 10,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 325,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 326,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project delta targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 327,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project delta supports 42 locales."
+  },
+  {
+   "category": "project",
+   "id": 328,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project atlas launches in November 2027."
+  },
+  {
+   "category": "project",
+   "id": 329,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project summit supports 27 locales."
+  },
+  {
+   "category": "project",
+   "id": 330,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project tundra targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 331,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project nexus targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 332,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project summit launches in June 2027."
+  },
+  {
+   "category": "project",
+   "id": 333,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project fjord supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 334,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass launches in March 2027."
+  },
+  {
+   "category": "project",
+   "id": 335,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project junction supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 336,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 337,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project beacon uses Rust for performance-critical paths."
+  },
+  {
+   "category": "project",
+   "id": 338,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass launches in November 2027."
+  },
+  {
+   "category": "project",
+   "id": 339,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project prism launches in September 2026."
+  },
+  {
+   "category": "project",
+   "id": 340,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 341,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass launches in September 2026."
+  },
+  {
+   "category": "project",
+   "id": 342,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project quartz targets 10,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 343,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project iris targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 344,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge launches in June 2026."
+  },
+  {
+   "category": "project",
+   "id": 345,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo launches in November 2026."
+  },
+  {
+   "category": "project",
+   "id": 346,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project junction targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 347,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass launches in March 2027."
+  },
+  {
+   "category": "project",
+   "id": 348,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project delta supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 349,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project fjord targets 10,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 350,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project fjord uses S3 for object storage."
+  },
+  {
+   "category": "project",
+   "id": 351,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project iris targets 10,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 352,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project atlas supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 353,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project glacier supports 12 locales."
+  },
+  {
+   "category": "project",
+   "id": 354,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass launches in September 2026."
+  },
+  {
+   "category": "project",
+   "id": 355,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project lattice uses PostgreSQL for primary storage."
+  },
+  {
+   "category": "project",
+   "id": 356,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project nexus uses TypeScript for the client."
+  },
+  {
+   "category": "project",
+   "id": 357,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project prism uses OpenTelemetry for tracing."
+  },
+  {
+   "category": "project",
+   "id": 358,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project beacon supports 27 locales."
+  },
+  {
+   "category": "project",
+   "id": 359,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project summit targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 360,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project kestrel launches in November 2026."
+  },
+  {
+   "category": "project",
+   "id": 361,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge uses ClickHouse for analytics."
+  },
+  {
+   "category": "project",
+   "id": 362,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit uses Tailwind for styling."
+  },
+  {
+   "category": "project",
+   "id": 363,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project atlas targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 364,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project tundra supports 27 locales."
+  },
+  {
+   "category": "project",
+   "id": 365,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project nexus supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 366,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project prism launches in June 2027."
+  },
+  {
+   "category": "project",
+   "id": 367,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project beacon uses Docker for containerization."
+  },
+  {
+   "category": "project",
+   "id": 368,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge uses OpenTelemetry for tracing."
+  },
+  {
+   "category": "project",
+   "id": 369,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project junction uses OpenTelemetry for tracing."
+  },
+  {
+   "category": "project",
+   "id": 370,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project kestrel launches in November 2027."
+  },
+  {
+   "category": "project",
+   "id": 371,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project beacon supports 5 locales."
+  },
+  {
+   "category": "project",
+   "id": 372,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project monolith targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 373,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project atlas launches in November 2027."
+  },
+  {
+   "category": "project",
+   "id": 374,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project delta targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 375,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit uses Prometheus for metrics."
+  },
+  {
+   "category": "project",
+   "id": 376,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project junction targets 1,000,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 377,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 378,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass uses Kafka for event streaming."
+  },
+  {
+   "category": "project",
+   "id": 379,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo launches in November 2027."
+  },
+  {
+   "category": "project",
+   "id": 380,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 381,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project ridge supports 27 locales."
+  },
+  {
+   "category": "project",
+   "id": 382,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project nexus targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 383,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project summit launches in September 2026."
+  },
+  {
+   "category": "project",
+   "id": 384,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project tundra uses S3 for object storage."
+  },
+  {
+   "category": "project",
+   "id": 385,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project glacier targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 386,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project kestrel uses Tailwind for styling."
+  },
+  {
+   "category": "project",
+   "id": 387,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project prism supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 388,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project prism targets 100,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 389,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project echo targets 1,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 390,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project iris supports 3 locales."
+  },
+  {
+   "category": "project",
+   "id": 391,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project harbor targets 10,000 monthly active users."
+  },
+  {
+   "category": "project",
+   "id": 392,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project harbor uses S3 for object storage."
+  },
+  {
+   "category": "project",
+   "id": 393,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project kestrel uses Grafana for dashboards."
+  },
+  {
+   "category": "project",
+   "id": 394,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project kestrel uses Elasticsearch for search."
+  },
+  {
+   "category": "project",
+   "id": 395,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit uses Sentry for error tracking."
+  },
+  {
+   "category": "project",
+   "id": 396,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project compass uses Elasticsearch for search."
+  },
+  {
+   "category": "project",
+   "id": 397,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project orbit supports 42 locales."
+  },
+  {
+   "category": "project",
+   "id": 398,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project fjord uses ClickHouse for analytics."
+  },
+  {
+   "category": "project",
+   "id": 399,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project junction launches in September 2027."
+  },
+  {
+   "category": "project",
+   "id": 400,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Project kestrel targets 100,000 monthly active users."
+  },
+  {
+   "category": "person",
+   "id": 401,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ivy owns the infra surface."
+  },
+  {
+   "category": "person",
+   "id": 402,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Taylor reports to Carol."
+  },
+  {
+   "category": "person",
+   "id": 403,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Liam owns the ingest surface."
+  },
+  {
+   "category": "person",
+   "id": 404,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Sam reports to Grace."
+  },
+  {
+   "category": "person",
+   "id": 405,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Bob reports to Grace."
+  },
+  {
+   "category": "person",
+   "id": 406,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley owns the dashboard surface."
+  },
+  {
+   "category": "person",
+   "id": 407,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Bob reports to Jack."
+  },
+  {
+   "category": "person",
+   "id": 408,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave owns the billing surface."
+  },
+  {
+   "category": "person",
+   "id": 409,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Grace prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 410,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave owns the billing surface."
+  },
+  {
+   "category": "person",
+   "id": 411,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley is on PTO from Thursday to Thursday."
+  },
+  {
+   "category": "person",
+   "id": 412,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Pat prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 413,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave owns the infra surface."
+  },
+  {
+   "category": "person",
+   "id": 414,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "category": "person",
+   "id": 415,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia owns the billing surface."
+  },
+  {
+   "category": "person",
+   "id": 416,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Quinn prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 417,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Liam prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 418,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia owns the dashboard surface."
+  },
+  {
+   "category": "person",
+   "id": 419,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Carol is the QA lead on the junction team."
+  },
+  {
+   "category": "person",
+   "id": 420,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Noah reports to Taylor."
+  },
+  {
+   "category": "person",
+   "id": 421,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley is on PTO from Tuesday to Thursday."
+  },
+  {
+   "category": "person",
+   "id": 422,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley is the QA lead on the compass team."
+  },
+  {
+   "category": "person",
+   "id": 423,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Pat is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "category": "person",
+   "id": 424,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Eve owns the API surface."
+  },
+  {
+   "category": "person",
+   "id": 425,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "category": "person",
+   "id": 426,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Noah owns the auth surface."
+  },
+  {
+   "category": "person",
+   "id": 427,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank reports to Bob."
+  },
+  {
+   "category": "person",
+   "id": 428,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia reports to Kate."
+  },
+  {
+   "category": "person",
+   "id": 429,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Mia reports to Alice."
+  },
+  {
+   "category": "person",
+   "id": 430,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Eve prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 431,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave is the tech lead on the iris team."
+  },
+  {
+   "category": "person",
+   "id": 432,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Grace owns the auth surface."
+  },
+  {
+   "category": "person",
+   "id": 433,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Noah prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 434,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Noah is the tech lead on the tundra team."
+  },
+  {
+   "category": "person",
+   "id": 435,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Henry is the designer on the lattice team."
+  },
+  {
+   "category": "person",
+   "id": 436,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Mia reports to Bob."
+  },
+  {
+   "category": "person",
+   "id": 437,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Noah owns the dashboard surface."
+  },
+  {
+   "category": "person",
+   "id": 438,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Jack owns the deploy surface."
+  },
+  {
+   "category": "person",
+   "id": 439,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave reports to Noah."
+  },
+  {
+   "category": "person",
+   "id": 440,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ivy is the designer on the echo team."
+  },
+  {
+   "category": "person",
+   "id": 441,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Kate owns the billing surface."
+  },
+  {
+   "category": "person",
+   "id": 442,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Eve is the principal engineer on the junction team."
+  },
+  {
+   "category": "person",
+   "id": 443,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ivy is the QA lead on the fjord team."
+  },
+  {
+   "category": "person",
+   "id": 444,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Bob is on PTO from Wednesday to Friday."
+  },
+  {
+   "category": "person",
+   "id": 445,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 446,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank is on PTO from Tuesday to Monday."
+  },
+  {
+   "category": "person",
+   "id": 447,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Henry reports to Liam."
+  },
+  {
+   "category": "person",
+   "id": 448,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Henry is on PTO from Friday to Friday."
+  },
+  {
+   "category": "person",
+   "id": 449,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley is on PTO from Tuesday to Monday."
+  },
+  {
+   "category": "person",
+   "id": 450,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Mia prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 451,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Quinn is the staff engineer on the summit team."
+  },
+  {
+   "category": "person",
+   "id": 452,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ivy prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 453,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Pat owns the API surface."
+  },
+  {
+   "category": "person",
+   "id": 454,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Pat reports to Riley."
+  },
+  {
+   "category": "person",
+   "id": 455,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Sam owns the ingest surface."
+  },
+  {
+   "category": "person",
+   "id": 456,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Liam is on PTO from Thursday to Monday."
+  },
+  {
+   "category": "person",
+   "id": 457,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank is on PTO from Thursday to Wednesday."
+  },
+  {
+   "category": "person",
+   "id": 458,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Alice prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 459,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Eve reports to Ivy."
+  },
+  {
+   "category": "person",
+   "id": 460,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Bob reports to Dave."
+  },
+  {
+   "category": "person",
+   "id": 461,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Kate is the PM on the glacier team."
+  },
+  {
+   "category": "person",
+   "id": 462,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Grace prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 463,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Taylor reports to Sam."
+  },
+  {
+   "category": "person",
+   "id": 464,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ivy is the staff engineer on the kestrel team."
+  },
+  {
+   "category": "person",
+   "id": 465,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank is on PTO from Wednesday to Friday."
+  },
+  {
+   "category": "person",
+   "id": 466,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Bob owns the deploy surface."
+  },
+  {
+   "category": "person",
+   "id": 467,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Noah reports to Jack."
+  },
+  {
+   "category": "person",
+   "id": 468,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Kate is on PTO from Wednesday to Friday."
+  },
+  {
+   "category": "person",
+   "id": 469,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley owns the dashboard surface."
+  },
+  {
+   "category": "person",
+   "id": 470,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Pat is the staff engineer on the prism team."
+  },
+  {
+   "category": "person",
+   "id": 471,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave reports to Eve."
+  },
+  {
+   "category": "person",
+   "id": 472,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Liam is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "category": "person",
+   "id": 473,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Taylor reports to Carol."
+  },
+  {
+   "category": "person",
+   "id": 474,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Quinn is the tech lead on the atlas team."
+  },
+  {
+   "category": "person",
+   "id": 475,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley owns the billing surface."
+  },
+  {
+   "category": "person",
+   "id": 476,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave is on PTO from Monday to Tuesday."
+  },
+  {
+   "category": "person",
+   "id": 477,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank is the principal engineer on the delta team."
+  },
+  {
+   "category": "person",
+   "id": 478,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Henry reports to Alice."
+  },
+  {
+   "category": "person",
+   "id": 479,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank reports to Jack."
+  },
+  {
+   "category": "person",
+   "id": 480,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Alice is the engineering manager on the glacier team."
+  },
+  {
+   "category": "person",
+   "id": 481,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Eve is on PTO from Thursday to Tuesday."
+  },
+  {
+   "category": "person",
+   "id": 482,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Mia owns the billing surface."
+  },
+  {
+   "category": "person",
+   "id": 483,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Carol is the senior engineer on the junction team."
+  },
+  {
+   "category": "person",
+   "id": 484,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Quinn reports to Bob."
+  },
+  {
+   "category": "person",
+   "id": 485,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Jack reports to Riley."
+  },
+  {
+   "category": "person",
+   "id": 486,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Quinn is on PTO from Tuesday to Monday."
+  },
+  {
+   "category": "person",
+   "id": 487,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Quinn prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 488,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia reports to Sam."
+  },
+  {
+   "category": "person",
+   "id": 489,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 490,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Eve owns the deploy surface."
+  },
+  {
+   "category": "person",
+   "id": 491,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Liam is the senior engineer on the monolith team."
+  },
+  {
+   "category": "person",
+   "id": 492,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ivy is the engineering manager on the monolith team."
+  },
+  {
+   "category": "person",
+   "id": 493,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Grace owns the API surface."
+  },
+  {
+   "category": "person",
+   "id": 494,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Carol owns the ingest surface."
+  },
+  {
+   "category": "person",
+   "id": 495,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Alice reports to Taylor."
+  },
+  {
+   "category": "person",
+   "id": 496,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Eve reports to Grace."
+  },
+  {
+   "category": "person",
+   "id": 497,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Carol prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 498,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Sam is the QA lead on the glacier team."
+  },
+  {
+   "category": "person",
+   "id": 499,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Alice owns the API surface."
+  },
+  {
+   "category": "person",
+   "id": 500,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Mia prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 501,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Eve reports to Henry."
+  },
+  {
+   "category": "person",
+   "id": 502,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia reports to Taylor."
+  },
+  {
+   "category": "person",
+   "id": 503,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Pat is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "category": "person",
+   "id": 504,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Grace is on PTO from Thursday to Monday."
+  },
+  {
+   "category": "person",
+   "id": 505,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave reports to Liam."
+  },
+  {
+   "category": "person",
+   "id": 506,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Henry owns the auth surface."
+  },
+  {
+   "category": "person",
+   "id": 507,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Bob is the engineering manager on the fjord team."
+  },
+  {
+   "category": "person",
+   "id": 508,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Taylor reports to Jack."
+  },
+  {
+   "category": "person",
+   "id": 509,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Jack is the engineering manager on the quartz team."
+  },
+  {
+   "category": "person",
+   "id": 510,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Taylor is the engineering manager on the beacon team."
+  },
+  {
+   "category": "person",
+   "id": 511,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave reports to Grace."
+  },
+  {
+   "category": "person",
+   "id": 512,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Grace is on PTO from Thursday to Thursday."
+  },
+  {
+   "category": "person",
+   "id": 513,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Bob owns the API surface."
+  },
+  {
+   "category": "person",
+   "id": 514,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Pat owns the search surface."
+  },
+  {
+   "category": "person",
+   "id": 515,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Taylor reports to Sam."
+  },
+  {
+   "category": "person",
+   "id": 516,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Mia reports to Eve."
+  },
+  {
+   "category": "person",
+   "id": 517,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Carol owns the search surface."
+  },
+  {
+   "category": "person",
+   "id": 518,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Carol reports to Ivy."
+  },
+  {
+   "category": "person",
+   "id": 519,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia is the principal engineer on the tundra team."
+  },
+  {
+   "category": "person",
+   "id": 520,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Kate is on PTO from Thursday to Tuesday."
+  },
+  {
+   "category": "person",
+   "id": 521,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Henry owns the API surface."
+  },
+  {
+   "category": "person",
+   "id": 522,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Pat prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 523,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave owns the dashboard surface."
+  },
+  {
+   "category": "person",
+   "id": 524,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 525,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave is the tech lead on the compass team."
+  },
+  {
+   "category": "person",
+   "id": 526,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Jack is the designer on the kestrel team."
+  },
+  {
+   "category": "person",
+   "id": 527,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Jack is on PTO from Monday to Thursday."
+  },
+  {
+   "category": "person",
+   "id": 528,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Grace is the PM on the lattice team."
+  },
+  {
+   "category": "person",
+   "id": 529,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Noah owns the infra surface."
+  },
+  {
+   "category": "person",
+   "id": 530,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Kate reports to Pat."
+  },
+  {
+   "category": "person",
+   "id": 531,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Sam is the engineering manager on the summit team."
+  },
+  {
+   "category": "person",
+   "id": 532,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia reports to Jack."
+  },
+  {
+   "category": "person",
+   "id": 533,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Taylor is on PTO from Thursday to Thursday."
+  },
+  {
+   "category": "person",
+   "id": 534,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank is the staff engineer on the nexus team."
+  },
+  {
+   "category": "person",
+   "id": 535,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 536,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia reports to Liam."
+  },
+  {
+   "category": "person",
+   "id": 537,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Kate reports to Pat."
+  },
+  {
+   "category": "person",
+   "id": 538,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Quinn reports to Eve."
+  },
+  {
+   "category": "person",
+   "id": 539,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave owns the dashboard surface."
+  },
+  {
+   "category": "person",
+   "id": 540,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Eve prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 541,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 542,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Jack prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 543,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Sam is on PTO from Tuesday to Thursday."
+  },
+  {
+   "category": "person",
+   "id": 544,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 545,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Liam is on PTO from Tuesday to Thursday."
+  },
+  {
+   "category": "person",
+   "id": 546,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Mia prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 547,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Henry prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 548,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley is on PTO from Thursday to Tuesday."
+  },
+  {
+   "category": "person",
+   "id": 549,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Liam prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 550,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Quinn owns the billing surface."
+  },
+  {
+   "category": "person",
+   "id": 551,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Jack is the engineering manager on the ridge team."
+  },
+  {
+   "category": "person",
+   "id": 552,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ivy is on PTO from Wednesday to Monday."
+  },
+  {
+   "category": "person",
+   "id": 553,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley reports to Pat."
+  },
+  {
+   "category": "person",
+   "id": 554,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank is the staff engineer on the atlas team."
+  },
+  {
+   "category": "person",
+   "id": 555,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Sam is on PTO from Friday to Friday."
+  },
+  {
+   "category": "person",
+   "id": 556,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank is the PM on the prism team."
+  },
+  {
+   "category": "person",
+   "id": 557,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia is the principal engineer on the ridge team."
+  },
+  {
+   "category": "person",
+   "id": 558,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Liam reports to Mia."
+  },
+  {
+   "category": "person",
+   "id": 559,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank reports to Carol."
+  },
+  {
+   "category": "person",
+   "id": 560,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Liam is the QA lead on the monolith team."
+  },
+  {
+   "category": "person",
+   "id": 561,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Pat reports to Olivia."
+  },
+  {
+   "category": "person",
+   "id": 562,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Taylor is the tech lead on the lattice team."
+  },
+  {
+   "category": "person",
+   "id": 563,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave is on PTO from Wednesday to Thursday."
+  },
+  {
+   "category": "person",
+   "id": 564,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Grace owns the dashboard surface."
+  },
+  {
+   "category": "person",
+   "id": 565,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Mia owns the auth surface."
+  },
+  {
+   "category": "person",
+   "id": 566,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Taylor owns the deploy surface."
+  },
+  {
+   "category": "person",
+   "id": 567,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Sam is on PTO from Monday to Friday."
+  },
+  {
+   "category": "person",
+   "id": 568,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Henry is the senior engineer on the lattice team."
+  },
+  {
+   "category": "person",
+   "id": 569,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Pat is the engineering manager on the compass team."
+  },
+  {
+   "category": "person",
+   "id": 570,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Carol prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 571,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Eve owns the ingest surface."
+  },
+  {
+   "category": "person",
+   "id": 572,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Quinn is on PTO from Wednesday to Monday."
+  },
+  {
+   "category": "person",
+   "id": 573,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Carol is the senior engineer on the kestrel team."
+  },
+  {
+   "category": "person",
+   "id": 574,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley is on PTO from Wednesday to Monday."
+  },
+  {
+   "category": "person",
+   "id": 575,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Bob is on PTO from Monday to Friday."
+  },
+  {
+   "category": "person",
+   "id": 576,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Liam prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 577,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Jack owns the deploy surface."
+  },
+  {
+   "category": "person",
+   "id": 578,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley is the engineering manager on the iris team."
+  },
+  {
+   "category": "person",
+   "id": 579,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Riley reports to Sam."
+  },
+  {
+   "category": "person",
+   "id": 580,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Sam prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 581,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave is on PTO from Tuesday to Thursday."
+  },
+  {
+   "category": "person",
+   "id": 582,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Noah reports to Dave."
+  },
+  {
+   "category": "person",
+   "id": 583,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Eve reports to Jack."
+  },
+  {
+   "category": "person",
+   "id": 584,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Carol reports to Sam."
+  },
+  {
+   "category": "person",
+   "id": 585,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia is the staff engineer on the atlas team."
+  },
+  {
+   "category": "person",
+   "id": 586,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Carol reports to Mia."
+  },
+  {
+   "category": "person",
+   "id": 587,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Grace prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 588,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Taylor owns the API surface."
+  },
+  {
+   "category": "person",
+   "id": 589,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Olivia is the staff engineer on the orbit team."
+  },
+  {
+   "category": "person",
+   "id": 590,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Quinn prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 591,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Frank reports to Alice."
+  },
+  {
+   "category": "person",
+   "id": 592,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Liam is the QA lead on the prism team."
+  },
+  {
+   "category": "person",
+   "id": 593,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Bob is the engineering manager on the harbor team."
+  },
+  {
+   "category": "person",
+   "id": 594,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Jack reports to Frank."
+  },
+  {
+   "category": "person",
+   "id": 595,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Taylor reports to Alice."
+  },
+  {
+   "category": "person",
+   "id": 596,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Dave is on PTO from Friday to Tuesday."
+  },
+  {
+   "category": "person",
+   "id": 597,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Henry prefers async over standups."
+  },
+  {
+   "category": "person",
+   "id": 598,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Noah is on PTO from Monday to Tuesday."
+  },
+  {
+   "category": "person",
+   "id": 599,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Noah reports to Sam."
+  },
+  {
+   "category": "person",
+   "id": 600,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Pat is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 601,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for five hours in Portland yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 602,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Hana and Hana discussed the compliance report on Monday."
+  },
+  {
+   "category": "noise",
+   "id": 603,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Drew and Ezra discussed the audit report on Tuesday."
+  },
+  {
+   "category": "noise",
+   "id": 604,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber kettle sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 605,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The owl crossed the bridge at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 606,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for five hours in Portland yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 607,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Cale and Aria discussed the compliance report on Tuesday."
+  },
+  {
+   "category": "noise",
+   "id": 608,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ezra and Aria discussed the quarterly report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 609,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the meadow at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 610,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The badger crossed the trail at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 611,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The badger crossed the fence at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 612,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Cale and Gus discussed the diversity report on Friday."
+  },
+  {
+   "category": "noise",
+   "id": 613,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Gus and Drew discussed the audit report on Tuesday."
+  },
+  {
+   "category": "noise",
+   "id": 614,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The fox crossed the bridge at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 615,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Cale and Beck discussed the diversity report on Tuesday."
+  },
+  {
+   "category": "noise",
+   "id": 616,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for six hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 617,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The otter crossed the river at noon."
+  },
+  {
+   "category": "noise",
+   "id": 618,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "fig is the most-shipped fruit at the co-op."
+  },
+  {
+   "category": "noise",
+   "id": 619,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The indigo compass sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 620,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ezra and Hana discussed the diversity report on Monday."
+  },
+  {
+   "category": "noise",
+   "id": 621,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 622,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre globe sat on the mantel all morning."
+  },
+  {
+   "category": "noise",
+   "id": 623,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The otter crossed the fence at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 624,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for five hours in Lyon yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 625,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the fence at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 626,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The badger crossed the thicket at noon."
+  },
+  {
+   "category": "noise",
+   "id": 627,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The teal lamp sat on the bench all morning."
+  },
+  {
+   "category": "noise",
+   "id": 628,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 629,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The egret crossed the ridge at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 630,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 631,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Hobart yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 632,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The teal kettle sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 633,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Hana and Ezra discussed the annual report on Monday."
+  },
+  {
+   "category": "noise",
+   "id": 634,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The crimson kettle sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 635,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for five hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 636,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The teal atlas sat on the windowsill all morning."
+  },
+  {
+   "category": "noise",
+   "id": 637,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "fig is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 638,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "kumquat is the most-shipped fruit at the co-op."
+  },
+  {
+   "category": "noise",
+   "id": 639,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Hana and Finn discussed the diversity report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 640,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for two hours in Kraków yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 641,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "kumquat is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 642,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "guava is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 643,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the co-op."
+  },
+  {
+   "category": "noise",
+   "id": 644,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The indigo globe sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 645,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the fence at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 646,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The heron crossed the highway at noon."
+  },
+  {
+   "category": "noise",
+   "id": 647,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre lamp sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 648,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for four hours in Lyon yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 649,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for two hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 650,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber compass sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 651,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Finn and Drew discussed the compliance report on Monday."
+  },
+  {
+   "category": "noise",
+   "id": 652,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Gus and Beck discussed the compliance report on Tuesday."
+  },
+  {
+   "category": "noise",
+   "id": 653,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber kettle sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 654,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 655,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for six hours in Portland yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 656,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for four hours in Lyon yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 657,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 658,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The otter crossed the river at noon."
+  },
+  {
+   "category": "noise",
+   "id": 659,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The otter crossed the fence at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 660,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Cale and Cale discussed the audit report on Friday."
+  },
+  {
+   "category": "noise",
+   "id": 661,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Gus and Gus discussed the compliance report on Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 662,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Gus and Aria discussed the inventory report on Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 663,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The heron crossed the bridge at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 664,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 665,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "kumquat is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 666,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The crimson globe sat on the windowsill all morning."
+  },
+  {
+   "category": "noise",
+   "id": 667,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the bridge at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 668,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 669,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "kumquat is the most-shipped fruit at the Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 670,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Beck and Beck discussed the diversity report on Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 671,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for five hours in Hobart yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 672,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Hobart yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 673,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the co-op."
+  },
+  {
+   "category": "noise",
+   "id": 674,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the trail at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 675,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber vase sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 676,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The indigo globe sat on the windowsill all morning."
+  },
+  {
+   "category": "noise",
+   "id": 677,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "fig is the most-shipped fruit at the co-op."
+  },
+  {
+   "category": "noise",
+   "id": 678,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Beck and Cale discussed the audit report on Monday."
+  },
+  {
+   "category": "noise",
+   "id": 679,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for four hours in Portland yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 680,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The raccoon crossed the bridge at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 681,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber lamp sat on the windowsill all morning."
+  },
+  {
+   "category": "noise",
+   "id": 682,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for six hours in Hobart yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 683,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "fig is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 684,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "fig is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 685,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The egret crossed the meadow at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 686,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 687,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The teal compass sat on the windowsill all morning."
+  },
+  {
+   "category": "noise",
+   "id": 688,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber kettle sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 689,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The owl crossed the highway at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 690,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The crimson atlas sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 691,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The owl crossed the trail at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 692,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The badger crossed the river at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 693,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The owl crossed the meadow at midnight."
+  },
+  {
+   "category": "noise",
+   "id": 694,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The teal vase sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 695,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for two hours in Lyon yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 696,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre kettle sat on the windowsill all morning."
+  },
+  {
+   "category": "noise",
+   "id": 697,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "fig is the most-shipped fruit at the co-op."
+  },
+  {
+   "category": "noise",
+   "id": 698,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber vase sat on the mantel all morning."
+  },
+  {
+   "category": "noise",
+   "id": 699,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Portland yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 700,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The owl crossed the ridge at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 701,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber lamp sat on the bench all morning."
+  },
+  {
+   "category": "noise",
+   "id": 702,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ezra and Ezra discussed the inventory report on Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 703,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The fox crossed the river at noon."
+  },
+  {
+   "category": "noise",
+   "id": 704,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for four hours in Portland yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 705,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The fox crossed the thicket at noon."
+  },
+  {
+   "category": "noise",
+   "id": 706,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the co-op."
+  },
+  {
+   "category": "noise",
+   "id": 707,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The crimson compass sat on the mantel all morning."
+  },
+  {
+   "category": "noise",
+   "id": 708,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 709,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre globe sat on the windowsill all morning."
+  },
+  {
+   "category": "noise",
+   "id": 710,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "kumquat is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 711,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 712,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Hana and Drew discussed the annual report on Tuesday."
+  },
+  {
+   "category": "noise",
+   "id": 713,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The badger crossed the highway at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 714,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Gus and Drew discussed the inventory report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 715,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The indigo lamp sat on the mantel all morning."
+  },
+  {
+   "category": "noise",
+   "id": 716,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ezra and Ezra discussed the inventory report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 717,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ezra and Ezra discussed the inventory report on Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 718,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The fox crossed the highway at noon."
+  },
+  {
+   "category": "noise",
+   "id": 719,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "guava is the most-shipped fruit at the co-op."
+  },
+  {
+   "category": "noise",
+   "id": 720,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Aria and Drew discussed the quarterly report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 721,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The fox crossed the river at noon."
+  },
+  {
+   "category": "noise",
+   "id": 722,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The crimson atlas sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 723,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 724,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber atlas sat on the bench all morning."
+  },
+  {
+   "category": "noise",
+   "id": 725,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "guava is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 726,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The fox crossed the river at midnight."
+  },
+  {
+   "category": "noise",
+   "id": 727,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The fox crossed the highway at noon."
+  },
+  {
+   "category": "noise",
+   "id": 728,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 729,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the bridge at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 730,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "guava is the most-shipped fruit at the Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 731,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "fig is the most-shipped fruit at the co-op."
+  },
+  {
+   "category": "noise",
+   "id": 732,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The badger crossed the highway at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 733,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Aria and Finn discussed the annual report on Tuesday."
+  },
+  {
+   "category": "noise",
+   "id": 734,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre lamp sat on the bench all morning."
+  },
+  {
+   "category": "noise",
+   "id": 735,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The indigo vase sat on the bench all morning."
+  },
+  {
+   "category": "noise",
+   "id": 736,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ezra and Hana discussed the compliance report on Monday."
+  },
+  {
+   "category": "noise",
+   "id": 737,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The fox crossed the bridge at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 738,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The indigo globe sat on the mantel all morning."
+  },
+  {
+   "category": "noise",
+   "id": 739,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Beck and Ezra discussed the diversity report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 740,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The owl crossed the bridge at midnight."
+  },
+  {
+   "category": "noise",
+   "id": 741,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The fox crossed the highway at midnight."
+  },
+  {
+   "category": "noise",
+   "id": 742,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Finn and Aria discussed the compliance report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 743,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The raccoon crossed the ridge at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 744,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre compass sat on the bench all morning."
+  },
+  {
+   "category": "noise",
+   "id": 745,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 746,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The teal atlas sat on the mantel all morning."
+  },
+  {
+   "category": "noise",
+   "id": 747,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 748,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 749,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The owl crossed the trail at noon."
+  },
+  {
+   "category": "noise",
+   "id": 750,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Beck and Hana discussed the compliance report on Friday."
+  },
+  {
+   "category": "noise",
+   "id": 751,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ezra and Beck discussed the quarterly report on Friday."
+  },
+  {
+   "category": "noise",
+   "id": 752,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The otter crossed the bridge at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 753,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "kumquat is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 754,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 755,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Aria and Finn discussed the annual report on Tuesday."
+  },
+  {
+   "category": "noise",
+   "id": 756,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for four hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 757,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre lamp sat on the bench all morning."
+  },
+  {
+   "category": "noise",
+   "id": 758,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Finn and Aria discussed the inventory report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 759,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre vase sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 760,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre compass sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 761,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 762,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Drew and Hana discussed the inventory report on Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 763,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The egret crossed the fence at noon."
+  },
+  {
+   "category": "noise",
+   "id": 764,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre vase sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 765,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The fox crossed the fence at noon."
+  },
+  {
+   "category": "noise",
+   "id": 766,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Aria and Beck discussed the diversity report on Tuesday."
+  },
+  {
+   "category": "noise",
+   "id": 767,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for six hours in Kraków yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 768,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 769,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "kumquat is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 770,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber globe sat on the mantel all morning."
+  },
+  {
+   "category": "noise",
+   "id": 771,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The owl crossed the thicket at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 772,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for two hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 773,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for six hours in Kraków yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 774,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The crimson vase sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 775,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The raccoon crossed the fence at noon."
+  },
+  {
+   "category": "noise",
+   "id": 776,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for six hours in Lyon yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 777,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "kumquat is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 778,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the fence at noon."
+  },
+  {
+   "category": "noise",
+   "id": 779,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Cale and Aria discussed the diversity report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 780,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "guava is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 781,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 782,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The indigo globe sat on the windowsill all morning."
+  },
+  {
+   "category": "noise",
+   "id": 783,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Lyon yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 784,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Hana and Finn discussed the annual report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 785,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre atlas sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 786,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The indigo globe sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 787,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Finn and Finn discussed the quarterly report on Monday."
+  },
+  {
+   "category": "noise",
+   "id": 788,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for four hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 789,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "guava is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 790,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The owl crossed the fence at noon."
+  },
+  {
+   "category": "noise",
+   "id": 791,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Beck and Drew discussed the diversity report on Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 792,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 793,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre atlas sat on the windowsill all morning."
+  },
+  {
+   "category": "noise",
+   "id": 794,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The heron crossed the highway at noon."
+  },
+  {
+   "category": "noise",
+   "id": 795,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The indigo atlas sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 796,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 797,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the thicket at midnight."
+  },
+  {
+   "category": "noise",
+   "id": 798,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The egret crossed the bridge at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 799,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "fig is the most-shipped fruit at the co-op."
+  },
+  {
+   "category": "noise",
+   "id": 800,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for four hours in Kraków yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 801,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the meadow at midnight."
+  },
+  {
+   "category": "noise",
+   "id": 802,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "kumquat is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 803,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for two hours in Hobart yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 804,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the thicket at midnight."
+  },
+  {
+   "category": "noise",
+   "id": 805,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 806,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for two hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 807,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "guava is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 808,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The otter crossed the highway at noon."
+  },
+  {
+   "category": "noise",
+   "id": 809,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Drew and Finn discussed the quarterly report on Tuesday."
+  },
+  {
+   "category": "noise",
+   "id": 810,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for two hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 811,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Finn and Ezra discussed the inventory report on Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 812,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Finn and Beck discussed the quarterly report on Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 813,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for four hours in Portland yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 814,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre atlas sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 815,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Gus and Gus discussed the quarterly report on Friday."
+  },
+  {
+   "category": "noise",
+   "id": 816,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The badger crossed the ridge at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 817,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The raccoon crossed the trail at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 818,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Portland yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 819,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The raccoon crossed the thicket at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 820,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 821,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "guava is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 822,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Finn and Aria discussed the audit report on Friday."
+  },
+  {
+   "category": "noise",
+   "id": 823,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 824,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for six hours in Portland yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 825,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The crimson lamp sat on the bench all morning."
+  },
+  {
+   "category": "noise",
+   "id": 826,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Drew and Aria discussed the quarterly report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 827,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the fence at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 828,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Cale and Beck discussed the quarterly report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 829,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "kumquat is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 830,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Finn and Drew discussed the annual report on Friday."
+  },
+  {
+   "category": "noise",
+   "id": 831,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre atlas sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 832,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "kumquat is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 833,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for five hours in Portland yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 834,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The teal compass sat on the mantel all morning."
+  },
+  {
+   "category": "noise",
+   "id": 835,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The teal globe sat on the mantel all morning."
+  },
+  {
+   "category": "noise",
+   "id": 836,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Hana and Aria discussed the compliance report on Tuesday."
+  },
+  {
+   "category": "noise",
+   "id": 837,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Lyon yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 838,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The otter crossed the thicket at noon."
+  },
+  {
+   "category": "noise",
+   "id": 839,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The fox crossed the river at midnight."
+  },
+  {
+   "category": "noise",
+   "id": 840,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for six hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 841,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for six hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 842,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the co-op."
+  },
+  {
+   "category": "noise",
+   "id": 843,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Hobart yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 844,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for four hours in Lyon yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 845,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The heron crossed the highway at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 846,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ezra and Ezra discussed the quarterly report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 847,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "guava is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 848,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for two hours in Hobart yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 849,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Cale and Aria discussed the inventory report on Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 850,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber vase sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 851,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The raccoon crossed the river at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 852,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Lyon yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 853,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The egret crossed the bridge at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 854,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The egret crossed the ridge at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 855,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The crimson atlas sat on the mantel all morning."
+  },
+  {
+   "category": "noise",
+   "id": 856,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 857,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The crimson lamp sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 858,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "fig is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 859,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for five hours in Lyon yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 860,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for two hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 861,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for four hours in Hobart yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 862,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Gus and Finn discussed the diversity report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 863,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Aria and Beck discussed the quarterly report on Tuesday."
+  },
+  {
+   "category": "noise",
+   "id": 864,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Finn and Gus discussed the quarterly report on Friday."
+  },
+  {
+   "category": "noise",
+   "id": 865,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The egret crossed the thicket at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 866,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "guava is the most-shipped fruit at the westside."
+  },
+  {
+   "category": "noise",
+   "id": 867,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The crimson atlas sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 868,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Gus and Beck discussed the audit report on Thursday."
+  },
+  {
+   "category": "noise",
+   "id": 869,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber kettle sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 870,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber kettle sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 871,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 872,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Hana and Beck discussed the audit report on Friday."
+  },
+  {
+   "category": "noise",
+   "id": 873,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The ochre lamp sat on the bench all morning."
+  },
+  {
+   "category": "noise",
+   "id": 874,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for five hours in Portland yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 875,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for five hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 876,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "persimmon is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 877,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for six hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 878,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "fig is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 879,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 880,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The teal lamp sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 881,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the highway at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 882,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Ezra and Drew discussed the compliance report on Monday."
+  },
+  {
+   "category": "noise",
+   "id": 883,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Cale and Ezra discussed the quarterly report on Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 884,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The raccoon crossed the trail at midnight."
+  },
+  {
+   "category": "noise",
+   "id": 885,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for three hours in Aarhus yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 886,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The lynx crossed the highway at dusk."
+  },
+  {
+   "category": "noise",
+   "id": 887,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "guava is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 888,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The crimson vase sat on the desk all morning."
+  },
+  {
+   "category": "noise",
+   "id": 889,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "guava is the most-shipped fruit at the harbor."
+  },
+  {
+   "category": "noise",
+   "id": 890,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber kettle sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 891,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The heron crossed the bridge at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 892,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "Hana and Aria discussed the diversity report on Wednesday."
+  },
+  {
+   "category": "noise",
+   "id": 893,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for four hours in Portland yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 894,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The indigo kettle sat on the shelf all morning."
+  },
+  {
+   "category": "noise",
+   "id": 895,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The owl crossed the river at dawn."
+  },
+  {
+   "category": "noise",
+   "id": 896,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "fig is the most-shipped fruit at the downtown."
+  },
+  {
+   "category": "noise",
+   "id": 897,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The amber globe sat on the mantel all morning."
+  },
+  {
+   "category": "noise",
+   "id": 898,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "It rained for six hours in Kraków yesterday."
+  },
+  {
+   "category": "noise",
+   "id": 899,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "lychee is the most-shipped fruit at the co-op."
+  },
+  {
+   "category": "noise",
+   "id": 900,
+   "planted_kind": null,
+   "source_text": null,
+   "text": "The badger crossed the thicket at dawn."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 901,
+   "planted_kind": "exact_dup",
+   "source_text": "Project echo launches in September 2026.",
+   "text": "Project echo launches in September 2026."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 902,
+   "planted_kind": "exact_dup",
+   "source_text": "Project prism uses OpenTelemetry for tracing.",
+   "text": "Project prism uses OpenTelemetry for tracing."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 903,
+   "planted_kind": "exact_dup",
+   "source_text": "Project glacier supports 12 locales.",
+   "text": "Project glacier supports 12 locales."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 904,
+   "planted_kind": "exact_dup",
+   "source_text": "Project compass targets 100,000 monthly active users.",
+   "text": "Project compass targets 100,000 monthly active users."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 905,
+   "planted_kind": "exact_dup",
+   "source_text": "The user prefers 12pt as their font size in bash.",
+   "text": "The user prefers 12pt as their font size in bash."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 906,
+   "planted_kind": "exact_dup",
+   "source_text": "The user prefers 16pt as their font size in Vim.",
+   "text": "The user prefers 16pt as their font size in Vim."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 907,
+   "planted_kind": "exact_dup",
+   "source_text": "Project kestrel supports 3 locales.",
+   "text": "Project kestrel supports 3 locales."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 908,
+   "planted_kind": "exact_dup",
+   "source_text": "Project orbit supports 42 locales.",
+   "text": "Project orbit supports 42 locales."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 909,
+   "planted_kind": "exact_dup",
+   "source_text": "Project tundra supports 3 locales.",
+   "text": "Project tundra supports 3 locales."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 910,
+   "planted_kind": "exact_dup",
+   "source_text": "The user prefers on save as their auto-format in PyCharm.",
+   "text": "The user prefers on save as their auto-format in PyCharm."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 911,
+   "planted_kind": "exact_dup",
+   "source_text": "Project compass targets 1,000 monthly active users.",
+   "text": "Project compass targets 1,000 monthly active users."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 912,
+   "planted_kind": "exact_dup",
+   "source_text": "Project lattice uses PostgreSQL for primary storage.",
+   "text": "Project lattice uses PostgreSQL for primary storage."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 913,
+   "planted_kind": "exact_dup",
+   "source_text": "Project iris launches in September 2026.",
+   "text": "Project iris launches in September 2026."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 914,
+   "planted_kind": "exact_dup",
+   "source_text": "Project nexus uses Go for the orchestrator.",
+   "text": "Project nexus uses Go for the orchestrator."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 915,
+   "planted_kind": "exact_dup",
+   "source_text": "The user prefers nord as their color scheme in IntelliJ.",
+   "text": "The user prefers nord as their color scheme in IntelliJ."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 916,
+   "planted_kind": "exact_dup",
+   "source_text": "Project ridge uses Prometheus for metrics.",
+   "text": "Project ridge uses Prometheus for metrics."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 917,
+   "planted_kind": "exact_dup",
+   "source_text": "The user prefers high-contrast as their color scheme in IntelliJ.",
+   "text": "The user prefers high-contrast as their color scheme in IntelliJ."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 918,
+   "planted_kind": "exact_dup",
+   "source_text": "The user prefers Iosevka as their font in zsh.",
+   "text": "The user prefers Iosevka as their font in zsh."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 919,
+   "planted_kind": "exact_dup",
+   "source_text": "Project nexus supports 3 locales.",
+   "text": "Project nexus supports 3 locales."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 920,
+   "planted_kind": "exact_dup",
+   "source_text": "The user prefers Source Code Pro as their font in Cursor.",
+   "text": "The user prefers Source Code Pro as their font in Cursor."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 921,
+   "planted_kind": "exact_dup",
+   "source_text": "The user prefers Source Code Pro as their font in zsh.",
+   "text": "The user prefers Source Code Pro as their font in zsh."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 922,
+   "planted_kind": "exact_dup",
+   "source_text": "Project ridge uses ClickHouse for analytics.",
+   "text": "Project ridge uses ClickHouse for analytics."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 923,
+   "planted_kind": "exact_dup",
+   "source_text": "Project fjord launches in November 2027.",
+   "text": "Project fjord launches in November 2027."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 924,
+   "planted_kind": "exact_dup",
+   "source_text": "The user prefers high-contrast as their color scheme in zsh.",
+   "text": "The user prefers high-contrast as their color scheme in zsh."
+  },
+  {
+   "category": "duplicate_exact",
+   "id": 925,
+   "planted_kind": "exact_dup",
+   "source_text": "The user prefers manually only as their auto-format in Vim.",
+   "text": "The user prefers manually only as their auto-format in Vim."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 926,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers LF as their line endings in alacritty.",
+   "text": "The user's preferred LF as their line endings in alacritty."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 927,
+   "planted_kind": "paraphrase",
+   "source_text": "Project fjord launches in November 2027.",
+   "text": "The fjord launches in November 2027."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 928,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers tabs as their tab width in VS Code.",
+   "text": "The user's preferred tabs as their tab width in VS Code."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 929,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers 15pt as their font size in IntelliJ.",
+   "text": "The user's preferred 15pt as their font size in IntelliJ."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 930,
+   "planted_kind": "paraphrase",
+   "source_text": "Project iris targets 100,000 monthly active users.",
+   "text": "The iris targets 100,000 monthly active users."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 931,
+   "planted_kind": "paraphrase",
+   "source_text": "Project harbor targets 1,000 monthly active users.",
+   "text": "The harbor targets 1,000 monthly active users."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 932,
+   "planted_kind": "paraphrase",
+   "source_text": "Project quartz uses Grafana for dashboards.",
+   "text": "The quartz uses Grafana for dashboards."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 933,
+   "planted_kind": "paraphrase",
+   "source_text": "Project glacier supports 12 locales.",
+   "text": "The glacier supports 12 locales."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 934,
+   "planted_kind": "paraphrase",
+   "source_text": "Project nexus supports 3 locales.",
+   "text": "The nexus supports 3 locales."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 935,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers Cascadia Code as their font in Hyper.",
+   "text": "The user's preferred Cascadia Code as their font in Hyper."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 936,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers Cascadia Code as their font in Zed.",
+   "text": "The user's preferred Cascadia Code as their font in Zed."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 937,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers 2 spaces as their tab width in kitty.",
+   "text": "The user's preferred 2 spaces as their tab width in kitty."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 938,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers 12pt as their font size in IntelliJ.",
+   "text": "The user's preferred 12pt as their font size in IntelliJ."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 939,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers tabs as their tab width in fish shell.",
+   "text": "The user's preferred tabs as their tab width in fish shell."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 940,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers lazygit as their git GUI in iTerm2.",
+   "text": "The user's preferred lazygit as their git GUI in iTerm2."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 941,
+   "planted_kind": "paraphrase",
+   "source_text": "Project orbit uses Prometheus for metrics.",
+   "text": "The orbit uses Prometheus for metrics."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 942,
+   "planted_kind": "paraphrase",
+   "source_text": "Project summit launches in September 2026.",
+   "text": "The summit launches in September 2026."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 943,
+   "planted_kind": "paraphrase",
+   "source_text": "Project ridge uses PostgreSQL for primary storage.",
+   "text": "The ridge uses PostgreSQL for primary storage."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 944,
+   "planted_kind": "paraphrase",
+   "source_text": "Project junction supports 12 locales.",
+   "text": "The junction supports 12 locales."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 945,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers 13pt as their font size in iTerm2.",
+   "text": "The user's preferred 13pt as their font size in iTerm2."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 946,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers LF as their line endings in IntelliJ.",
+   "text": "The user's preferred LF as their line endings in IntelliJ."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 947,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers 16pt as their font size in tmux.",
+   "text": "The user's preferred 16pt as their font size in tmux."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 948,
+   "planted_kind": "paraphrase",
+   "source_text": "Project prism launches in September 2026.",
+   "text": "The prism launches in September 2026."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 949,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers 2 spaces as their tab width in Warp.",
+   "text": "The user's preferred 2 spaces as their tab width in Warp."
+  },
+  {
+   "category": "duplicate_paraphrase",
+   "id": 950,
+   "planted_kind": "paraphrase",
+   "source_text": "The user prefers high-contrast as their color scheme in IntelliJ.",
+   "text": "The user's preferred high-contrast as their color scheme in IntelliJ."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 951,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers tokyo night as their color scheme in Cursor.",
+   "text": "The user prefers tokyo night as their color scheme in Cursor."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 952,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers GitKraken as their git GUI in Windsurf.",
+   "text": "The user prefers GitKraken as their git GUI in Windsurf."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 953,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers 12pt as their font size in IntelliJ.",
+   "text": "The user prefers 12pt as their font size in IntelliJ."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 954,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers CRLF as their line endings in Windsurf.",
+   "text": "The user prefers CRLF as their line endings in Windsurf."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 955,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers LF as their line endings in bash.",
+   "text": "The user prefers LF as their line endings in bash."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 956,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers on save as their auto-format in bash.",
+   "text": "The user prefers on save as their auto-format in bash."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 957,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers on save as their auto-format in iTerm2.",
+   "text": "The user prefers on save as their auto-format in iTerm2."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 958,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers 16pt as their font size in Neovim.",
+   "text": "The user prefers 16pt as their font size in Neovim."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 959,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers gruvbox as their color scheme in PyCharm.",
+   "text": "The user prefers gruvbox as their color scheme in PyCharm."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 960,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers never as their auto-format in IntelliJ.",
+   "text": "The user prefers never as their auto-format in IntelliJ."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 961,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers JetBrains Mono as their font in bash.",
+   "text": "The user prefers JetBrains Mono as their font in bash."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 962,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers Hack as their font in fish shell.",
+   "text": "The user prefers Hack as their font in fish shell."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 963,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers tokyo night as their color scheme in Hyper.",
+   "text": "The user prefers tokyo night as their color scheme in Hyper."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 964,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers Fork as their git GUI in Warp.",
+   "text": "The user prefers Fork as their git GUI in Warp."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 965,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers Source Code Pro as their font in Vim.",
+   "text": "The user prefers Source Code Pro as their font in Vim."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 966,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers 4 spaces as their tab width in iTerm2.",
+   "text": "The user prefers 4 spaces as their tab width in iTerm2."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 967,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers Source Code Pro as their font in Warp.",
+   "text": "The user prefers Source Code Pro as their font in Warp."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 968,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers Iosevka as their font in Windsurf.",
+   "text": "The user prefers Iosevka as their font in Windsurf."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 969,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers 2 spaces as their tab width in kitty.",
+   "text": "The user prefers 2 spaces as their tab width in kitty."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 970,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers lazygit as their git GUI in Windsurf.",
+   "text": "The user prefers lazygit as their git GUI in Windsurf."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 971,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers Iosevka as their font in Warp.",
+   "text": "The user prefers Iosevka as their font in Warp."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 972,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers command line only as their git GUI in Zed.",
+   "text": "The user prefers command line only as their git GUI in Zed."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 973,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers manually only as their auto-format in fish shell.",
+   "text": "The user prefers manually only as their auto-format in fish shell."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 974,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers manually only as their auto-format in Vim.",
+   "text": "The user prefers manually only as their auto-format in Vim."
+  },
+  {
+   "category": "contradiction_baseline",
+   "id": 975,
+   "planted_kind": "contradiction_base",
+   "source_text": "The user prefers catppuccin as their color scheme in Sublime Text.",
+   "text": "The user prefers catppuccin as their color scheme in Sublime Text."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 976,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers tokyo night as their color scheme in Cursor.",
+   "text": "The user prefers dark mode as their color scheme in Cursor."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 977,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers GitKraken as their git GUI in Windsurf.",
+   "text": "The user prefers command line only as their git GUI in Windsurf."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 978,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers 12pt as their font size in IntelliJ.",
+   "text": "The user prefers 13pt as their font size in IntelliJ."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 979,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers CRLF as their line endings in Windsurf.",
+   "text": "The user prefers LF as their line endings in Windsurf."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 980,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers LF as their line endings in bash.",
+   "text": "The user prefers CRLF as their line endings in bash."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 981,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers on save as their auto-format in bash.",
+   "text": "The user prefers manually only as their auto-format in bash."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 982,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers on save as their auto-format in iTerm2.",
+   "text": "The user prefers manually only as their auto-format in iTerm2."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 983,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers 16pt as their font size in Neovim.",
+   "text": "The user prefers 12pt as their font size in Neovim."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 984,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers gruvbox as their color scheme in PyCharm.",
+   "text": "The user prefers dark mode as their color scheme in PyCharm."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 985,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers never as their auto-format in IntelliJ.",
+   "text": "The user prefers on save as their auto-format in IntelliJ."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 986,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers JetBrains Mono as their font in bash.",
+   "text": "The user prefers Fira Code as their font in bash."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 987,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers Hack as their font in fish shell.",
+   "text": "The user prefers JetBrains Mono as their font in fish shell."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 988,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers tokyo night as their color scheme in Hyper.",
+   "text": "The user prefers dark mode as their color scheme in Hyper."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 989,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers Fork as their git GUI in Warp.",
+   "text": "The user prefers command line only as their git GUI in Warp."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 990,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers Source Code Pro as their font in Vim.",
+   "text": "The user prefers JetBrains Mono as their font in Vim."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 991,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers 4 spaces as their tab width in iTerm2.",
+   "text": "The user prefers 2 spaces as their tab width in iTerm2."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 992,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers Source Code Pro as their font in Warp.",
+   "text": "The user prefers JetBrains Mono as their font in Warp."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 993,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers Iosevka as their font in Windsurf.",
+   "text": "The user prefers JetBrains Mono as their font in Windsurf."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 994,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers 2 spaces as their tab width in kitty.",
+   "text": "The user prefers 4 spaces as their tab width in kitty."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 995,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers lazygit as their git GUI in Windsurf.",
+   "text": "The user prefers command line only as their git GUI in Windsurf."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 996,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers Iosevka as their font in Warp.",
+   "text": "The user prefers JetBrains Mono as their font in Warp."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 997,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers command line only as their git GUI in Zed.",
+   "text": "The user prefers Fork as their git GUI in Zed."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 998,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers manually only as their auto-format in fish shell.",
+   "text": "The user prefers on save as their auto-format in fish shell."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 999,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers manually only as their auto-format in Vim.",
+   "text": "The user prefers on save as their auto-format in Vim."
+  },
+  {
+   "category": "contradiction_alt",
+   "id": 1000,
+   "planted_kind": "contradiction_alt",
+   "source_text": "The user prefers catppuccin as their color scheme in Sublime Text.",
+   "text": "The user prefers dark mode as their color scheme in Sublime Text."
+  },
+  {
+   "id": 20000,
+   "text": "The user prefers never as their auto-format in Sublime Text."
+  },
+  {
+   "id": 20001,
+   "text": "The user prefers tig as their git GUI in IntelliJ."
+  },
+  {
+   "id": 20002,
+   "text": "The user prefers solarized dark as their color scheme in tmux."
+  },
+  {
+   "id": 20003,
+   "text": "The user prefers Iosevka as their font in IntelliJ."
+  },
+  {
+   "id": 20004,
+   "text": "The user prefers light mode as their color scheme in PyCharm."
+  },
+  {
+   "id": 20005,
+   "text": "The user prefers tabs as their tab width in IntelliJ."
+  },
+  {
+   "id": 20006,
+   "text": "The user prefers 13pt as their font size in PyCharm."
+  },
+  {
+   "id": 20007,
+   "text": "The user prefers solarized dark as their color scheme in kitty."
+  },
+  {
+   "id": 20008,
+   "text": "The user prefers LF as their line endings in Cursor."
+  },
+  {
+   "id": 20009,
+   "text": "The user prefers Hack as their font in iTerm2."
+  },
+  {
+   "id": 20010,
+   "text": "The user prefers LF as their line endings in tmux."
+  },
+  {
+   "id": 20011,
+   "text": "The user prefers lazygit as their git GUI in zsh."
+  },
+  {
+   "id": 20012,
+   "text": "The user prefers on save as their auto-format in kitty."
+  },
+  {
+   "id": 20013,
+   "text": "The user prefers tabs as their tab width in Terminal.app."
+  },
+  {
+   "id": 20014,
+   "text": "The user prefers lazygit as their git GUI in Warp."
+  },
+  {
+   "id": 20015,
+   "text": "The user prefers CRLF as their line endings in Sublime Text."
+  },
+  {
+   "id": 20016,
+   "text": "The user prefers GitKraken as their git GUI in kitty."
+  },
+  {
+   "id": 20017,
+   "text": "The user prefers GitKraken as their git GUI in Sublime Text."
+  },
+  {
+   "id": 20018,
+   "text": "The user prefers 16pt as their font size in fish shell."
+  },
+  {
+   "id": 20019,
+   "text": "The user prefers tokyo night as their color scheme in Zed."
+  },
+  {
+   "id": 20020,
+   "text": "The user prefers dark mode as their color scheme in VS Code."
+  },
+  {
+   "id": 20021,
+   "text": "The user prefers 4 spaces as their tab width in PyCharm."
+  },
+  {
+   "id": 20022,
+   "text": "The user prefers dark mode as their color scheme in Warp."
+  },
+  {
+   "id": 20023,
+   "text": "The user prefers on save as their auto-format in zsh."
+  },
+  {
+   "id": 20024,
+   "text": "The user prefers CRLF as their line endings in Terminal.app."
+  },
+  {
+   "id": 20025,
+   "text": "The user prefers on save as their auto-format in Zed."
+  },
+  {
+   "id": 20026,
+   "text": "The user prefers 12pt as their font size in PyCharm."
+  },
+  {
+   "id": 20027,
+   "text": "The user prefers Source Code Pro as their font in kitty."
+  },
+  {
+   "id": 20028,
+   "text": "The user prefers LF as their line endings in Vim."
+  },
+  {
+   "id": 20029,
+   "text": "The user prefers manually only as their auto-format in IntelliJ."
+  },
+  {
+   "id": 20030,
+   "text": "The user prefers 15pt as their font size in Cursor."
+  },
+  {
+   "id": 20031,
+   "text": "The user prefers nord as their color scheme in VS Code."
+  },
+  {
+   "id": 20032,
+   "text": "The user prefers tig as their git GUI in Zed."
+  },
+  {
+   "id": 20033,
+   "text": "The user prefers 12pt as their font size in Emacs."
+  },
+  {
+   "id": 20034,
+   "text": "The user prefers 13pt as their font size in Vim."
+  },
+  {
+   "id": 20035,
+   "text": "The user prefers never as their auto-format in Neovim."
+  },
+  {
+   "id": 20036,
+   "text": "The user prefers 14pt as their font size in Vim."
+  },
+  {
+   "id": 20037,
+   "text": "The user prefers JetBrains Mono as their font in Sublime Text."
+  },
+  {
+   "id": 20038,
+   "text": "The user prefers tabs as their tab width in alacritty."
+  },
+  {
+   "id": 20039,
+   "text": "The user prefers 15pt as their font size in zsh."
+  },
+  {
+   "id": 20040,
+   "text": "The user prefers 4 spaces as their tab width in tmux."
+  },
+  {
+   "id": 20041,
+   "text": "The user prefers 4 spaces as their tab width in Cursor."
+  },
+  {
+   "id": 20042,
+   "text": "The user prefers LF as their line endings in zsh."
+  },
+  {
+   "id": 20043,
+   "text": "The user prefers manually only as their auto-format in Warp."
+  },
+  {
+   "id": 20044,
+   "text": "The user prefers JetBrains Mono as their font in zsh."
+  },
+  {
+   "id": 20045,
+   "text": "The user prefers LF as their line endings in Emacs."
+  },
+  {
+   "id": 20046,
+   "text": "The user prefers tabs as their tab width in Hyper."
+  },
+  {
+   "id": 20047,
+   "text": "The user prefers tig as their git GUI in Emacs."
+  },
+  {
+   "id": 20048,
+   "text": "The user prefers 12pt as their font size in tmux."
+  },
+  {
+   "id": 20049,
+   "text": "The user prefers Fork as their git GUI in Cursor."
+  },
+  {
+   "id": 20050,
+   "text": "The user prefers dark mode as their color scheme in Zed."
+  },
+  {
+   "id": 20051,
+   "text": "The user prefers tokyo night as their color scheme in zsh."
+  },
+  {
+   "id": 20052,
+   "text": "The user prefers dark mode as their color scheme in Emacs."
+  },
+  {
+   "id": 20053,
+   "text": "The user prefers 15pt as their font size in tmux."
+  },
+  {
+   "id": 20054,
+   "text": "The user prefers CRLF as their line endings in alacritty."
+  },
+  {
+   "id": 20055,
+   "text": "The user prefers Hack as their font in IntelliJ."
+  },
+  {
+   "id": 20056,
+   "text": "The user prefers CRLF as their line endings in Cursor."
+  },
+  {
+   "id": 20057,
+   "text": "The user prefers CRLF as their line endings in zsh."
+  },
+  {
+   "id": 20058,
+   "text": "The user prefers tabs as their tab width in Cursor."
+  },
+  {
+   "id": 20059,
+   "text": "The user prefers Source Code Pro as their font in alacritty."
+  },
+  {
+   "id": 20060,
+   "text": "The user prefers 12pt as their font size in Sublime Text."
+  },
+  {
+   "id": 20061,
+   "text": "The user prefers command line only as their git GUI in Vim."
+  },
+  {
+   "id": 20062,
+   "text": "The user prefers LF as their line endings in Sublime Text."
+  },
+  {
+   "id": 20063,
+   "text": "The user prefers Iosevka as their font in alacritty."
+  },
+  {
+   "id": 20064,
+   "text": "The user prefers GitKraken as their git GUI in alacritty."
+  },
+  {
+   "id": 20065,
+   "text": "The user prefers 14pt as their font size in Zed."
+  },
+  {
+   "id": 20066,
+   "text": "The user prefers never as their auto-format in iTerm2."
+  },
+  {
+   "id": 20067,
+   "text": "The user prefers Fork as their git GUI in iTerm2."
+  },
+  {
+   "id": 20068,
+   "text": "The user prefers 4 spaces as their tab width in Sublime Text."
+  },
+  {
+   "id": 20069,
+   "text": "The user prefers high-contrast as their color scheme in Cursor."
+  },
+  {
+   "id": 20070,
+   "text": "The user prefers manually only as their auto-format in Emacs."
+  },
+  {
+   "id": 20071,
+   "text": "The user prefers 12pt as their font size in Terminal.app."
+  },
+  {
+   "id": 20072,
+   "text": "The user prefers on save as their auto-format in Warp."
+  },
+  {
+   "id": 20073,
+   "text": "The user prefers CRLF as their line endings in Emacs."
+  },
+  {
+   "id": 20074,
+   "text": "The user prefers gruvbox as their color scheme in Windsurf."
+  },
+  {
+   "id": 20075,
+   "text": "The user prefers on save as their auto-format in alacritty."
+  },
+  {
+   "id": 20076,
+   "text": "The user prefers lazygit as their git GUI in Neovim."
+  },
+  {
+   "id": 20077,
+   "text": "The user prefers nord as their color scheme in Vim."
+  },
+  {
+   "id": 20078,
+   "text": "The user prefers never as their auto-format in zsh."
+  },
+  {
+   "id": 20079,
+   "text": "The user prefers light mode as their color scheme in alacritty."
+  },
+  {
+   "id": 20080,
+   "text": "The user prefers tig as their git GUI in Neovim."
+  },
+  {
+   "id": 20081,
+   "text": "The user prefers 4 spaces as their tab width in alacritty."
+  },
+  {
+   "id": 20082,
+   "text": "The user prefers Fork as their git GUI in Hyper."
+  },
+  {
+   "id": 20083,
+   "text": "The user prefers light mode as their color scheme in Vim."
+  },
+  {
+   "id": 20084,
+   "text": "The user prefers Fork as their git GUI in kitty."
+  },
+  {
+   "id": 20085,
+   "text": "The user prefers Hack as their font in zsh."
+  },
+  {
+   "id": 20086,
+   "text": "The user prefers Source Code Pro as their font in Terminal.app."
+  },
+  {
+   "id": 20087,
+   "text": "The user prefers LF as their line endings in iTerm2."
+  },
+  {
+   "id": 20088,
+   "text": "The user prefers JetBrains Mono as their font in IntelliJ."
+  },
+  {
+   "id": 20089,
+   "text": "The user prefers Iosevka as their font in Zed."
+  },
+  {
+   "id": 20090,
+   "text": "The user prefers 2 spaces as their tab width in Windsurf."
+  },
+  {
+   "id": 20091,
+   "text": "The user prefers Source Code Pro as their font in PyCharm."
+  },
+  {
+   "id": 20092,
+   "text": "The user prefers command line only as their git GUI in Cursor."
+  },
+  {
+   "id": 20093,
+   "text": "The user prefers 2 spaces as their tab width in PyCharm."
+  },
+  {
+   "id": 20094,
+   "text": "The user prefers CRLF as their line endings in kitty."
+  },
+  {
+   "id": 20095,
+   "text": "The user prefers LF as their line endings in PyCharm."
+  },
+  {
+   "id": 20096,
+   "text": "The user prefers 15pt as their font size in alacritty."
+  },
+  {
+   "id": 20097,
+   "text": "The user prefers tabs as their tab width in kitty."
+  },
+  {
+   "id": 20098,
+   "text": "The user prefers never as their auto-format in alacritty."
+  },
+  {
+   "id": 20099,
+   "text": "The user prefers 15pt as their font size in Hyper."
+  },
+  {
+   "id": 20100,
+   "text": "The user prefers Cascadia Code as their font in fish shell."
+  },
+  {
+   "id": 20101,
+   "text": "The user prefers high-contrast as their color scheme in Zed."
+  },
+  {
+   "id": 20102,
+   "text": "The user prefers lazygit as their git GUI in Vim."
+  },
+  {
+   "id": 20103,
+   "text": "The user prefers high-contrast as their color scheme in tmux."
+  },
+  {
+   "id": 20104,
+   "text": "The user prefers lazygit as their git GUI in Terminal.app."
+  },
+  {
+   "id": 20105,
+   "text": "The user prefers 13pt as their font size in Warp."
+  },
+  {
+   "id": 20106,
+   "text": "Project compass launches in September 2027."
+  },
+  {
+   "id": 20107,
+   "text": "Project glacier launches in June 2026."
+  },
+  {
+   "id": 20108,
+   "text": "Project junction supports 3 locales."
+  },
+  {
+   "id": 20109,
+   "text": "Project atlas launches in November 2026."
+  },
+  {
+   "id": 20110,
+   "text": "Project tundra supports 5 locales."
+  },
+  {
+   "id": 20111,
+   "text": "Project kestrel supports 27 locales."
+  },
+  {
+   "id": 20112,
+   "text": "Project compass uses Kubernetes for orchestration."
+  },
+  {
+   "id": 20113,
+   "text": "Project monolith uses Docker for containerization."
+  },
+  {
+   "id": 20114,
+   "text": "Project glacier targets 10,000 monthly active users."
+  },
+  {
+   "id": 20115,
+   "text": "Project glacier supports 5 locales."
+  },
+  {
+   "id": 20116,
+   "text": "Project orbit launches in March 2026."
+  },
+  {
+   "id": 20117,
+   "text": "Project quartz uses Next.js for server-side rendering."
+  },
+  {
+   "id": 20118,
+   "text": "Project glacier targets 1,000,000 monthly active users."
+  },
+  {
+   "id": 20119,
+   "text": "Project orbit uses TypeScript for the client."
+  },
+  {
+   "id": 20120,
+   "text": "Project glacier uses FastAPI for the API layer."
+  },
+  {
+   "id": 20121,
+   "text": "Project nexus uses S3 for object storage."
+  },
+  {
+   "id": 20122,
+   "text": "Project ridge supports 3 locales."
+  },
+  {
+   "id": 20123,
+   "text": "Project nexus uses Next.js for server-side rendering."
+  },
+  {
+   "id": 20124,
+   "text": "Project delta launches in June 2027."
+  },
+  {
+   "id": 20125,
+   "text": "Project junction uses React for the frontend."
+  },
+  {
+   "id": 20126,
+   "text": "Project monolith uses Rust for performance-critical paths."
+  },
+  {
+   "id": 20127,
+   "text": "Project lattice supports 5 locales."
+  },
+  {
+   "id": 20128,
+   "text": "Project ridge targets 1,000,000 monthly active users."
+  },
+  {
+   "id": 20129,
+   "text": "Project summit launches in November 2027."
+  },
+  {
+   "id": 20130,
+   "text": "Project lattice supports 27 locales."
+  },
+  {
+   "id": 20131,
+   "text": "Project quartz supports 27 locales."
+  },
+  {
+   "id": 20132,
+   "text": "Project echo launches in June 2026."
+  },
+  {
+   "id": 20133,
+   "text": "Project kestrel launches in September 2026."
+  },
+  {
+   "id": 20134,
+   "text": "Project lattice launches in March 2027."
+  },
+  {
+   "id": 20135,
+   "text": "Project ridge launches in September 2027."
+  },
+  {
+   "id": 20136,
+   "text": "Project tundra targets 1,000 monthly active users."
+  },
+  {
+   "id": 20137,
+   "text": "Project orbit supports 3 locales."
+  },
+  {
+   "id": 20138,
+   "text": "Project echo targets 10,000 monthly active users."
+  },
+  {
+   "id": 20139,
+   "text": "Project iris supports 12 locales."
+  },
+  {
+   "id": 20140,
+   "text": "Project nexus uses FastAPI for the API layer."
+  },
+  {
+   "id": 20141,
+   "text": "Project summit launches in June 2026."
+  },
+  {
+   "id": 20142,
+   "text": "Project orbit supports 27 locales."
+  },
+  {
+   "id": 20143,
+   "text": "Project monolith supports 27 locales."
+  },
+  {
+   "id": 20144,
+   "text": "Project atlas launches in March 2026."
+  },
+  {
+   "id": 20145,
+   "text": "Project nexus launches in September 2026."
+  },
+  {
+   "id": 20146,
+   "text": "Project fjord uses Tailwind for styling."
+  },
+  {
+   "id": 20147,
+   "text": "Project summit uses Go for the orchestrator."
+  },
+  {
+   "id": 20148,
+   "text": "Project summit targets 1,000 monthly active users."
+  },
+  {
+   "id": 20149,
+   "text": "Project monolith launches in November 2027."
+  },
+  {
+   "id": 20150,
+   "text": "Project fjord uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 20151,
+   "text": "Project junction launches in March 2027."
+  },
+  {
+   "id": 20152,
+   "text": "Project iris launches in November 2027."
+  },
+  {
+   "id": 20153,
+   "text": "Project atlas uses FastAPI for the API layer."
+  },
+  {
+   "id": 20154,
+   "text": "Project summit supports 12 locales."
+  },
+  {
+   "id": 20155,
+   "text": "Project tundra uses Docker for containerization."
+  },
+  {
+   "id": 20156,
+   "text": "Project monolith uses S3 for object storage."
+  },
+  {
+   "id": 20157,
+   "text": "Project monolith targets 100,000 monthly active users."
+  },
+  {
+   "id": 20158,
+   "text": "Project summit supports 5 locales."
+  },
+  {
+   "id": 20159,
+   "text": "Project nexus supports 42 locales."
+  },
+  {
+   "id": 20160,
+   "text": "Project delta targets 10,000 monthly active users."
+  },
+  {
+   "id": 20161,
+   "text": "Project harbor uses Python for data pipelines."
+  },
+  {
+   "id": 20162,
+   "text": "Project echo supports 5 locales."
+  },
+  {
+   "id": 20163,
+   "text": "Project iris uses Redis for caching."
+  },
+  {
+   "id": 20164,
+   "text": "Project summit uses Rust for performance-critical paths."
+  },
+  {
+   "id": 20165,
+   "text": "Project harbor uses Kubernetes for orchestration."
+  },
+  {
+   "id": 20166,
+   "text": "Project beacon launches in September 2026."
+  },
+  {
+   "id": 20167,
+   "text": "Project compass launches in June 2026."
+  },
+  {
+   "id": 20168,
+   "text": "Project harbor supports 12 locales."
+  },
+  {
+   "id": 20169,
+   "text": "Project fjord launches in September 2026."
+  },
+  {
+   "id": 20170,
+   "text": "Project orbit uses Docker for containerization."
+  },
+  {
+   "id": 20171,
+   "text": "Project quartz launches in November 2027."
+  },
+  {
+   "id": 20172,
+   "text": "Project nexus targets 1,000,000 monthly active users."
+  },
+  {
+   "id": 20173,
+   "text": "Project quartz supports 5 locales."
+  },
+  {
+   "id": 20174,
+   "text": "Project iris launches in September 2027."
+  },
+  {
+   "id": 20175,
+   "text": "Project kestrel supports 12 locales."
+  },
+  {
+   "id": 20176,
+   "text": "Project prism supports 5 locales."
+  },
+  {
+   "id": 20177,
+   "text": "Project harbor supports 5 locales."
+  },
+  {
+   "id": 20178,
+   "text": "Project orbit launches in September 2026."
+  },
+  {
+   "id": 20179,
+   "text": "Project lattice uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 20180,
+   "text": "Project junction uses S3 for object storage."
+  },
+  {
+   "id": 20181,
+   "text": "Project ridge targets 10,000 monthly active users."
+  },
+  {
+   "id": 20182,
+   "text": "Project ridge launches in November 2027."
+  },
+  {
+   "id": 20183,
+   "text": "Project summit targets 10,000 monthly active users."
+  },
+  {
+   "id": 20184,
+   "text": "Project lattice targets 100,000 monthly active users."
+  },
+  {
+   "id": 20185,
+   "text": "Project monolith launches in September 2026."
+  },
+  {
+   "id": 20186,
+   "text": "Project orbit targets 100,000 monthly active users."
+  },
+  {
+   "id": 20187,
+   "text": "Project atlas uses TypeScript for the client."
+  },
+  {
+   "id": 20188,
+   "text": "Project harbor uses TypeScript for the client."
+  },
+  {
+   "id": 20189,
+   "text": "Project compass supports 12 locales."
+  },
+  {
+   "id": 20190,
+   "text": "Project junction supports 42 locales."
+  },
+  {
+   "id": 20191,
+   "text": "Project junction uses Docker for containerization."
+  },
+  {
+   "id": 20192,
+   "text": "Project summit launches in March 2026."
+  },
+  {
+   "id": 20193,
+   "text": "Project junction launches in September 2026."
+  },
+  {
+   "id": 20194,
+   "text": "Project tundra targets 10,000 monthly active users."
+  },
+  {
+   "id": 20195,
+   "text": "Project tundra targets 1,000,000 monthly active users."
+  },
+  {
+   "id": 20196,
+   "text": "Project compass supports 5 locales."
+  },
+  {
+   "id": 20197,
+   "text": "Project iris uses Grafana for dashboards."
+  },
+  {
+   "id": 20198,
+   "text": "Project quartz uses ClickHouse for analytics."
+  },
+  {
+   "id": 20199,
+   "text": "Project lattice targets 1,000 monthly active users."
+  },
+  {
+   "id": 20200,
+   "text": "Project kestrel targets 1,000 monthly active users."
+  },
+  {
+   "id": 20201,
+   "text": "Project atlas supports 5 locales."
+  },
+  {
+   "id": 20202,
+   "text": "Project glacier supports 42 locales."
+  },
+  {
+   "id": 20203,
+   "text": "Project monolith targets 10,000 monthly active users."
+  },
+  {
+   "id": 20204,
+   "text": "Project delta launches in November 2027."
+  },
+  {
+   "id": 20205,
+   "text": "Project lattice uses Grafana for dashboards."
+  },
+  {
+   "id": 20206,
+   "text": "Project echo launches in September 2027."
+  },
+  {
+   "id": 20207,
+   "text": "Project monolith supports 3 locales."
+  },
+  {
+   "id": 20208,
+   "text": "Project delta supports 27 locales."
+  },
+  {
+   "id": 20209,
+   "text": "Project tundra launches in November 2026."
+  },
+  {
+   "id": 20210,
+   "text": "Project lattice targets 10,000 monthly active users."
+  },
+  {
+   "id": 20211,
+   "text": "Project harbor uses ClickHouse for analytics."
+  },
+  {
+   "id": 20212,
+   "text": "Project glacier supports 3 locales."
+  },
+  {
+   "id": 20213,
+   "text": "Project compass uses TypeScript for the client."
+  },
+  {
+   "id": 20214,
+   "text": "Project ridge uses TypeScript for the client."
+  },
+  {
+   "id": 20215,
+   "text": "Project beacon launches in September 2027."
+  },
+  {
+   "id": 20216,
+   "text": "Project quartz uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 20217,
+   "text": "Project junction targets 1,000 monthly active users."
+  },
+  {
+   "id": 20218,
+   "text": "Project prism uses Go for the orchestrator."
+  },
+  {
+   "id": 20219,
+   "text": "Project fjord uses Python for data pipelines."
+  },
+  {
+   "id": 20220,
+   "text": "Project ridge supports 5 locales."
+  },
+  {
+   "id": 20221,
+   "text": "Project tundra uses TypeScript for the client."
+  },
+  {
+   "id": 20222,
+   "text": "Project compass targets 10,000 monthly active users."
+  },
+  {
+   "id": 20223,
+   "text": "Project compass targets 1,000,000 monthly active users."
+  },
+  {
+   "id": 20224,
+   "text": "Project prism launches in March 2027."
+  },
+  {
+   "id": 20225,
+   "text": "Project prism uses TypeScript for the client."
+  },
+  {
+   "id": 20226,
+   "text": "Alice owns the deploy surface."
+  },
+  {
+   "id": 20227,
+   "text": "Taylor is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 20228,
+   "text": "Eve is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 20229,
+   "text": "Bob reports to Riley."
+  },
+  {
+   "id": 20230,
+   "text": "Taylor prefers async over standups."
+  },
+  {
+   "id": 20231,
+   "text": "Jack owns the search surface."
+  },
+  {
+   "id": 20232,
+   "text": "Kate is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 20233,
+   "text": "Eve is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 20234,
+   "text": "Mia owns the dashboard surface."
+  },
+  {
+   "id": 20235,
+   "text": "Liam is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 20236,
+   "text": "Quinn is on PTO from Monday to Monday."
+  },
+  {
+   "id": 20237,
+   "text": "Liam is on PTO from Friday to Monday."
+  },
+  {
+   "id": 20238,
+   "text": "Grace is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 20239,
+   "text": "Alice owns the ingest surface."
+  },
+  {
+   "id": 20240,
+   "text": "Jack is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 20241,
+   "text": "Taylor is the designer on the delta team."
+  },
+  {
+   "id": 20242,
+   "text": "Frank is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 20243,
+   "text": "Dave is the QA lead on the lattice team."
+  },
+  {
+   "id": 20244,
+   "text": "Eve reports to Riley."
+  },
+  {
+   "id": 20245,
+   "text": "Quinn is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 20246,
+   "text": "Riley reports to Olivia."
+  },
+  {
+   "id": 20247,
+   "text": "Riley reports to Mia."
+  },
+  {
+   "id": 20248,
+   "text": "Quinn is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 20249,
+   "text": "Quinn is the PM on the tundra team."
+  },
+  {
+   "id": 20250,
+   "text": "Kate owns the infra surface."
+  },
+  {
+   "id": 20251,
+   "text": "Sam is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 20252,
+   "text": "Noah reports to Alice."
+  },
+  {
+   "id": 20253,
+   "text": "Alice reports to Riley."
+  },
+  {
+   "id": 20254,
+   "text": "Riley is the engineering manager on the tundra team."
+  },
+  {
+   "id": 20255,
+   "text": "Alice reports to Mia."
+  },
+  {
+   "id": 20256,
+   "text": "Alice is on PTO from Friday to Monday."
+  },
+  {
+   "id": 20257,
+   "text": "Alice is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 20258,
+   "text": "Pat reports to Carol."
+  },
+  {
+   "id": 20259,
+   "text": "Olivia is the engineering manager on the harbor team."
+  },
+  {
+   "id": 20260,
+   "text": "Quinn reports to Henry."
+  },
+  {
+   "id": 20261,
+   "text": "Henry is the designer on the beacon team."
+  },
+  {
+   "id": 20262,
+   "text": "Sam is the staff engineer on the ridge team."
+  },
+  {
+   "id": 20263,
+   "text": "Kate is the staff engineer on the monolith team."
+  },
+  {
+   "id": 20264,
+   "text": "Taylor is the staff engineer on the prism team."
+  },
+  {
+   "id": 20265,
+   "text": "Dave is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 20266,
+   "text": "Frank is the senior engineer on the delta team."
+  },
+  {
+   "id": 20267,
+   "text": "Noah is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 20268,
+   "text": "Alice owns the infra surface."
+  },
+  {
+   "id": 20269,
+   "text": "Bob reports to Olivia."
+  },
+  {
+   "id": 20270,
+   "text": "Bob reports to Carol."
+  },
+  {
+   "id": 20271,
+   "text": "Sam is the principal engineer on the quartz team."
+  },
+  {
+   "id": 20272,
+   "text": "Mia owns the infra surface."
+  },
+  {
+   "id": 20273,
+   "text": "Sam is the PM on the monolith team."
+  },
+  {
+   "id": 20274,
+   "text": "Jack is the senior engineer on the kestrel team."
+  },
+  {
+   "id": 20275,
+   "text": "Kate is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 20276,
+   "text": "Grace is the senior engineer on the delta team."
+  },
+  {
+   "id": 20277,
+   "text": "Frank is the tech lead on the quartz team."
+  },
+  {
+   "id": 20278,
+   "text": "Ivy is the staff engineer on the beacon team."
+  },
+  {
+   "id": 20279,
+   "text": "Dave owns the API surface."
+  },
+  {
+   "id": 20280,
+   "text": "Grace is the designer on the fjord team."
+  },
+  {
+   "id": 20281,
+   "text": "Bob prefers async over standups."
+  },
+  {
+   "id": 20282,
+   "text": "Quinn reports to Grace."
+  },
+  {
+   "id": 20283,
+   "text": "Riley is the staff engineer on the lattice team."
+  },
+  {
+   "id": 20284,
+   "text": "Eve owns the dashboard surface."
+  },
+  {
+   "id": 20285,
+   "text": "Noah is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 20286,
+   "text": "Ivy owns the API surface."
+  },
+  {
+   "id": 20287,
+   "text": "Quinn reports to Alice."
+  },
+  {
+   "id": 20288,
+   "text": "Noah owns the deploy surface."
+  },
+  {
+   "id": 20289,
+   "text": "Ivy is the QA lead on the compass team."
+  },
+  {
+   "id": 20290,
+   "text": "Kate prefers async over standups."
+  },
+  {
+   "id": 20291,
+   "text": "Riley reports to Ivy."
+  },
+  {
+   "id": 20292,
+   "text": "Riley reports to Bob."
+  },
+  {
+   "id": 20293,
+   "text": "Dave is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 20294,
+   "text": "Olivia is the PM on the fjord team."
+  },
+  {
+   "id": 20295,
+   "text": "Olivia is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 20296,
+   "text": "Mia reports to Quinn."
+  },
+  {
+   "id": 20297,
+   "text": "Jack reports to Kate."
+  },
+  {
+   "id": 20298,
+   "text": "Riley is the QA lead on the summit team."
+  },
+  {
+   "id": 20299,
+   "text": "Taylor reports to Ivy."
+  },
+  {
+   "id": 20300,
+   "text": "Carol is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 20301,
+   "text": "Kate is the staff engineer on the delta team."
+  },
+  {
+   "id": 20302,
+   "text": "Mia is the QA lead on the glacier team."
+  },
+  {
+   "id": 20303,
+   "text": "Alice owns the billing surface."
+  },
+  {
+   "id": 20304,
+   "text": "Frank reports to Riley."
+  },
+  {
+   "id": 20305,
+   "text": "Olivia owns the auth surface."
+  },
+  {
+   "id": 20306,
+   "text": "Taylor is the designer on the compass team."
+  },
+  {
+   "id": 20307,
+   "text": "Bob owns the auth surface."
+  },
+  {
+   "id": 20308,
+   "text": "Taylor owns the auth surface."
+  },
+  {
+   "id": 20309,
+   "text": "Alice is the QA lead on the nexus team."
+  },
+  {
+   "id": 20310,
+   "text": "Eve is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 20311,
+   "text": "Dave is the tech lead on the summit team."
+  },
+  {
+   "id": 20312,
+   "text": "Riley is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 20313,
+   "text": "Noah is the senior engineer on the harbor team."
+  },
+  {
+   "id": 20314,
+   "text": "Ivy reports to Olivia."
+  },
+  {
+   "id": 20315,
+   "text": "Ivy is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 20316,
+   "text": "Ivy is the PM on the nexus team."
+  },
+  {
+   "id": 20317,
+   "text": "Sam is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 20318,
+   "text": "Pat is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 20319,
+   "text": "Kate is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 20320,
+   "text": "Frank reports to Grace."
+  },
+  {
+   "id": 20321,
+   "text": "Ivy is the staff engineer on the compass team."
+  },
+  {
+   "id": 20322,
+   "text": "Jack is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 20323,
+   "text": "Riley owns the search surface."
+  },
+  {
+   "id": 20324,
+   "text": "Pat reports to Jack."
+  },
+  {
+   "id": 20325,
+   "text": "Grace reports to Bob."
+  },
+  {
+   "id": 20326,
+   "text": "Noah reports to Bob."
+  },
+  {
+   "id": 20327,
+   "text": "Mia is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 20328,
+   "text": "Bob is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 20329,
+   "text": "Olivia is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 20330,
+   "text": "Jack is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 20331,
+   "text": "Henry is on PTO from Monday to Monday."
+  },
+  {
+   "id": 20332,
+   "text": "Quinn owns the ingest surface."
+  },
+  {
+   "id": 20333,
+   "text": "Mia reports to Ivy."
+  },
+  {
+   "id": 20334,
+   "text": "Mia owns the search surface."
+  },
+  {
+   "id": 20335,
+   "text": "Jack reports to Alice."
+  },
+  {
+   "id": 20336,
+   "text": "Henry owns the dashboard surface."
+  },
+  {
+   "id": 20337,
+   "text": "Sam is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 20338,
+   "text": "Dave reports to Quinn."
+  },
+  {
+   "id": 20339,
+   "text": "Frank is the principal engineer on the prism team."
+  },
+  {
+   "id": 20340,
+   "text": "Grace is the staff engineer on the tundra team."
+  },
+  {
+   "id": 20341,
+   "text": "Quinn is the senior engineer on the harbor team."
+  },
+  {
+   "id": 20342,
+   "text": "Grace is the senior engineer on the beacon team."
+  },
+  {
+   "id": 20343,
+   "text": "Ivy is the staff engineer on the iris team."
+  },
+  {
+   "id": 20344,
+   "text": "Liam reports to Taylor."
+  },
+  {
+   "id": 20345,
+   "text": "Ivy owns the search surface."
+  },
+  {
+   "id": 20346,
+   "text": "Mia reports to Noah."
+  },
+  {
+   "id": 20347,
+   "text": "Jack is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 20348,
+   "text": "Grace reports to Jack."
+  },
+  {
+   "id": 20349,
+   "text": "Alice reports to Pat."
+  },
+  {
+   "id": 20350,
+   "text": "Eve reports to Noah."
+  },
+  {
+   "id": 20351,
+   "text": "Liam owns the deploy surface."
+  },
+  {
+   "id": 20352,
+   "text": "Liam is the tech lead on the atlas team."
+  },
+  {
+   "id": 20353,
+   "text": "Kate owns the deploy surface."
+  },
+  {
+   "id": 20354,
+   "text": "Bob is the designer on the kestrel team."
+  },
+  {
+   "id": 20355,
+   "text": "Carol is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 20356,
+   "text": "Carol owns the infra surface."
+  },
+  {
+   "id": 20357,
+   "text": "Riley is the principal engineer on the tundra team."
+  },
+  {
+   "id": 20358,
+   "text": "Ivy owns the auth surface."
+  },
+  {
+   "id": 20359,
+   "text": "Grace is the PM on the beacon team."
+  },
+  {
+   "id": 20360,
+   "text": "Alice reports to Eve."
+  },
+  {
+   "id": 20361,
+   "text": "Alice is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 20362,
+   "text": "Dave is the principal engineer on the prism team."
+  },
+  {
+   "id": 20363,
+   "text": "Carol is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 20364,
+   "text": "Kate is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 20365,
+   "text": "Pat owns the infra surface."
+  },
+  {
+   "id": 20366,
+   "text": "Mia reports to Riley."
+  },
+  {
+   "id": 20367,
+   "text": "Sam is the senior engineer on the orbit team."
+  },
+  {
+   "id": 20368,
+   "text": "Eve is the designer on the orbit team."
+  },
+  {
+   "id": 20369,
+   "text": "Henry is the staff engineer on the nexus team."
+  },
+  {
+   "id": 20370,
+   "text": "Frank owns the ingest surface."
+  },
+  {
+   "id": 20371,
+   "text": "The user prefers Iosevka as their font in Neovim."
+  },
+  {
+   "id": 20372,
+   "text": "The user prefers 2 spaces as their tab width in VS Code."
+  },
+  {
+   "id": 20373,
+   "text": "The user prefers 4 spaces as their tab width in Neovim."
+  },
+  {
+   "id": 20374,
+   "text": "The user prefers Iosevka as their font in fish shell."
+  },
+  {
+   "id": 20375,
+   "text": "The user prefers Hack as their font in Sublime Text."
+  },
+  {
+   "id": 20376,
+   "text": "The user prefers 4 spaces as their tab width in IntelliJ."
+  },
+  {
+   "id": 20377,
+   "text": "The user prefers Iosevka as their font in Terminal.app."
+  },
+  {
+   "id": 20378,
+   "text": "The user prefers 4 spaces as their tab width in Zed."
+  },
+  {
+   "id": 20379,
+   "text": "The user prefers 12pt as their font size in Windsurf."
+  },
+  {
+   "id": 20380,
+   "text": "The user prefers tokyo night as their color scheme in Sublime Text."
+  },
+  {
+   "id": 20381,
+   "text": "The user prefers on save as their auto-format in Sublime Text."
+  },
+  {
+   "id": 20382,
+   "text": "The user prefers 15pt as their font size in VS Code."
+  },
+  {
+   "id": 20383,
+   "text": "The user prefers LF as their line endings in Warp."
+  },
+  {
+   "id": 20384,
+   "text": "The user prefers high-contrast as their color scheme in fish shell."
+  },
+  {
+   "id": 20385,
+   "text": "The user prefers 14pt as their font size in Terminal.app."
+  },
+  {
+   "id": 20386,
+   "text": "The user prefers nord as their color scheme in Zed."
+  },
+  {
+   "id": 20387,
+   "text": "The user prefers on save as their auto-format in Terminal.app."
+  },
+  {
+   "id": 20388,
+   "text": "The user prefers Hack as their font in VS Code."
+  },
+  {
+   "id": 20389,
+   "text": "The user prefers never as their auto-format in Hyper."
+  },
+  {
+   "id": 20390,
+   "text": "The user prefers Cascadia Code as their font in tmux."
+  },
+  {
+   "id": 20391,
+   "text": "The user prefers 13pt as their font size in Windsurf."
+  },
+  {
+   "id": 20392,
+   "text": "The user prefers command line only as their git GUI in Terminal.app."
+  },
+  {
+   "id": 20393,
+   "text": "The user prefers 16pt as their font size in IntelliJ."
+  },
+  {
+   "id": 20394,
+   "text": "The user prefers Fira Code as their font in Windsurf."
+  },
+  {
+   "id": 20395,
+   "text": "The user prefers nord as their color scheme in fish shell."
+  },
+  {
+   "id": 20396,
+   "text": "The user prefers lazygit as their git GUI in alacritty."
+  },
+  {
+   "id": 20397,
+   "text": "The user prefers nord as their color scheme in bash."
+  },
+  {
+   "id": 20398,
+   "text": "The user prefers nord as their color scheme in Warp."
+  },
+  {
+   "id": 20399,
+   "text": "The user prefers tabs as their tab width in bash."
+  },
+  {
+   "id": 20400,
+   "text": "The user prefers Fork as their git GUI in fish shell."
+  },
+  {
+   "id": 20401,
+   "text": "The user prefers 16pt as their font size in zsh."
+  },
+  {
+   "id": 20402,
+   "text": "The user prefers never as their auto-format in Zed."
+  },
+  {
+   "id": 20403,
+   "text": "The user prefers 13pt as their font size in Emacs."
+  },
+  {
+   "id": 20404,
+   "text": "The user prefers GitKraken as their git GUI in Hyper."
+  },
+  {
+   "id": 20405,
+   "text": "The user prefers command line only as their git GUI in zsh."
+  },
+  {
+   "id": 20406,
+   "text": "The user prefers nord as their color scheme in iTerm2."
+  },
+  {
+   "id": 20407,
+   "text": "The user prefers tokyo night as their color scheme in Windsurf."
+  },
+  {
+   "id": 20408,
+   "text": "The user prefers tokyo night as their color scheme in kitty."
+  },
+  {
+   "id": 20409,
+   "text": "The user prefers 2 spaces as their tab width in IntelliJ."
+  },
+  {
+   "id": 20410,
+   "text": "The user prefers Source Code Pro as their font in Hyper."
+  },
+  {
+   "id": 20411,
+   "text": "The user prefers dark mode as their color scheme in kitty."
+  },
+  {
+   "id": 20412,
+   "text": "The user prefers solarized dark as their color scheme in VS Code."
+  },
+  {
+   "id": 20413,
+   "text": "The user prefers Iosevka as their font in Vim."
+  },
+  {
+   "id": 20414,
+   "text": "The user prefers 14pt as their font size in bash."
+  },
+  {
+   "id": 20415,
+   "text": "The user prefers 14pt as their font size in Warp."
+  },
+  {
+   "id": 20416,
+   "text": "The user prefers Source Code Pro as their font in bash."
+  },
+  {
+   "id": 20417,
+   "text": "The user prefers JetBrains Mono as their font in Emacs."
+  },
+  {
+   "id": 20418,
+   "text": "The user prefers JetBrains Mono as their font in Zed."
+  },
+  {
+   "id": 20419,
+   "text": "The user prefers gruvbox as their color scheme in Emacs."
+  },
+  {
+   "id": 20420,
+   "text": "The user prefers 14pt as their font size in PyCharm."
+  },
+  {
+   "id": 20421,
+   "text": "The user prefers manually only as their auto-format in zsh."
+  },
+  {
+   "id": 20422,
+   "text": "The user prefers light mode as their color scheme in fish shell."
+  },
+  {
+   "id": 20423,
+   "text": "The user prefers tabs as their tab width in zsh."
+  },
+  {
+   "id": 20424,
+   "text": "The user prefers Fork as their git GUI in Sublime Text."
+  },
+  {
+   "id": 20425,
+   "text": "The user prefers high-contrast as their color scheme in Sublime Text."
+  },
+  {
+   "id": 20426,
+   "text": "The user prefers Cascadia Code as their font in PyCharm."
+  },
+  {
+   "id": 20427,
+   "text": "The user prefers Source Code Pro as their font in tmux."
+  },
+  {
+   "id": 20428,
+   "text": "The user prefers 2 spaces as their tab width in alacritty."
+  },
+  {
+   "id": 20429,
+   "text": "The user prefers 15pt as their font size in Sublime Text."
+  },
+  {
+   "id": 20430,
+   "text": "The user prefers manually only as their auto-format in Sublime Text."
+  },
+  {
+   "id": 20431,
+   "text": "The user prefers Fira Code as their font in Emacs."
+  },
+  {
+   "id": 20432,
+   "text": "The user prefers light mode as their color scheme in bash."
+  },
+  {
+   "id": 20433,
+   "text": "The user prefers 14pt as their font size in iTerm2."
+  },
+  {
+   "id": 20434,
+   "text": "The user prefers Source Code Pro as their font in fish shell."
+  },
+  {
+   "id": 20435,
+   "text": "The user prefers catppuccin as their color scheme in Hyper."
+  },
+  {
+   "id": 20436,
+   "text": "The user prefers 15pt as their font size in kitty."
+  },
+  {
+   "id": 20437,
+   "text": "The user prefers 15pt as their font size in Warp."
+  },
+  {
+   "id": 20438,
+   "text": "The user prefers catppuccin as their color scheme in Terminal.app."
+  },
+  {
+   "id": 20439,
+   "text": "The user prefers catppuccin as their color scheme in PyCharm."
+  },
+  {
+   "id": 20440,
+   "text": "The user prefers tabs as their tab width in iTerm2."
+  },
+  {
+   "id": 20441,
+   "text": "The user prefers 16pt as their font size in PyCharm."
+  },
+  {
+   "id": 20442,
+   "text": "The user prefers CRLF as their line endings in Hyper."
+  },
+  {
+   "id": 20443,
+   "text": "The user prefers Cascadia Code as their font in alacritty."
+  },
+  {
+   "id": 20444,
+   "text": "The user prefers never as their auto-format in Emacs."
+  },
+  {
+   "id": 20445,
+   "text": "The user prefers tig as their git GUI in alacritty."
+  },
+  {
+   "id": 20446,
+   "text": "The user prefers CRLF as their line endings in Warp."
+  },
+  {
+   "id": 20447,
+   "text": "The user prefers nord as their color scheme in zsh."
+  },
+  {
+   "id": 20448,
+   "text": "The user prefers tig as their git GUI in Sublime Text."
+  },
+  {
+   "id": 20449,
+   "text": "The user prefers light mode as their color scheme in Neovim."
+  },
+  {
+   "id": 20450,
+   "text": "The user prefers 13pt as their font size in VS Code."
+  },
+  {
+   "id": 20451,
+   "text": "The user prefers catppuccin as their color scheme in IntelliJ."
+  },
+  {
+   "id": 20452,
+   "text": "The user prefers Fira Code as their font in Warp."
+  },
+  {
+   "id": 20453,
+   "text": "The user prefers 13pt as their font size in zsh."
+  },
+  {
+   "id": 20454,
+   "text": "The user prefers 16pt as their font size in Cursor."
+  },
+  {
+   "id": 20455,
+   "text": "The user prefers 15pt as their font size in fish shell."
+  },
+  {
+   "id": 20456,
+   "text": "The user prefers dark mode as their color scheme in Windsurf."
+  },
+  {
+   "id": 20457,
+   "text": "Project lattice supports 42 locales."
+  },
+  {
+   "id": 20458,
+   "text": "Project kestrel supports 42 locales."
+  },
+  {
+   "id": 20459,
+   "text": "Project echo uses Docker for containerization."
+  },
+  {
+   "id": 20460,
+   "text": "Project ridge uses Sentry for error tracking."
+  },
+  {
+   "id": 20461,
+   "text": "Project junction uses Elasticsearch for search."
+  },
+  {
+   "id": 20462,
+   "text": "Project iris uses S3 for object storage."
+  },
+  {
+   "id": 20463,
+   "text": "Project kestrel launches in June 2026."
+  },
+  {
+   "id": 20464,
+   "text": "Project atlas uses Elasticsearch for search."
+  },
+  {
+   "id": 20465,
+   "text": "Project quartz supports 3 locales."
+  },
+  {
+   "id": 20466,
+   "text": "Project atlas uses Sentry for error tracking."
+  },
+  {
+   "id": 20467,
+   "text": "Project beacon targets 100,000 monthly active users."
+  },
+  {
+   "id": 20468,
+   "text": "Project tundra uses FastAPI for the API layer."
+  },
+  {
+   "id": 20469,
+   "text": "Project orbit launches in September 2027."
+  },
+  {
+   "id": 20470,
+   "text": "Project prism targets 1,000 monthly active users."
+  },
+  {
+   "id": 20471,
+   "text": "Project quartz uses TypeScript for the client."
+  },
+  {
+   "id": 20472,
+   "text": "Project tundra launches in September 2026."
+  },
+  {
+   "id": 20473,
+   "text": "Project lattice launches in September 2026."
+  },
+  {
+   "id": 20474,
+   "text": "Project echo uses ClickHouse for analytics."
+  },
+  {
+   "id": 20475,
+   "text": "Project harbor supports 27 locales."
+  },
+  {
+   "id": 20476,
+   "text": "Project ridge supports 12 locales."
+  },
+  {
+   "id": 20477,
+   "text": "Project fjord uses Kafka for event streaming."
+  },
+  {
+   "id": 20478,
+   "text": "Project fjord launches in June 2026."
+  },
+  {
+   "id": 20479,
+   "text": "Project atlas uses Redis for caching."
+  },
+  {
+   "id": 20480,
+   "text": "Project echo supports 27 locales."
+  },
+  {
+   "id": 20481,
+   "text": "Project delta launches in November 2026."
+  },
+  {
+   "id": 20482,
+   "text": "Project lattice uses Tailwind for styling."
+  },
+  {
+   "id": 20483,
+   "text": "Project compass supports 27 locales."
+  },
+  {
+   "id": 20484,
+   "text": "Project kestrel uses Redis for caching."
+  },
+  {
+   "id": 20485,
+   "text": "Project kestrel uses Next.js for server-side rendering."
+  },
+  {
+   "id": 20486,
+   "text": "Project harbor launches in June 2027."
+  },
+  {
+   "id": 20487,
+   "text": "Project nexus uses Sentry for error tracking."
+  },
+  {
+   "id": 20488,
+   "text": "Project nexus launches in June 2027."
+  },
+  {
+   "id": 20489,
+   "text": "Project quartz uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 20490,
+   "text": "Project fjord launches in March 2026."
+  },
+  {
+   "id": 20491,
+   "text": "Project harbor targets 1,000,000 monthly active users."
+  },
+  {
+   "id": 20492,
+   "text": "Project nexus launches in March 2026."
+  },
+  {
+   "id": 20493,
+   "text": "Project quartz uses Docker for containerization."
+  },
+  {
+   "id": 20494,
+   "text": "Project harbor supports 42 locales."
+  },
+  {
+   "id": 20495,
+   "text": "Project quartz launches in June 2027."
+  },
+  {
+   "id": 20496,
+   "text": "Project tundra uses Redis for caching."
+  },
+  {
+   "id": 20497,
+   "text": "Project quartz supports 42 locales."
+  },
+  {
+   "id": 20498,
+   "text": "Project summit launches in September 2027."
+  },
+  {
+   "id": 20499,
+   "text": "Project monolith uses Sentry for error tracking."
+  },
+  {
+   "id": 20500,
+   "text": "Project monolith uses Kubernetes for orchestration."
+  },
+  {
+   "id": 20501,
+   "text": "Project prism targets 10,000 monthly active users."
+  },
+  {
+   "id": 20502,
+   "text": "Project kestrel launches in September 2027."
+  },
+  {
+   "id": 20503,
+   "text": "Project quartz launches in June 2026."
+  },
+  {
+   "id": 20504,
+   "text": "Project compass uses Redis for caching."
+  },
+  {
+   "id": 20505,
+   "text": "Project ridge uses React for the frontend."
+  },
+  {
+   "id": 20506,
+   "text": "Project fjord uses React for the frontend."
+  },
+  {
+   "id": 20507,
+   "text": "Project kestrel uses Go for the orchestrator."
+  },
+  {
+   "id": 20508,
+   "text": "Project harbor launches in September 2027."
+  },
+  {
+   "id": 20509,
+   "text": "Project compass uses Docker for containerization."
+  },
+  {
+   "id": 20510,
+   "text": "Project quartz uses Go for the orchestrator."
+  },
+  {
+   "id": 20511,
+   "text": "Project atlas uses Tailwind for styling."
+  },
+  {
+   "id": 20512,
+   "text": "Project echo launches in March 2027."
+  },
+  {
+   "id": 20513,
+   "text": "Project fjord uses Next.js for server-side rendering."
+  },
+  {
+   "id": 20514,
+   "text": "Project tundra uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 20515,
+   "text": "Project fjord uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 20516,
+   "text": "Project monolith uses TypeScript for the client."
+  },
+  {
+   "id": 20517,
+   "text": "Project fjord targets 1,000 monthly active users."
+  },
+  {
+   "id": 20518,
+   "text": "Project quartz launches in November 2026."
+  },
+  {
+   "id": 20519,
+   "text": "Project orbit launches in March 2027."
+  },
+  {
+   "id": 20520,
+   "text": "Project atlas supports 42 locales."
+  },
+  {
+   "id": 20521,
+   "text": "Project lattice launches in June 2026."
+  },
+  {
+   "id": 20522,
+   "text": "Project lattice uses S3 for object storage."
+  },
+  {
+   "id": 20523,
+   "text": "Project delta uses Python for data pipelines."
+  },
+  {
+   "id": 20524,
+   "text": "Project harbor uses FastAPI for the API layer."
+  },
+  {
+   "id": 20525,
+   "text": "Project delta uses S3 for object storage."
+  },
+  {
+   "id": 20526,
+   "text": "Project junction supports 27 locales."
+  },
+  {
+   "id": 20527,
+   "text": "Project kestrel uses Python for data pipelines."
+  },
+  {
+   "id": 20528,
+   "text": "Project fjord supports 42 locales."
+  },
+  {
+   "id": 20529,
+   "text": "Project quartz targets 1,000,000 monthly active users."
+  },
+  {
+   "id": 20530,
+   "text": "Project echo uses React for the frontend."
+  },
+  {
+   "id": 20531,
+   "text": "Project quartz uses Python for data pipelines."
+  },
+  {
+   "id": 20532,
+   "text": "Project atlas uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 20533,
+   "text": "Project glacier launches in September 2026."
+  },
+  {
+   "id": 20534,
+   "text": "Project beacon uses TypeScript for the client."
+  },
+  {
+   "id": 20535,
+   "text": "Quinn is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 20536,
+   "text": "Jack reports to Eve."
+  },
+  {
+   "id": 20537,
+   "text": "Jack is the designer on the echo team."
+  },
+  {
+   "id": 20538,
+   "text": "Riley is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 20539,
+   "text": "Quinn reports to Jack."
+  },
+  {
+   "id": 20540,
+   "text": "Quinn owns the dashboard surface."
+  },
+  {
+   "id": 20541,
+   "text": "Olivia reports to Ivy."
+  },
+  {
+   "id": 20542,
+   "text": "Sam owns the deploy surface."
+  },
+  {
+   "id": 20543,
+   "text": "Grace reports to Riley."
+  },
+  {
+   "id": 20544,
+   "text": "Henry reports to Quinn."
+  },
+  {
+   "id": 20545,
+   "text": "Sam is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 20546,
+   "text": "Dave is the QA lead on the harbor team."
+  },
+  {
+   "id": 20547,
+   "text": "Sam owns the dashboard surface."
+  },
+  {
+   "id": 20548,
+   "text": "Dave is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 20549,
+   "text": "Henry is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 20550,
+   "text": "Pat is the engineering manager on the junction team."
+  },
+  {
+   "id": 20551,
+   "text": "Riley is the PM on the echo team."
+  },
+  {
+   "id": 20552,
+   "text": "Carol is the staff engineer on the echo team."
+  },
+  {
+   "id": 20553,
+   "text": "Pat is the designer on the iris team."
+  },
+  {
+   "id": 20554,
+   "text": "Henry is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 20555,
+   "text": "Dave owns the deploy surface."
+  },
+  {
+   "id": 20556,
+   "text": "Kate owns the dashboard surface."
+  },
+  {
+   "id": 20557,
+   "text": "Dave is on PTO from Friday to Friday."
+  },
+  {
+   "id": 20558,
+   "text": "Pat reports to Dave."
+  },
+  {
+   "id": 20559,
+   "text": "Bob owns the ingest surface."
+  },
+  {
+   "id": 20560,
+   "text": "Liam reports to Olivia."
+  },
+  {
+   "id": 20561,
+   "text": "Liam reports to Eve."
+  },
+  {
+   "id": 20562,
+   "text": "Taylor is the QA lead on the glacier team."
+  },
+  {
+   "id": 20563,
+   "text": "Liam is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 20564,
+   "text": "Kate is on PTO from Friday to Monday."
+  },
+  {
+   "id": 20565,
+   "text": "Olivia reports to Dave."
+  },
+  {
+   "id": 20566,
+   "text": "Taylor reports to Liam."
+  },
+  {
+   "id": 20567,
+   "text": "Ivy is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 20568,
+   "text": "Dave is the senior engineer on the harbor team."
+  },
+  {
+   "id": 20569,
+   "text": "Liam owns the auth surface."
+  },
+  {
+   "id": 20570,
+   "text": "Sam owns the billing surface."
+  },
+  {
+   "id": 20571,
+   "text": "Henry reports to Pat."
+  },
+  {
+   "id": 20572,
+   "text": "Riley is on PTO from Monday to Friday."
+  },
+  {
+   "id": 20573,
+   "text": "Mia is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 20574,
+   "text": "Ivy is the designer on the prism team."
+  },
+  {
+   "id": 20575,
+   "text": "Henry is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 20576,
+   "text": "Quinn reports to Sam."
+  },
+  {
+   "id": 20577,
+   "text": "Noah owns the ingest surface."
+  },
+  {
+   "id": 20578,
+   "text": "Mia reports to Liam."
+  },
+  {
+   "id": 20579,
+   "text": "Frank is the tech lead on the tundra team."
+  },
+  {
+   "id": 20580,
+   "text": "Mia is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 20581,
+   "text": "Grace is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 20582,
+   "text": "Pat owns the auth surface."
+  },
+  {
+   "id": 20583,
+   "text": "Dave reports to Taylor."
+  },
+  {
+   "id": 20584,
+   "text": "Carol owns the dashboard surface."
+  },
+  {
+   "id": 20585,
+   "text": "Kate is the designer on the iris team."
+  },
+  {
+   "id": 20586,
+   "text": "Frank owns the infra surface."
+  },
+  {
+   "id": 20587,
+   "text": "Quinn owns the auth surface."
+  },
+  {
+   "id": 20588,
+   "text": "Pat reports to Kate."
+  },
+  {
+   "id": 20589,
+   "text": "Noah owns the search surface."
+  },
+  {
+   "id": 20590,
+   "text": "Jack reports to Grace."
+  },
+  {
+   "id": 20591,
+   "text": "Jack is the QA lead on the nexus team."
+  },
+  {
+   "id": 20592,
+   "text": "Riley reports to Frank."
+  },
+  {
+   "id": 20593,
+   "text": "Liam owns the dashboard surface."
+  },
+  {
+   "id": 20594,
+   "text": "Ivy reports to Liam."
+  },
+  {
+   "id": 20595,
+   "text": "Mia is the designer on the echo team."
+  },
+  {
+   "id": 20596,
+   "text": "Taylor is on PTO from Friday to Monday."
+  },
+  {
+   "id": 20597,
+   "text": "Taylor is on PTO from Monday to Friday."
+  },
+  {
+   "id": 20598,
+   "text": "Ivy owns the dashboard surface."
+  },
+  {
+   "id": 20599,
+   "text": "Frank is the PM on the summit team."
+  },
+  {
+   "id": 20600,
+   "text": "Eve is on PTO from Friday to Monday."
+  },
+  {
+   "id": 20601,
+   "text": "Kate owns the ingest surface."
+  },
+  {
+   "id": 20602,
+   "text": "Carol is the principal engineer on the kestrel team."
+  },
+  {
+   "id": 20603,
+   "text": "Sam is the PM on the iris team."
+  },
+  {
+   "id": 20604,
+   "text": "Pat is the engineering manager on the delta team."
+  },
+  {
+   "id": 20605,
+   "text": "Carol is the QA lead on the monolith team."
+  },
+  {
+   "id": 20606,
+   "text": "Ivy reports to Mia."
+  },
+  {
+   "id": 20607,
+   "text": "Olivia is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 20608,
+   "text": "Ivy is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 20609,
+   "text": "Pat reports to Eve."
+  },
+  {
+   "id": 20610,
+   "text": "Henry is the designer on the monolith team."
+  },
+  {
+   "id": 20611,
+   "text": "Dave is the senior engineer on the monolith team."
+  },
+  {
+   "id": 20612,
+   "text": "Grace is the principal engineer on the iris team."
+  },
+  {
+   "id": 20613,
+   "text": "Carol is the staff engineer on the junction team."
+  },
+  {
+   "id": 20614,
+   "text": "Riley is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 20615,
+   "text": "Bob is the QA lead on the fjord team."
+  },
+  {
+   "id": 20616,
+   "text": "Ivy reports to Taylor."
+  },
+  {
+   "id": 20617,
+   "text": "Sam is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 20618,
+   "text": "Olivia is the designer on the tundra team."
+  },
+  {
+   "id": 20619,
+   "text": "Jack reports to Carol."
+  },
+  {
+   "id": 20620,
+   "text": "Alice is the tech lead on the orbit team."
+  },
+  {
+   "id": 20621,
+   "text": "Riley owns the ingest surface."
+  },
+  {
+   "id": 20622,
+   "text": "Frank is the senior engineer on the compass team."
+  },
+  {
+   "id": 20623,
+   "text": "Jack is the designer on the tundra team."
+  },
+  {
+   "id": 20624,
+   "text": "Olivia is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 20625,
+   "text": "Alice owns the dashboard surface."
+  },
+  {
+   "id": 20626,
+   "text": "Pat is the QA lead on the delta team."
+  },
+  {
+   "id": 20627,
+   "text": "Alice is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 20628,
+   "text": "Kate owns the API surface."
+  },
+  {
+   "id": 20629,
+   "text": "Grace is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 20630,
+   "text": "Carol is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 20631,
+   "text": "Riley owns the deploy surface."
+  },
+  {
+   "id": 20632,
+   "text": "Olivia owns the deploy surface."
+  },
+  {
+   "id": 20633,
+   "text": "Jack is on PTO from Monday to Friday."
+  },
+  {
+   "id": 20634,
+   "text": "Frank owns the auth surface."
+  },
+  {
+   "id": 20635,
+   "text": "Alice is the tech lead on the junction team."
+  },
+  {
+   "id": 20636,
+   "text": "Kate reports to Mia."
+  },
+  {
+   "id": 20637,
+   "text": "Frank is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 20638,
+   "text": "Olivia is the QA lead on the beacon team."
+  },
+  {
+   "id": 20639,
+   "text": "Sam is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 20640,
+   "text": "Taylor reports to Olivia."
+  },
+  {
+   "id": 20641,
+   "text": "Riley is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 20642,
+   "text": "Noah reports to Henry."
+  },
+  {
+   "id": 20643,
+   "text": "Olivia is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 20644,
+   "text": "Henry is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 20645,
+   "text": "Riley reports to Jack."
+  },
+  {
+   "id": 20646,
+   "text": "Jack is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 20647,
+   "text": "Grace reports to Ivy."
+  },
+  {
+   "id": 20648,
+   "text": "Riley is the senior engineer on the fjord team."
+  },
+  {
+   "id": 20649,
+   "text": "Liam is the engineering manager on the iris team."
+  },
+  {
+   "id": 20650,
+   "text": "Mia owns the API surface."
+  },
+  {
+   "id": 20651,
+   "text": "Alice is the senior engineer on the prism team."
+  },
+  {
+   "id": 20652,
+   "text": "Mia is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 20653,
+   "text": "Frank is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 20654,
+   "text": "Taylor reports to Noah."
+  },
+  {
+   "id": 20655,
+   "text": "Sam is the designer on the orbit team."
+  },
+  {
+   "id": 20656,
+   "text": "Kate is the senior engineer on the quartz team."
+  },
+  {
+   "id": 20657,
+   "text": "Noah is on PTO from Friday to Monday."
+  },
+  {
+   "id": 20658,
+   "text": "Quinn is on PTO from Friday to Friday."
+  },
+  {
+   "id": 20659,
+   "text": "The user prefers never as their auto-format in Cursor."
+  },
+  {
+   "id": 20660,
+   "text": "The user prefers solarized dark as their color scheme in alacritty."
+  },
+  {
+   "id": 20661,
+   "text": "The user prefers Fira Code as their font in fish shell."
+  },
+  {
+   "id": 20662,
+   "text": "The user prefers JetBrains Mono as their font in alacritty."
+  },
+  {
+   "id": 20663,
+   "text": "The user prefers 14pt as their font size in Neovim."
+  },
+  {
+   "id": 20664,
+   "text": "The user prefers light mode as their color scheme in kitty."
+  },
+  {
+   "id": 20665,
+   "text": "The user prefers JetBrains Mono as their font in PyCharm."
+  },
+  {
+   "id": 20666,
+   "text": "The user prefers tokyo night as their color scheme in Neovim."
+  },
+  {
+   "id": 20667,
+   "text": "The user prefers 15pt as their font size in Terminal.app."
+  },
+  {
+   "id": 20668,
+   "text": "The user prefers tokyo night as their color scheme in VS Code."
+  },
+  {
+   "id": 20669,
+   "text": "The user prefers Fira Code as their font in VS Code."
+  },
+  {
+   "id": 20670,
+   "text": "The user prefers Cascadia Code as their font in Emacs."
+  },
+  {
+   "id": 20671,
+   "text": "The user prefers Fira Code as their font in alacritty."
+  },
+  {
+   "id": 20672,
+   "text": "The user prefers 16pt as their font size in Emacs."
+  },
+  {
+   "id": 20673,
+   "text": "The user prefers catppuccin as their color scheme in Cursor."
+  },
+  {
+   "id": 20674,
+   "text": "The user prefers Cascadia Code as their font in kitty."
+  },
+  {
+   "id": 20675,
+   "text": "The user prefers 2 spaces as their tab width in bash."
+  },
+  {
+   "id": 20676,
+   "text": "The user prefers CRLF as their line endings in fish shell."
+  },
+  {
+   "id": 20677,
+   "text": "The user prefers 12pt as their font size in Zed."
+  },
+  {
+   "id": 20678,
+   "text": "The user prefers 16pt as their font size in bash."
+  },
+  {
+   "id": 20679,
+   "text": "The user prefers 2 spaces as their tab width in Cursor."
+  },
+  {
+   "id": 20680,
+   "text": "The user prefers tokyo night as their color scheme in IntelliJ."
+  },
+  {
+   "id": 20681,
+   "text": "The user prefers tig as their git GUI in bash."
+  },
+  {
+   "id": 20682,
+   "text": "The user prefers CRLF as their line endings in Zed."
+  },
+  {
+   "id": 20683,
+   "text": "The user prefers tig as their git GUI in Hyper."
+  },
+  {
+   "id": 20684,
+   "text": "The user prefers 4 spaces as their tab width in Warp."
+  },
+  {
+   "id": 20685,
+   "text": "The user prefers never as their auto-format in tmux."
+  },
+  {
+   "id": 20686,
+   "text": "The user prefers 4 spaces as their tab width in Windsurf."
+  },
+  {
+   "id": 20687,
+   "text": "The user prefers manually only as their auto-format in Zed."
+  },
+  {
+   "id": 20688,
+   "text": "The user prefers Iosevka as their font in Sublime Text."
+  },
+  {
+   "id": 20689,
+   "text": "The user prefers light mode as their color scheme in Zed."
+  },
+  {
+   "id": 20690,
+   "text": "The user prefers 16pt as their font size in Sublime Text."
+  },
+  {
+   "id": 20691,
+   "text": "The user prefers 14pt as their font size in Hyper."
+  },
+  {
+   "id": 20692,
+   "text": "The user prefers GitKraken as their git GUI in zsh."
+  },
+  {
+   "id": 20693,
+   "text": "The user prefers 2 spaces as their tab width in Sublime Text."
+  },
+  {
+   "id": 20694,
+   "text": "The user prefers JetBrains Mono as their font in Neovim."
+  },
+  {
+   "id": 20695,
+   "text": "The user prefers GitKraken as their git GUI in Zed."
+  },
+  {
+   "id": 20696,
+   "text": "The user prefers tokyo night as their color scheme in Warp."
+  },
+  {
+   "id": 20697,
+   "text": "The user prefers catppuccin as their color scheme in iTerm2."
+  },
+  {
+   "id": 20698,
+   "text": "The user prefers LF as their line endings in VS Code."
+  },
+  {
+   "id": 20699,
+   "text": "The user prefers solarized dark as their color scheme in Vim."
+  },
+  {
+   "id": 20700,
+   "text": "The user prefers Fork as their git GUI in tmux."
+  },
+  {
+   "id": 20701,
+   "text": "The user prefers Cascadia Code as their font in Terminal.app."
+  },
+  {
+   "id": 20702,
+   "text": "The user prefers Fira Code as their font in Terminal.app."
+  },
+  {
+   "id": 20703,
+   "text": "The user prefers CRLF as their line endings in tmux."
+  },
+  {
+   "id": 20704,
+   "text": "The user prefers Cascadia Code as their font in Warp."
+  },
+  {
+   "id": 20705,
+   "text": "The user prefers Hack as their font in Zed."
+  },
+  {
+   "id": 20706,
+   "text": "The user prefers 2 spaces as their tab width in tmux."
+  },
+  {
+   "id": 20707,
+   "text": "The user prefers Source Code Pro as their font in Zed."
+  },
+  {
+   "id": 20708,
+   "text": "The user prefers Fork as their git GUI in Neovim."
+  },
+  {
+   "id": 20709,
+   "text": "The user prefers 13pt as their font size in Neovim."
+  },
+  {
+   "id": 20710,
+   "text": "The user prefers Fira Code as their font in IntelliJ."
+  },
+  {
+   "id": 20711,
+   "text": "The user prefers 14pt as their font size in VS Code."
+  },
+  {
+   "id": 20712,
+   "text": "The user prefers catppuccin as their color scheme in Neovim."
+  },
+  {
+   "id": 20713,
+   "text": "The user prefers manually only as their auto-format in VS Code."
+  },
+  {
+   "id": 20714,
+   "text": "The user prefers 16pt as their font size in Zed."
+  },
+  {
+   "id": 20715,
+   "text": "The user prefers 15pt as their font size in iTerm2."
+  },
+  {
+   "id": 20716,
+   "text": "The user prefers 14pt as their font size in Emacs."
+  },
+  {
+   "id": 20717,
+   "text": "The user prefers 14pt as their font size in IntelliJ."
+  },
+  {
+   "id": 20718,
+   "text": "The user prefers 2 spaces as their tab width in Neovim."
+  },
+  {
+   "id": 20719,
+   "text": "The user prefers 12pt as their font size in fish shell."
+  },
+  {
+   "id": 20720,
+   "text": "The user prefers Cascadia Code as their font in Cursor."
+  },
+  {
+   "id": 20721,
+   "text": "The user prefers 16pt as their font size in Hyper."
+  },
+  {
+   "id": 20722,
+   "text": "The user prefers Fork as their git GUI in bash."
+  },
+  {
+   "id": 20723,
+   "text": "The user prefers on save as their auto-format in Windsurf."
+  },
+  {
+   "id": 20724,
+   "text": "Project kestrel supports 5 locales."
+  },
+  {
+   "id": 20725,
+   "text": "Project lattice supports 12 locales."
+  },
+  {
+   "id": 20726,
+   "text": "Project beacon targets 10,000 monthly active users."
+  },
+  {
+   "id": 20727,
+   "text": "Project nexus launches in March 2027."
+  },
+  {
+   "id": 20728,
+   "text": "Project quartz uses S3 for object storage."
+  },
+  {
+   "id": 20729,
+   "text": "Project compass uses Go for the orchestrator."
+  },
+  {
+   "id": 20730,
+   "text": "Project orbit targets 1,000,000 monthly active users."
+  },
+  {
+   "id": 20731,
+   "text": "Project iris uses TypeScript for the client."
+  },
+  {
+   "id": 20732,
+   "text": "Project beacon launches in June 2027."
+  },
+  {
+   "id": 20733,
+   "text": "Project beacon uses Elasticsearch for search."
+  },
+  {
+   "id": 20734,
+   "text": "Project quartz launches in March 2026."
+  },
+  {
+   "id": 20735,
+   "text": "Project iris supports 42 locales."
+  },
+  {
+   "id": 20736,
+   "text": "Project nexus supports 27 locales."
+  },
+  {
+   "id": 20737,
+   "text": "Project tundra launches in November 2027."
+  },
+  {
+   "id": 20738,
+   "text": "Project lattice uses Redis for caching."
+  },
+  {
+   "id": 20739,
+   "text": "Project kestrel uses ClickHouse for analytics."
+  },
+  {
+   "id": 20740,
+   "text": "Project tundra uses Elasticsearch for search."
+  },
+  {
+   "id": 20741,
+   "text": "Project iris targets 1,000 monthly active users."
+  },
+  {
+   "id": 20742,
+   "text": "Project glacier uses ClickHouse for analytics."
+  },
+  {
+   "id": 20743,
+   "text": "Project nexus uses Elasticsearch for search."
+  },
+  {
+   "id": 20744,
+   "text": "Project orbit uses Elasticsearch for search."
+  },
+  {
+   "id": 20745,
+   "text": "Project echo supports 3 locales."
+  },
+  {
+   "id": 20746,
+   "text": "Project beacon launches in March 2026."
+  },
+  {
+   "id": 20747,
+   "text": "Project summit uses Docker for containerization."
+  },
+  {
+   "id": 20748,
+   "text": "Project delta targets 1,000 monthly active users."
+  },
+  {
+   "id": 20749,
+   "text": "Project glacier launches in November 2026."
+  },
+  {
+   "id": 20750,
+   "text": "Project fjord launches in September 2027."
+  },
+  {
+   "id": 20751,
+   "text": "Project junction uses FastAPI for the API layer."
+  },
+  {
+   "id": 20752,
+   "text": "Project beacon uses Grafana for dashboards."
+  },
+  {
+   "id": 20753,
+   "text": "Project prism launches in November 2027."
+  },
+  {
+   "id": 20754,
+   "text": "Project orbit launches in June 2026."
+  },
+  {
+   "id": 20755,
+   "text": "Project junction launches in June 2026."
+  },
+  {
+   "id": 20756,
+   "text": "Project beacon uses Redis for caching."
+  },
+  {
+   "id": 20757,
+   "text": "Project tundra launches in September 2027."
+  },
+  {
+   "id": 20758,
+   "text": "Project ridge launches in June 2027."
+  },
+  {
+   "id": 20759,
+   "text": "Project fjord uses Grafana for dashboards."
+  },
+  {
+   "id": 20760,
+   "text": "Project summit uses ClickHouse for analytics."
+  },
+  {
+   "id": 20761,
+   "text": "Project quartz targets 1,000 monthly active users."
+  },
+  {
+   "id": 20762,
+   "text": "Project beacon launches in November 2027."
+  },
+  {
+   "id": 20763,
+   "text": "Project summit uses S3 for object storage."
+  },
+  {
+   "id": 20764,
+   "text": "Project glacier uses Elasticsearch for search."
+  },
+  {
+   "id": 20765,
+   "text": "Project ridge uses Docker for containerization."
+  },
+  {
+   "id": 20766,
+   "text": "Project kestrel uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 20767,
+   "text": "Project fjord uses Rust for performance-critical paths."
+  },
+  {
+   "id": 20768,
+   "text": "Project junction launches in November 2026."
+  },
+  {
+   "id": 20769,
+   "text": "Project beacon uses React for the frontend."
+  },
+  {
+   "id": 20770,
+   "text": "Project monolith launches in November 2026."
+  },
+  {
+   "id": 20771,
+   "text": "Project iris uses React for the frontend."
+  },
+  {
+   "id": 20772,
+   "text": "Project atlas launches in September 2027."
+  },
+  {
+   "id": 20773,
+   "text": "Project atlas uses Go for the orchestrator."
+  },
+  {
+   "id": 20774,
+   "text": "Project orbit uses Kafka for event streaming."
+  },
+  {
+   "id": 20775,
+   "text": "Taylor reports to Kate."
+  },
+  {
+   "id": 20776,
+   "text": "Kate is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 20777,
+   "text": "Jack owns the ingest surface."
+  },
+  {
+   "id": 20778,
+   "text": "Liam is on PTO from Monday to Friday."
+  },
+  {
+   "id": 20779,
+   "text": "Grace is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 20780,
+   "text": "Alice is the engineering manager on the tundra team."
+  },
+  {
+   "id": 20781,
+   "text": "Kate owns the search surface."
+  },
+  {
+   "id": 20782,
+   "text": "Alice is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 20783,
+   "text": "Liam is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 20784,
+   "text": "Eve reports to Olivia."
+  },
+  {
+   "id": 20785,
+   "text": "Frank owns the search surface."
+  },
+  {
+   "id": 20786,
+   "text": "Frank reports to Sam."
+  },
+  {
+   "id": 20787,
+   "text": "Grace is the PM on the orbit team."
+  },
+  {
+   "id": 20788,
+   "text": "Mia is the tech lead on the echo team."
+  },
+  {
+   "id": 20789,
+   "text": "Riley is the principal engineer on the quartz team."
+  },
+  {
+   "id": 20790,
+   "text": "Pat is the QA lead on the echo team."
+  },
+  {
+   "id": 20791,
+   "text": "Bob is the senior engineer on the iris team."
+  },
+  {
+   "id": 20792,
+   "text": "Olivia is the tech lead on the echo team."
+  },
+  {
+   "id": 20793,
+   "text": "Ivy reports to Kate."
+  },
+  {
+   "id": 20794,
+   "text": "Carol is the QA lead on the lattice team."
+  },
+  {
+   "id": 20795,
+   "text": "Carol owns the auth surface."
+  },
+  {
+   "id": 20796,
+   "text": "Liam is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 20797,
+   "text": "Eve is the designer on the fjord team."
+  },
+  {
+   "id": 20798,
+   "text": "Alice is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 20799,
+   "text": "Grace is the engineering manager on the delta team."
+  },
+  {
+   "id": 20800,
+   "text": "Taylor owns the ingest surface."
+  },
+  {
+   "id": 20801,
+   "text": "Mia is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 20802,
+   "text": "Riley owns the infra surface."
+  },
+  {
+   "id": 20803,
+   "text": "Pat reports to Quinn."
+  },
+  {
+   "id": 20804,
+   "text": "Bob is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 20805,
+   "text": "Alice reports to Bob."
+  },
+  {
+   "id": 20806,
+   "text": "Riley reports to Henry."
+  },
+  {
+   "id": 20807,
+   "text": "Mia is the senior engineer on the quartz team."
+  },
+  {
+   "id": 20808,
+   "text": "Quinn is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 20809,
+   "text": "Riley is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 20810,
+   "text": "Olivia reports to Eve."
+  },
+  {
+   "id": 20811,
+   "text": "Dave is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 20812,
+   "text": "Ivy owns the billing surface."
+  },
+  {
+   "id": 20813,
+   "text": "Taylor is the QA lead on the compass team."
+  },
+  {
+   "id": 20814,
+   "text": "Quinn owns the search surface."
+  },
+  {
+   "id": 20815,
+   "text": "Kate is the principal engineer on the iris team."
+  },
+  {
+   "id": 20816,
+   "text": "Noah is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 20817,
+   "text": "Kate reports to Riley."
+  },
+  {
+   "id": 20818,
+   "text": "Alice is the PM on the delta team."
+  },
+  {
+   "id": 20819,
+   "text": "Frank is the designer on the beacon team."
+  },
+  {
+   "id": 20820,
+   "text": "Jack reports to Dave."
+  },
+  {
+   "id": 20821,
+   "text": "Quinn owns the API surface."
+  },
+  {
+   "id": 20822,
+   "text": "Kate is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 20823,
+   "text": "Jack is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 20824,
+   "text": "Frank owns the deploy surface."
+  },
+  {
+   "id": 20825,
+   "text": "Eve is the tech lead on the harbor team."
+  },
+  {
+   "id": 20826,
+   "text": "Sam reports to Henry."
+  },
+  {
+   "id": 20827,
+   "text": "Sam owns the infra surface."
+  },
+  {
+   "id": 20828,
+   "text": "Jack is the engineering manager on the iris team."
+  },
+  {
+   "id": 20829,
+   "text": "Noah reports to Liam."
+  },
+  {
+   "id": 20830,
+   "text": "Grace reports to Mia."
+  },
+  {
+   "id": 20831,
+   "text": "Grace reports to Liam."
+  },
+  {
+   "id": 20832,
+   "text": "Pat is the designer on the harbor team."
+  },
+  {
+   "id": 20833,
+   "text": "Carol reports to Riley."
+  },
+  {
+   "id": 20834,
+   "text": "Kate is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 20835,
+   "text": "Grace is the senior engineer on the kestrel team."
+  },
+  {
+   "id": 20836,
+   "text": "Eve is the tech lead on the beacon team."
+  },
+  {
+   "id": 20837,
+   "text": "Quinn owns the deploy surface."
+  },
+  {
+   "id": 20838,
+   "text": "Frank is the senior engineer on the glacier team."
+  },
+  {
+   "id": 20839,
+   "text": "Ivy is the senior engineer on the ridge team."
+  },
+  {
+   "id": 20840,
+   "text": "Ivy is the PM on the tundra team."
+  },
+  {
+   "id": 20841,
+   "text": "Alice reports to Grace."
+  },
+  {
+   "id": 20842,
+   "text": "Alice reports to Quinn."
+  },
+  {
+   "id": 20843,
+   "text": "Alice is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 20844,
+   "text": "Bob is the tech lead on the glacier team."
+  },
+  {
+   "id": 20845,
+   "text": "Olivia is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 20846,
+   "text": "Dave reports to Jack."
+  },
+  {
+   "id": 20847,
+   "text": "Dave is the QA lead on the ridge team."
+  },
+  {
+   "id": 20848,
+   "text": "Eve is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 20849,
+   "text": "Taylor is the senior engineer on the beacon team."
+  },
+  {
+   "id": 20850,
+   "text": "Henry is the tech lead on the orbit team."
+  },
+  {
+   "id": 20851,
+   "text": "Kate owns the auth surface."
+  },
+  {
+   "id": 20852,
+   "text": "Taylor reports to Mia."
+  },
+  {
+   "id": 20853,
+   "text": "Liam reports to Sam."
+  },
+  {
+   "id": 20854,
+   "text": "Pat is the PM on the delta team."
+  },
+  {
+   "id": 20855,
+   "text": "Quinn is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 20856,
+   "text": "Bob is on PTO from Monday to Monday."
+  },
+  {
+   "id": 20857,
+   "text": "Quinn is the staff engineer on the orbit team."
+  },
+  {
+   "id": 20858,
+   "text": "Grace is the tech lead on the echo team."
+  },
+  {
+   "id": 20859,
+   "text": "Sam reports to Taylor."
+  },
+  {
+   "id": 20860,
+   "text": "Henry is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 20861,
+   "text": "Jack is the senior engineer on the monolith team."
+  },
+  {
+   "id": 20862,
+   "text": "Bob is the QA lead on the tundra team."
+  },
+  {
+   "id": 20863,
+   "text": "Alice reports to Liam."
+  },
+  {
+   "id": 20864,
+   "text": "Carol reports to Eve."
+  },
+  {
+   "id": 20865,
+   "text": "Bob is the engineering manager on the junction team."
+  },
+  {
+   "id": 20866,
+   "text": "Bob owns the infra surface."
+  },
+  {
+   "id": 20867,
+   "text": "Jack is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 20868,
+   "text": "Olivia is the staff engineer on the fjord team."
+  },
+  {
+   "id": 20869,
+   "text": "Liam is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 20870,
+   "text": "Liam reports to Grace."
+  },
+  {
+   "id": 20871,
+   "text": "Grace is on PTO from Friday to Monday."
+  },
+  {
+   "id": 20872,
+   "text": "Eve is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 20873,
+   "text": "Jack reports to Noah."
+  },
+  {
+   "id": 20874,
+   "text": "Frank is the staff engineer on the lattice team."
+  },
+  {
+   "id": 20875,
+   "text": "Frank is the senior engineer on the echo team."
+  },
+  {
+   "id": 20876,
+   "text": "Mia is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 20877,
+   "text": "Grace is on PTO from Friday to Friday."
+  },
+  {
+   "id": 20878,
+   "text": "Olivia is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 20879,
+   "text": "Bob is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 20880,
+   "text": "Pat is the designer on the orbit team."
+  },
+  {
+   "id": 20881,
+   "text": "Frank owns the billing surface."
+  },
+  {
+   "id": 20882,
+   "text": "Noah reports to Pat."
+  },
+  {
+   "id": 20883,
+   "text": "Alice owns the search surface."
+  },
+  {
+   "id": 20884,
+   "text": "Taylor owns the billing surface."
+  },
+  {
+   "id": 20885,
+   "text": "Sam owns the API surface."
+  },
+  {
+   "id": 20886,
+   "text": "Grace is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 20887,
+   "text": "Dave reports to Henry."
+  },
+  {
+   "id": 20888,
+   "text": "Mia is on PTO from Monday to Friday."
+  },
+  {
+   "id": 20889,
+   "text": "Bob is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 20890,
+   "text": "Ivy reports to Alice."
+  },
+  {
+   "id": 20891,
+   "text": "Kate reports to Noah."
+  },
+  {
+   "id": 20892,
+   "text": "Taylor reports to Pat."
+  },
+  {
+   "id": 20893,
+   "text": "Pat reports to Ivy."
+  },
+  {
+   "id": 20894,
+   "text": "Eve reports to Mia."
+  },
+  {
+   "id": 20895,
+   "text": "Alice reports to Olivia."
+  },
+  {
+   "id": 20896,
+   "text": "The user prefers Cascadia Code as their font in bash."
+  },
+  {
+   "id": 20897,
+   "text": "The user prefers dark mode as their color scheme in fish shell."
+  },
+  {
+   "id": 20898,
+   "text": "The user prefers tig as their git GUI in tmux."
+  },
+  {
+   "id": 20899,
+   "text": "The user prefers 4 spaces as their tab width in Terminal.app."
+  },
+  {
+   "id": 20900,
+   "text": "The user prefers 14pt as their font size in zsh."
+  },
+  {
+   "id": 20901,
+   "text": "The user prefers dark mode as their color scheme in zsh."
+  },
+  {
+   "id": 20902,
+   "text": "The user prefers tabs as their tab width in Neovim."
+  },
+  {
+   "id": 20903,
+   "text": "The user prefers tig as their git GUI in PyCharm."
+  },
+  {
+   "id": 20904,
+   "text": "The user prefers command line only as their git GUI in bash."
+  },
+  {
+   "id": 20905,
+   "text": "The user prefers on save as their auto-format in Hyper."
+  },
+  {
+   "id": 20906,
+   "text": "The user prefers 12pt as their font size in Vim."
+  },
+  {
+   "id": 20907,
+   "text": "The user prefers Fork as their git GUI in Windsurf."
+  },
+  {
+   "id": 20908,
+   "text": "The user prefers 2 spaces as their tab width in fish shell."
+  },
+  {
+   "id": 20909,
+   "text": "The user prefers catppuccin as their color scheme in zsh."
+  },
+  {
+   "id": 20910,
+   "text": "The user prefers 13pt as their font size in Cursor."
+  },
+  {
+   "id": 20911,
+   "text": "The user prefers tabs as their tab width in Vim."
+  },
+  {
+   "id": 20912,
+   "text": "The user prefers command line only as their git GUI in alacritty."
+  },
+  {
+   "id": 20913,
+   "text": "The user prefers dark mode as their color scheme in Vim."
+  },
+  {
+   "id": 20914,
+   "text": "The user prefers manually only as their auto-format in Neovim."
+  },
+  {
+   "id": 20915,
+   "text": "The user prefers Cascadia Code as their font in IntelliJ."
+  },
+  {
+   "id": 20916,
+   "text": "The user prefers solarized dark as their color scheme in PyCharm."
+  },
+  {
+   "id": 20917,
+   "text": "The user prefers gruvbox as their color scheme in kitty."
+  },
+  {
+   "id": 20918,
+   "text": "The user prefers 4 spaces as their tab width in bash."
+  },
+  {
+   "id": 20919,
+   "text": "The user prefers GitKraken as their git GUI in iTerm2."
+  },
+  {
+   "id": 20920,
+   "text": "The user prefers Iosevka as their font in Cursor."
+  },
+  {
+   "id": 20921,
+   "text": "The user prefers catppuccin as their color scheme in Vim."
+  },
+  {
+   "id": 20922,
+   "text": "The user prefers GitKraken as their git GUI in Emacs."
+  },
+  {
+   "id": 20923,
+   "text": "The user prefers 13pt as their font size in tmux."
+  },
+  {
+   "id": 20924,
+   "text": "The user prefers solarized dark as their color scheme in zsh."
+  },
+  {
+   "id": 20925,
+   "text": "The user prefers tig as their git GUI in Warp."
+  },
+  {
+   "id": 20926,
+   "text": "The user prefers high-contrast as their color scheme in alacritty."
+  },
+  {
+   "id": 20927,
+   "text": "The user prefers 16pt as their font size in kitty."
+  },
+  {
+   "id": 20928,
+   "text": "The user prefers high-contrast as their color scheme in Windsurf."
+  },
+  {
+   "id": 20929,
+   "text": "The user prefers command line only as their git GUI in Hyper."
+  },
+  {
+   "id": 20930,
+   "text": "The user prefers gruvbox as their color scheme in IntelliJ."
+  },
+  {
+   "id": 20931,
+   "text": "The user prefers command line only as their git GUI in iTerm2."
+  },
+  {
+   "id": 20932,
+   "text": "The user prefers gruvbox as their color scheme in zsh."
+  },
+  {
+   "id": 20933,
+   "text": "The user prefers tig as their git GUI in VS Code."
+  },
+  {
+   "id": 20934,
+   "text": "The user prefers catppuccin as their color scheme in alacritty."
+  },
+  {
+   "id": 20935,
+   "text": "The user prefers 13pt as their font size in fish shell."
+  },
+  {
+   "id": 20936,
+   "text": "Project iris launches in March 2027."
+  },
+  {
+   "id": 20937,
+   "text": "Project glacier launches in March 2026."
+  },
+  {
+   "id": 20938,
+   "text": "Project tundra launches in March 2027."
+  },
+  {
+   "id": 20939,
+   "text": "Project glacier uses Rust for performance-critical paths."
+  },
+  {
+   "id": 20940,
+   "text": "Project ridge uses Go for the orchestrator."
+  },
+  {
+   "id": 20941,
+   "text": "Project monolith uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 20942,
+   "text": "Project glacier uses Kafka for event streaming."
+  },
+  {
+   "id": 20943,
+   "text": "Project orbit launches in November 2026."
+  },
+  {
+   "id": 20944,
+   "text": "Project compass supports 42 locales."
+  },
+  {
+   "id": 20945,
+   "text": "Project kestrel uses S3 for object storage."
+  },
+  {
+   "id": 20946,
+   "text": "Project echo uses Sentry for error tracking."
+  },
+  {
+   "id": 20947,
+   "text": "Project beacon supports 12 locales."
+  },
+  {
+   "id": 20948,
+   "text": "Project echo uses Next.js for server-side rendering."
+  },
+  {
+   "id": 20949,
+   "text": "Project harbor uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 20950,
+   "text": "Project glacier uses TypeScript for the client."
+  },
+  {
+   "id": 20951,
+   "text": "Project nexus uses ClickHouse for analytics."
+  },
+  {
+   "id": 20952,
+   "text": "Project prism supports 27 locales."
+  },
+  {
+   "id": 20953,
+   "text": "Project orbit uses Grafana for dashboards."
+  },
+  {
+   "id": 20954,
+   "text": "Project fjord uses Docker for containerization."
+  },
+  {
+   "id": 20955,
+   "text": "Project glacier uses Prometheus for metrics."
+  },
+  {
+   "id": 20956,
+   "text": "Project nexus uses Redis for caching."
+  },
+  {
+   "id": 20957,
+   "text": "Project lattice uses Prometheus for metrics."
+  },
+  {
+   "id": 20958,
+   "text": "Project kestrel launches in March 2026."
+  },
+  {
+   "id": 20959,
+   "text": "Project nexus targets 10,000 monthly active users."
+  },
+  {
+   "id": 20960,
+   "text": "Project compass launches in June 2027."
+  },
+  {
+   "id": 20961,
+   "text": "Project junction supports 5 locales."
+  },
+  {
+   "id": 20962,
+   "text": "Project harbor launches in September 2026."
+  },
+  {
+   "id": 20963,
+   "text": "Project summit uses Next.js for server-side rendering."
+  },
+  {
+   "id": 20964,
+   "text": "Project nexus launches in November 2027."
+  },
+  {
+   "id": 20965,
+   "text": "Project beacon uses Kafka for event streaming."
+  },
+  {
+   "id": 20966,
+   "text": "Project glacier targets 100,000 monthly active users."
+  },
+  {
+   "id": 20967,
+   "text": "Project ridge uses S3 for object storage."
+  },
+  {
+   "id": 20968,
+   "text": "Project atlas uses Docker for containerization."
+  },
+  {
+   "id": 20969,
+   "text": "Project echo launches in June 2027."
+  },
+  {
+   "id": 20970,
+   "text": "Project junction uses Grafana for dashboards."
+  },
+  {
+   "id": 20971,
+   "text": "Project harbor supports 3 locales."
+  },
+  {
+   "id": 20972,
+   "text": "Project iris uses Kafka for event streaming."
+  },
+  {
+   "id": 20973,
+   "text": "Project summit uses React for the frontend."
+  },
+  {
+   "id": 20974,
+   "text": "Project compass uses Python for data pipelines."
+  },
+  {
+   "id": 20975,
+   "text": "Project delta uses Kubernetes for orchestration."
+  },
+  {
+   "id": 20976,
+   "text": "Project prism uses Kafka for event streaming."
+  },
+  {
+   "id": 20977,
+   "text": "Project atlas launches in June 2026."
+  },
+  {
+   "id": 20978,
+   "text": "Project glacier uses S3 for object storage."
+  },
+  {
+   "id": 20979,
+   "text": "Project orbit launches in June 2027."
+  },
+  {
+   "id": 20980,
+   "text": "Project fjord targets 1,000,000 monthly active users."
+  },
+  {
+   "id": 20981,
+   "text": "Project junction launches in June 2027."
+  },
+  {
+   "id": 20982,
+   "text": "Project delta uses Sentry for error tracking."
+  },
+  {
+   "id": 20983,
+   "text": "Project monolith launches in June 2026."
+  },
+  {
+   "id": 20984,
+   "text": "Project harbor uses Sentry for error tracking."
+  },
+  {
+   "id": 20985,
+   "text": "Project echo uses Rust for performance-critical paths."
+  },
+  {
+   "id": 20986,
+   "text": "Project quartz uses Prometheus for metrics."
+  },
+  {
+   "id": 20987,
+   "text": "Project delta uses Go for the orchestrator."
+  },
+  {
+   "id": 20988,
+   "text": "Project atlas launches in June 2027."
+  },
+  {
+   "id": 20989,
+   "text": "Project beacon uses Python for data pipelines."
+  },
+  {
+   "id": 20990,
+   "text": "Project glacier launches in March 2027."
+  },
+  {
+   "id": 20991,
+   "text": "Project iris launches in November 2026."
+  },
+  {
+   "id": 20992,
+   "text": "Project iris launches in June 2026."
+  },
+  {
+   "id": 20993,
+   "text": "Project orbit uses Redis for caching."
+  },
+  {
+   "id": 20994,
+   "text": "Project glacier uses Kubernetes for orchestration."
+  },
+  {
+   "id": 20995,
+   "text": "Project summit uses Redis for caching."
+  },
+  {
+   "id": 20996,
+   "text": "Project glacier launches in September 2027."
+  },
+  {
+   "id": 20997,
+   "text": "Eve reports to Carol."
+  },
+  {
+   "id": 20998,
+   "text": "Eve is the tech lead on the ridge team."
+  },
+  {
+   "id": 20999,
+   "text": "Sam owns the search surface."
+  },
+  {
+   "id": 21000,
+   "text": "Noah is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 21001,
+   "text": "Riley is the designer on the compass team."
+  },
+  {
+   "id": 21002,
+   "text": "Frank reports to Eve."
+  },
+  {
+   "id": 21003,
+   "text": "Sam is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 21004,
+   "text": "Riley is the staff engineer on the compass team."
+  },
+  {
+   "id": 21005,
+   "text": "Pat is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 21006,
+   "text": "Eve is on PTO from Friday to Friday."
+  },
+  {
+   "id": 21007,
+   "text": "Ivy is the staff engineer on the echo team."
+  },
+  {
+   "id": 21008,
+   "text": "Mia is the senior engineer on the monolith team."
+  },
+  {
+   "id": 21009,
+   "text": "Noah owns the API surface."
+  },
+  {
+   "id": 21010,
+   "text": "Noah reports to Kate."
+  },
+  {
+   "id": 21011,
+   "text": "Kate is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 21012,
+   "text": "Taylor reports to Dave."
+  },
+  {
+   "id": 21013,
+   "text": "Taylor is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 21014,
+   "text": "Grace owns the billing surface."
+  },
+  {
+   "id": 21015,
+   "text": "Henry is the PM on the kestrel team."
+  },
+  {
+   "id": 21016,
+   "text": "Taylor owns the search surface."
+  },
+  {
+   "id": 21017,
+   "text": "Alice is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 21018,
+   "text": "Pat is on PTO from Monday to Monday."
+  },
+  {
+   "id": 21019,
+   "text": "Dave owns the auth surface."
+  },
+  {
+   "id": 21020,
+   "text": "Grace is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 21021,
+   "text": "Kate reports to Alice."
+  },
+  {
+   "id": 21022,
+   "text": "Mia is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 21023,
+   "text": "Jack reports to Bob."
+  },
+  {
+   "id": 21024,
+   "text": "Taylor reports to Riley."
+  },
+  {
+   "id": 21025,
+   "text": "Frank is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 21026,
+   "text": "Jack is the senior engineer on the glacier team."
+  },
+  {
+   "id": 21027,
+   "text": "Alice is the engineering manager on the junction team."
+  },
+  {
+   "id": 21028,
+   "text": "Henry is the PM on the echo team."
+  },
+  {
+   "id": 21029,
+   "text": "Alice is on PTO from Monday to Monday."
+  },
+  {
+   "id": 21030,
+   "text": "Liam is the senior engineer on the quartz team."
+  },
+  {
+   "id": 21031,
+   "text": "Dave is the staff engineer on the glacier team."
+  },
+  {
+   "id": 21032,
+   "text": "Jack owns the billing surface."
+  },
+  {
+   "id": 21033,
+   "text": "Alice is the designer on the tundra team."
+  },
+  {
+   "id": 21034,
+   "text": "Taylor is the staff engineer on the beacon team."
+  },
+  {
+   "id": 21035,
+   "text": "Riley owns the API surface."
+  },
+  {
+   "id": 21036,
+   "text": "Liam is the senior engineer on the tundra team."
+  },
+  {
+   "id": 21037,
+   "text": "Bob reports to Mia."
+  },
+  {
+   "id": 21038,
+   "text": "Taylor reports to Bob."
+  },
+  {
+   "id": 21039,
+   "text": "Liam is on PTO from Friday to Friday."
+  },
+  {
+   "id": 21040,
+   "text": "Jack is on PTO from Friday to Monday."
+  },
+  {
+   "id": 21041,
+   "text": "Dave is the senior engineer on the summit team."
+  },
+  {
+   "id": 21042,
+   "text": "Noah is the senior engineer on the prism team."
+  },
+  {
+   "id": 21043,
+   "text": "Quinn is the senior engineer on the nexus team."
+  },
+  {
+   "id": 21044,
+   "text": "Frank is the tech lead on the atlas team."
+  },
+  {
+   "id": 21045,
+   "text": "Kate is on PTO from Friday to Friday."
+  },
+  {
+   "id": 21046,
+   "text": "Eve owns the billing surface."
+  },
+  {
+   "id": 21047,
+   "text": "Sam is the principal engineer on the ridge team."
+  },
+  {
+   "id": 21048,
+   "text": "Olivia owns the ingest surface."
+  },
+  {
+   "id": 21049,
+   "text": "Carol is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 21050,
+   "text": "Sam is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 21051,
+   "text": "Grace is the engineering manager on the fjord team."
+  },
+  {
+   "id": 21052,
+   "text": "Alice is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 21053,
+   "text": "Quinn is the engineering manager on the glacier team."
+  },
+  {
+   "id": 21054,
+   "text": "Noah reports to Mia."
+  },
+  {
+   "id": 21055,
+   "text": "Henry is the designer on the compass team."
+  },
+  {
+   "id": 21056,
+   "text": "Riley reports to Noah."
+  },
+  {
+   "id": 21057,
+   "text": "Jack is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 21058,
+   "text": "Carol is on PTO from Friday to Friday."
+  },
+  {
+   "id": 21059,
+   "text": "Noah is on PTO from Monday to Friday."
+  },
+  {
+   "id": 21060,
+   "text": "Noah is the engineering manager on the prism team."
+  },
+  {
+   "id": 21061,
+   "text": "Ivy is the designer on the delta team."
+  },
+  {
+   "id": 21062,
+   "text": "Carol is the engineering manager on the junction team."
+  },
+  {
+   "id": 21063,
+   "text": "Eve owns the search surface."
+  },
+  {
+   "id": 21064,
+   "text": "Frank is the staff engineer on the fjord team."
+  },
+  {
+   "id": 21065,
+   "text": "Grace reports to Olivia."
+  },
+  {
+   "id": 21066,
+   "text": "Pat is the PM on the ridge team."
+  },
+  {
+   "id": 21067,
+   "text": "Ivy is the principal engineer on the tundra team."
+  },
+  {
+   "id": 21068,
+   "text": "Henry is the PM on the beacon team."
+  },
+  {
+   "id": 21069,
+   "text": "Frank is the staff engineer on the echo team."
+  },
+  {
+   "id": 21070,
+   "text": "Ivy is the QA lead on the tundra team."
+  },
+  {
+   "id": 21071,
+   "text": "Eve is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 21072,
+   "text": "Taylor is the principal engineer on the atlas team."
+  },
+  {
+   "id": 21073,
+   "text": "Kate is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 21074,
+   "text": "Dave is the senior engineer on the iris team."
+  },
+  {
+   "id": 21075,
+   "text": "Jack is the PM on the orbit team."
+  },
+  {
+   "id": 21076,
+   "text": "Bob is the staff engineer on the kestrel team."
+  },
+  {
+   "id": 21077,
+   "text": "Grace is the principal engineer on the tundra team."
+  },
+  {
+   "id": 21078,
+   "text": "Bob reports to Kate."
+  },
+  {
+   "id": 21079,
+   "text": "Olivia is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 21080,
+   "text": "Mia reports to Frank."
+  },
+  {
+   "id": 21081,
+   "text": "Jack is the engineering manager on the monolith team."
+  },
+  {
+   "id": 21082,
+   "text": "Ivy reports to Henry."
+  },
+  {
+   "id": 21083,
+   "text": "Grace is the principal engineer on the harbor team."
+  },
+  {
+   "id": 21084,
+   "text": "Dave reports to Sam."
+  },
+  {
+   "id": 21085,
+   "text": "Grace reports to Kate."
+  },
+  {
+   "id": 21086,
+   "text": "Quinn is the QA lead on the quartz team."
+  },
+  {
+   "id": 21087,
+   "text": "Pat is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 21088,
+   "text": "Carol owns the API surface."
+  },
+  {
+   "id": 21089,
+   "text": "Grace is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 21090,
+   "text": "The user prefers tig as their git GUI in iTerm2."
+  },
+  {
+   "id": 21091,
+   "text": "The user prefers high-contrast as their color scheme in Neovim."
+  },
+  {
+   "id": 21092,
+   "text": "The user prefers 4 spaces as their tab width in Emacs."
+  },
+  {
+   "id": 21093,
+   "text": "The user prefers Fork as their git GUI in alacritty."
+  },
+  {
+   "id": 21094,
+   "text": "The user prefers catppuccin as their color scheme in bash."
+  },
+  {
+   "id": 21095,
+   "text": "The user prefers high-contrast as their color scheme in PyCharm."
+  },
+  {
+   "id": 21096,
+   "text": "The user prefers JetBrains Mono as their font in VS Code."
+  },
+  {
+   "id": 21097,
+   "text": "The user prefers gruvbox as their color scheme in alacritty."
+  },
+  {
+   "id": 21098,
+   "text": "The user prefers gruvbox as their color scheme in iTerm2."
+  },
+  {
+   "id": 21099,
+   "text": "The user prefers CRLF as their line endings in PyCharm."
+  },
+  {
+   "id": 21100,
+   "text": "The user prefers Iosevka as their font in iTerm2."
+  },
+  {
+   "id": 21101,
+   "text": "The user prefers 16pt as their font size in iTerm2."
+  },
+  {
+   "id": 21102,
+   "text": "The user prefers lazygit as their git GUI in PyCharm."
+  },
+  {
+   "id": 21103,
+   "text": "The user prefers Fira Code as their font in PyCharm."
+  },
+  {
+   "id": 21104,
+   "text": "The user prefers command line only as their git GUI in kitty."
+  },
+  {
+   "id": 21105,
+   "text": "The user prefers 2 spaces as their tab width in Zed."
+  },
+  {
+   "id": 21106,
+   "text": "The user prefers high-contrast as their color scheme in kitty."
+  },
+  {
+   "id": 21107,
+   "text": "The user prefers 15pt as their font size in Neovim."
+  },
+  {
+   "id": 21108,
+   "text": "The user prefers high-contrast as their color scheme in iTerm2."
+  },
+  {
+   "id": 21109,
+   "text": "The user prefers manually only as their auto-format in tmux."
+  },
+  {
+   "id": 21110,
+   "text": "The user prefers Fork as their git GUI in zsh."
+  },
+  {
+   "id": 21111,
+   "text": "The user prefers Hack as their font in Vim."
+  },
+  {
+   "id": 21112,
+   "text": "The user prefers 14pt as their font size in kitty."
+  },
+  {
+   "id": 21113,
+   "text": "The user prefers gruvbox as their color scheme in bash."
+  },
+  {
+   "id": 21114,
+   "text": "The user prefers 2 spaces as their tab width in Terminal.app."
+  },
+  {
+   "id": 21115,
+   "text": "The user prefers 12pt as their font size in VS Code."
+  },
+  {
+   "id": 21116,
+   "text": "The user prefers tabs as their tab width in Warp."
+  },
+  {
+   "id": 21117,
+   "text": "The user prefers lazygit as their git GUI in VS Code."
+  },
+  {
+   "id": 21118,
+   "text": "The user prefers solarized dark as their color scheme in Cursor."
+  },
+  {
+   "id": 21119,
+   "text": "The user prefers command line only as their git GUI in Sublime Text."
+  },
+  {
+   "id": 21120,
+   "text": "The user prefers Hack as their font in Warp."
+  },
+  {
+   "id": 21121,
+   "text": "The user prefers Cascadia Code as their font in Sublime Text."
+  },
+  {
+   "id": 21122,
+   "text": "The user prefers command line only as their git GUI in IntelliJ."
+  },
+  {
+   "id": 21123,
+   "text": "The user prefers dark mode as their color scheme in bash."
+  },
+  {
+   "id": 21124,
+   "text": "The user prefers Iosevka as their font in PyCharm."
+  },
+  {
+   "id": 21125,
+   "text": "The user prefers Hack as their font in Neovim."
+  },
+  {
+   "id": 21126,
+   "text": "The user prefers nord as their color scheme in Windsurf."
+  },
+  {
+   "id": 21127,
+   "text": "The user prefers light mode as their color scheme in IntelliJ."
+  },
+  {
+   "id": 21128,
+   "text": "Project orbit uses Python for data pipelines."
+  },
+  {
+   "id": 21129,
+   "text": "Project fjord uses FastAPI for the API layer."
+  },
+  {
+   "id": 21130,
+   "text": "Project prism uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 21131,
+   "text": "Project delta launches in March 2026."
+  },
+  {
+   "id": 21132,
+   "text": "Project prism targets 1,000,000 monthly active users."
+  },
+  {
+   "id": 21133,
+   "text": "Project atlas targets 100,000 monthly active users."
+  },
+  {
+   "id": 21134,
+   "text": "Project summit launches in March 2027."
+  },
+  {
+   "id": 21135,
+   "text": "Project lattice uses Kubernetes for orchestration."
+  },
+  {
+   "id": 21136,
+   "text": "Project junction targets 10,000 monthly active users."
+  },
+  {
+   "id": 21137,
+   "text": "Project prism launches in November 2026."
+  },
+  {
+   "id": 21138,
+   "text": "Project glacier uses Tailwind for styling."
+  },
+  {
+   "id": 21139,
+   "text": "Project tundra launches in June 2027."
+  },
+  {
+   "id": 21140,
+   "text": "Project orbit uses Kubernetes for orchestration."
+  },
+  {
+   "id": 21141,
+   "text": "Project delta uses Next.js for server-side rendering."
+  },
+  {
+   "id": 21142,
+   "text": "Project beacon uses ClickHouse for analytics."
+  },
+  {
+   "id": 21143,
+   "text": "Project compass launches in March 2026."
+  },
+  {
+   "id": 21144,
+   "text": "Project prism uses Redis for caching."
+  },
+  {
+   "id": 21145,
+   "text": "Project iris uses Prometheus for metrics."
+  },
+  {
+   "id": 21146,
+   "text": "Project ridge launches in November 2026."
+  },
+  {
+   "id": 21147,
+   "text": "Project fjord uses Sentry for error tracking."
+  },
+  {
+   "id": 21148,
+   "text": "Project lattice launches in March 2026."
+  },
+  {
+   "id": 21149,
+   "text": "Project harbor launches in November 2027."
+  },
+  {
+   "id": 21150,
+   "text": "Project kestrel uses Sentry for error tracking."
+  },
+  {
+   "id": 21151,
+   "text": "Project fjord uses Redis for caching."
+  },
+  {
+   "id": 21152,
+   "text": "Project prism uses React for the frontend."
+  },
+  {
+   "id": 21153,
+   "text": "Project summit uses Kafka for event streaming."
+  },
+  {
+   "id": 21154,
+   "text": "Project atlas targets 10,000 monthly active users."
+  },
+  {
+   "id": 21155,
+   "text": "Project prism uses Prometheus for metrics."
+  },
+  {
+   "id": 21156,
+   "text": "Project atlas launches in March 2027."
+  },
+  {
+   "id": 21157,
+   "text": "Project iris uses FastAPI for the API layer."
+  },
+  {
+   "id": 21158,
+   "text": "Project monolith uses Grafana for dashboards."
+  },
+  {
+   "id": 21159,
+   "text": "Project fjord launches in March 2027."
+  },
+  {
+   "id": 21160,
+   "text": "Project compass uses ClickHouse for analytics."
+  },
+  {
+   "id": 21161,
+   "text": "Project orbit uses Next.js for server-side rendering."
+  },
+  {
+   "id": 21162,
+   "text": "Project monolith uses Kafka for event streaming."
+  },
+  {
+   "id": 21163,
+   "text": "Project prism uses Elasticsearch for search."
+  },
+  {
+   "id": 21164,
+   "text": "Project echo uses Prometheus for metrics."
+  },
+  {
+   "id": 21165,
+   "text": "Project junction uses Next.js for server-side rendering."
+  },
+  {
+   "id": 21166,
+   "text": "Liam reports to Riley."
+  },
+  {
+   "id": 21167,
+   "text": "Quinn is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 21168,
+   "text": "Pat is the PM on the glacier team."
+  },
+  {
+   "id": 21169,
+   "text": "Carol reports to Henry."
+  },
+  {
+   "id": 21170,
+   "text": "Sam is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 21171,
+   "text": "Ivy is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 21172,
+   "text": "Alice is the PM on the quartz team."
+  },
+  {
+   "id": 21173,
+   "text": "Riley is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 21174,
+   "text": "Sam owns the auth surface."
+  },
+  {
+   "id": 21175,
+   "text": "Sam is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 21176,
+   "text": "Bob is the PM on the junction team."
+  },
+  {
+   "id": 21177,
+   "text": "Grace reports to Quinn."
+  },
+  {
+   "id": 21178,
+   "text": "Bob reports to Pat."
+  },
+  {
+   "id": 21179,
+   "text": "Sam reports to Quinn."
+  },
+  {
+   "id": 21180,
+   "text": "Quinn is the QA lead on the beacon team."
+  },
+  {
+   "id": 21181,
+   "text": "Ivy owns the ingest surface."
+  },
+  {
+   "id": 21182,
+   "text": "Olivia owns the API surface."
+  },
+  {
+   "id": 21183,
+   "text": "Ivy is the principal engineer on the prism team."
+  },
+  {
+   "id": 21184,
+   "text": "Carol is the tech lead on the nexus team."
+  },
+  {
+   "id": 21185,
+   "text": "Grace reports to Carol."
+  },
+  {
+   "id": 21186,
+   "text": "Quinn is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 21187,
+   "text": "Taylor is the senior engineer on the iris team."
+  },
+  {
+   "id": 21188,
+   "text": "Dave reports to Frank."
+  },
+  {
+   "id": 21189,
+   "text": "Ivy is the tech lead on the prism team."
+  },
+  {
+   "id": 21190,
+   "text": "Jack is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 21191,
+   "text": "Alice owns the auth surface."
+  },
+  {
+   "id": 21192,
+   "text": "Mia is the designer on the quartz team."
+  },
+  {
+   "id": 21193,
+   "text": "Quinn is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 21194,
+   "text": "Sam is the designer on the kestrel team."
+  },
+  {
+   "id": 21195,
+   "text": "Liam reports to Noah."
+  },
+  {
+   "id": 21196,
+   "text": "Mia is the staff engineer on the junction team."
+  },
+  {
+   "id": 21197,
+   "text": "Henry reports to Bob."
+  },
+  {
+   "id": 21198,
+   "text": "Henry is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 21199,
+   "text": "Henry owns the billing surface."
+  },
+  {
+   "id": 21200,
+   "text": "Mia reports to Olivia."
+  },
+  {
+   "id": 21201,
+   "text": "Bob is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 21202,
+   "text": "Dave is the tech lead on the glacier team."
+  },
+  {
+   "id": 21203,
+   "text": "Quinn is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 21204,
+   "text": "Sam is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 21205,
+   "text": "Riley owns the auth surface."
+  },
+  {
+   "id": 21206,
+   "text": "Dave is the QA lead on the junction team."
+  },
+  {
+   "id": 21207,
+   "text": "Sam is the QA lead on the orbit team."
+  },
+  {
+   "id": 21208,
+   "text": "Pat owns the dashboard surface."
+  },
+  {
+   "id": 21209,
+   "text": "Riley is the senior engineer on the beacon team."
+  },
+  {
+   "id": 21210,
+   "text": "Pat reports to Sam."
+  },
+  {
+   "id": 21211,
+   "text": "Kate is the QA lead on the compass team."
+  },
+  {
+   "id": 21212,
+   "text": "Eve is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 21213,
+   "text": "Pat is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 21214,
+   "text": "Henry is the engineering manager on the compass team."
+  },
+  {
+   "id": 21215,
+   "text": "Riley is the QA lead on the kestrel team."
+  },
+  {
+   "id": 21216,
+   "text": "Grace owns the deploy surface."
+  },
+  {
+   "id": 21217,
+   "text": "Kate is the QA lead on the fjord team."
+  },
+  {
+   "id": 21218,
+   "text": "Ivy reports to Grace."
+  },
+  {
+   "id": 21219,
+   "text": "Bob is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 21220,
+   "text": "Noah is the staff engineer on the junction team."
+  },
+  {
+   "id": 21221,
+   "text": "Jack is the designer on the atlas team."
+  },
+  {
+   "id": 21222,
+   "text": "Noah is the designer on the fjord team."
+  },
+  {
+   "id": 21223,
+   "text": "Henry reports to Kate."
+  },
+  {
+   "id": 21224,
+   "text": "Kate is the QA lead on the summit team."
+  },
+  {
+   "id": 21225,
+   "text": "Alice is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 21226,
+   "text": "Alice reports to Ivy."
+  },
+  {
+   "id": 21227,
+   "text": "Dave is the tech lead on the fjord team."
+  },
+  {
+   "id": 21228,
+   "text": "Grace reports to Taylor."
+  },
+  {
+   "id": 21229,
+   "text": "Liam is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 21230,
+   "text": "Olivia reports to Mia."
+  },
+  {
+   "id": 21231,
+   "text": "Eve is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 21232,
+   "text": "Mia is on PTO from Friday to Monday."
+  },
+  {
+   "id": 21233,
+   "text": "Frank reports to Henry."
+  },
+  {
+   "id": 21234,
+   "text": "Henry is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 21235,
+   "text": "Henry owns the search surface."
+  },
+  {
+   "id": 21236,
+   "text": "Pat is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 21237,
+   "text": "Olivia is the principal engineer on the harbor team."
+  },
+  {
+   "id": 21238,
+   "text": "Jack is the principal engineer on the monolith team."
+  },
+  {
+   "id": 21239,
+   "text": "Mia is the designer on the compass team."
+  },
+  {
+   "id": 21240,
+   "text": "Liam is the QA lead on the ridge team."
+  },
+  {
+   "id": 21241,
+   "text": "Ivy reports to Dave."
+  },
+  {
+   "id": 21242,
+   "text": "Sam is the staff engineer on the kestrel team."
+  },
+  {
+   "id": 21243,
+   "text": "Grace is the principal engineer on the glacier team."
+  },
+  {
+   "id": 21244,
+   "text": "Eve is the senior engineer on the nexus team."
+  },
+  {
+   "id": 21245,
+   "text": "Henry is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 21246,
+   "text": "Frank owns the API surface."
+  },
+  {
+   "id": 21247,
+   "text": "Bob is the engineering manager on the delta team."
+  },
+  {
+   "id": 21248,
+   "text": "Riley is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 21249,
+   "text": "Dave is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 21250,
+   "text": "Alice reports to Sam."
+  },
+  {
+   "id": 21251,
+   "text": "Sam is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 21252,
+   "text": "Mia owns the ingest surface."
+  },
+  {
+   "id": 21253,
+   "text": "Riley reports to Quinn."
+  },
+  {
+   "id": 21254,
+   "text": "Pat reports to Noah."
+  },
+  {
+   "id": 21255,
+   "text": "Dave reports to Riley."
+  },
+  {
+   "id": 21256,
+   "text": "The user prefers GitKraken as their git GUI in PyCharm."
+  },
+  {
+   "id": 21257,
+   "text": "The user prefers catppuccin as their color scheme in Warp."
+  },
+  {
+   "id": 21258,
+   "text": "The user prefers lazygit as their git GUI in Hyper."
+  },
+  {
+   "id": 21259,
+   "text": "The user prefers 14pt as their font size in Windsurf."
+  },
+  {
+   "id": 21260,
+   "text": "The user prefers Hack as their font in kitty."
+  },
+  {
+   "id": 21261,
+   "text": "The user prefers nord as their color scheme in Sublime Text."
+  },
+  {
+   "id": 21262,
+   "text": "The user prefers tig as their git GUI in Vim."
+  },
+  {
+   "id": 21263,
+   "text": "The user prefers 15pt as their font size in PyCharm."
+  },
+  {
+   "id": 21264,
+   "text": "The user prefers Fira Code as their font in iTerm2."
+  },
+  {
+   "id": 21265,
+   "text": "The user prefers JetBrains Mono as their font in Cursor."
+  },
+  {
+   "id": 21266,
+   "text": "The user prefers command line only as their git GUI in Emacs."
+  },
+  {
+   "id": 21267,
+   "text": "The user prefers 12pt as their font size in Hyper."
+  },
+  {
+   "id": 21268,
+   "text": "The user prefers JetBrains Mono as their font in Terminal.app."
+  },
+  {
+   "id": 21269,
+   "text": "The user prefers Fira Code as their font in kitty."
+  },
+  {
+   "id": 21270,
+   "text": "The user prefers 13pt as their font size in Hyper."
+  },
+  {
+   "id": 21271,
+   "text": "The user prefers Fira Code as their font in Neovim."
+  },
+  {
+   "id": 21272,
+   "text": "The user prefers gruvbox as their color scheme in Cursor."
+  },
+  {
+   "id": 21273,
+   "text": "The user prefers tokyo night as their color scheme in Vim."
+  },
+  {
+   "id": 21274,
+   "text": "The user prefers solarized dark as their color scheme in Neovim."
+  },
+  {
+   "id": 21275,
+   "text": "The user prefers nord as their color scheme in PyCharm."
+  },
+  {
+   "id": 21276,
+   "text": "The user prefers nord as their color scheme in Neovim."
+  },
+  {
+   "id": 21277,
+   "text": "The user prefers never as their auto-format in PyCharm."
+  },
+  {
+   "id": 21278,
+   "text": "The user prefers command line only as their git GUI in fish shell."
+  },
+  {
+   "id": 21279,
+   "text": "The user prefers catppuccin as their color scheme in fish shell."
+  },
+  {
+   "id": 21280,
+   "text": "Project prism uses Grafana for dashboards."
+  },
+  {
+   "id": 21281,
+   "text": "Project kestrel launches in June 2027."
+  },
+  {
+   "id": 21282,
+   "text": "Project atlas uses ClickHouse for analytics."
+  },
+  {
+   "id": 21283,
+   "text": "Project nexus launches in September 2027."
+  },
+  {
+   "id": 21284,
+   "text": "Project iris launches in March 2026."
+  },
+  {
+   "id": 21285,
+   "text": "Project harbor uses Tailwind for styling."
+  },
+  {
+   "id": 21286,
+   "text": "Project orbit uses Rust for performance-critical paths."
+  },
+  {
+   "id": 21287,
+   "text": "Project quartz uses Redis for caching."
+  },
+  {
+   "id": 21288,
+   "text": "Project junction uses Kafka for event streaming."
+  },
+  {
+   "id": 21289,
+   "text": "Project monolith uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 21290,
+   "text": "Project nexus launches in June 2026."
+  },
+  {
+   "id": 21291,
+   "text": "Project atlas supports 3 locales."
+  },
+  {
+   "id": 21292,
+   "text": "Project monolith launches in June 2027."
+  },
+  {
+   "id": 21293,
+   "text": "Project summit uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 21294,
+   "text": "Project tundra uses Prometheus for metrics."
+  },
+  {
+   "id": 21295,
+   "text": "Project junction uses Sentry for error tracking."
+  },
+  {
+   "id": 21296,
+   "text": "Project nexus uses Kubernetes for orchestration."
+  },
+  {
+   "id": 21297,
+   "text": "Project prism uses Tailwind for styling."
+  },
+  {
+   "id": 21298,
+   "text": "Project orbit uses FastAPI for the API layer."
+  },
+  {
+   "id": 21299,
+   "text": "Project monolith launches in March 2026."
+  },
+  {
+   "id": 21300,
+   "text": "Project compass uses Rust for performance-critical paths."
+  },
+  {
+   "id": 21301,
+   "text": "Project beacon uses Prometheus for metrics."
+  },
+  {
+   "id": 21302,
+   "text": "Project lattice uses Docker for containerization."
+  },
+  {
+   "id": 21303,
+   "text": "Project fjord launches in June 2027."
+  },
+  {
+   "id": 21304,
+   "text": "Project glacier uses React for the frontend."
+  },
+  {
+   "id": 21305,
+   "text": "Project glacier uses Grafana for dashboards."
+  },
+  {
+   "id": 21306,
+   "text": "Project orbit uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 21307,
+   "text": "Project fjord uses Kubernetes for orchestration."
+  },
+  {
+   "id": 21308,
+   "text": "Project fjord uses Prometheus for metrics."
+  },
+  {
+   "id": 21309,
+   "text": "Project summit uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 21310,
+   "text": "Project summit supports 42 locales."
+  },
+  {
+   "id": 21311,
+   "text": "Project junction uses TypeScript for the client."
+  },
+  {
+   "id": 21312,
+   "text": "Project compass uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 21313,
+   "text": "Project monolith uses ClickHouse for analytics."
+  },
+  {
+   "id": 21314,
+   "text": "Project monolith uses Elasticsearch for search."
+  },
+  {
+   "id": 21315,
+   "text": "Project tundra launches in March 2026."
+  },
+  {
+   "id": 21316,
+   "text": "Project lattice uses Python for data pipelines."
+  },
+  {
+   "id": 21317,
+   "text": "Project ridge uses FastAPI for the API layer."
+  },
+  {
+   "id": 21318,
+   "text": "Project prism uses Next.js for server-side rendering."
+  },
+  {
+   "id": 21319,
+   "text": "Project quartz uses Elasticsearch for search."
+  },
+  {
+   "id": 21320,
+   "text": "Project echo uses TypeScript for the client."
+  },
+  {
+   "id": 21321,
+   "text": "Eve is the QA lead on the prism team."
+  },
+  {
+   "id": 21322,
+   "text": "Sam is on PTO from Friday to Monday."
+  },
+  {
+   "id": 21323,
+   "text": "Pat owns the billing surface."
+  },
+  {
+   "id": 21324,
+   "text": "Taylor is the engineering manager on the lattice team."
+  },
+  {
+   "id": 21325,
+   "text": "Dave owns the search surface."
+  },
+  {
+   "id": 21326,
+   "text": "Liam is the principal engineer on the fjord team."
+  },
+  {
+   "id": 21327,
+   "text": "Riley is the engineering manager on the prism team."
+  },
+  {
+   "id": 21328,
+   "text": "Taylor is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 21329,
+   "text": "Liam is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 21330,
+   "text": "Riley is the PM on the kestrel team."
+  },
+  {
+   "id": 21331,
+   "text": "Kate reports to Quinn."
+  },
+  {
+   "id": 21332,
+   "text": "Frank reports to Kate."
+  },
+  {
+   "id": 21333,
+   "text": "Taylor is the PM on the harbor team."
+  },
+  {
+   "id": 21334,
+   "text": "Olivia is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 21335,
+   "text": "Frank is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 21336,
+   "text": "Taylor is the senior engineer on the quartz team."
+  },
+  {
+   "id": 21337,
+   "text": "Liam is the PM on the compass team."
+  },
+  {
+   "id": 21338,
+   "text": "Sam reports to Dave."
+  },
+  {
+   "id": 21339,
+   "text": "Kate is the tech lead on the orbit team."
+  },
+  {
+   "id": 21340,
+   "text": "Grace is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 21341,
+   "text": "Noah owns the billing surface."
+  },
+  {
+   "id": 21342,
+   "text": "Jack is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 21343,
+   "text": "Sam is the senior engineer on the tundra team."
+  },
+  {
+   "id": 21344,
+   "text": "Grace owns the infra surface."
+  },
+  {
+   "id": 21345,
+   "text": "Jack is on PTO from Friday to Friday."
+  },
+  {
+   "id": 21346,
+   "text": "Grace is the staff engineer on the summit team."
+  },
+  {
+   "id": 21347,
+   "text": "Henry owns the infra surface."
+  },
+  {
+   "id": 21348,
+   "text": "Liam is the senior engineer on the delta team."
+  },
+  {
+   "id": 21349,
+   "text": "Pat is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 21350,
+   "text": "Carol is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 21351,
+   "text": "Carol is the designer on the nexus team."
+  },
+  {
+   "id": 21352,
+   "text": "Pat is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 21353,
+   "text": "Mia is the staff engineer on the atlas team."
+  },
+  {
+   "id": 21354,
+   "text": "Grace reports to Dave."
+  },
+  {
+   "id": 21355,
+   "text": "Jack is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 21356,
+   "text": "Henry is the PM on the monolith team."
+  },
+  {
+   "id": 21357,
+   "text": "Sam reports to Frank."
+  },
+  {
+   "id": 21358,
+   "text": "Carol is the senior engineer on the harbor team."
+  },
+  {
+   "id": 21359,
+   "text": "Henry is the QA lead on the quartz team."
+  },
+  {
+   "id": 21360,
+   "text": "Jack is the tech lead on the glacier team."
+  },
+  {
+   "id": 21361,
+   "text": "Noah is the principal engineer on the atlas team."
+  },
+  {
+   "id": 21362,
+   "text": "Bob is the QA lead on the lattice team."
+  },
+  {
+   "id": 21363,
+   "text": "Riley is the engineering manager on the glacier team."
+  },
+  {
+   "id": 21364,
+   "text": "Henry is the staff engineer on the quartz team."
+  },
+  {
+   "id": 21365,
+   "text": "Sam is the staff engineer on the orbit team."
+  },
+  {
+   "id": 21366,
+   "text": "Mia reports to Taylor."
+  },
+  {
+   "id": 21367,
+   "text": "Quinn is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 21368,
+   "text": "Taylor is the designer on the lattice team."
+  },
+  {
+   "id": 21369,
+   "text": "Dave is the senior engineer on the delta team."
+  },
+  {
+   "id": 21370,
+   "text": "Ivy is the senior engineer on the junction team."
+  },
+  {
+   "id": 21371,
+   "text": "Liam is the staff engineer on the delta team."
+  },
+  {
+   "id": 21372,
+   "text": "Bob is on PTO from Friday to Friday."
+  },
+  {
+   "id": 21373,
+   "text": "Sam is the staff engineer on the quartz team."
+  },
+  {
+   "id": 21374,
+   "text": "Grace owns the ingest surface."
+  },
+  {
+   "id": 21375,
+   "text": "Carol is the senior engineer on the fjord team."
+  },
+  {
+   "id": 21376,
+   "text": "Eve owns the auth surface."
+  },
+  {
+   "id": 21377,
+   "text": "Riley is the senior engineer on the lattice team."
+  },
+  {
+   "id": 21378,
+   "text": "Frank is the principal engineer on the iris team."
+  },
+  {
+   "id": 21379,
+   "text": "Jack is the engineering manager on the lattice team."
+  },
+  {
+   "id": 21380,
+   "text": "Noah is the staff engineer on the lattice team."
+  },
+  {
+   "id": 21381,
+   "text": "Mia is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 21382,
+   "text": "Carol is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 21383,
+   "text": "Olivia reports to Grace."
+  },
+  {
+   "id": 21384,
+   "text": "Noah is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 21385,
+   "text": "Riley is the PM on the harbor team."
+  },
+  {
+   "id": 21386,
+   "text": "Sam is the principal engineer on the tundra team."
+  },
+  {
+   "id": 21387,
+   "text": "Carol is the PM on the iris team."
+  },
+  {
+   "id": 21388,
+   "text": "Dave is the staff engineer on the quartz team."
+  },
+  {
+   "id": 21389,
+   "text": "Quinn reports to Carol."
+  },
+  {
+   "id": 21390,
+   "text": "Riley is the tech lead on the delta team."
+  },
+  {
+   "id": 21391,
+   "text": "Sam is the designer on the nexus team."
+  },
+  {
+   "id": 21392,
+   "text": "Bob is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 21393,
+   "text": "Frank is the QA lead on the summit team."
+  },
+  {
+   "id": 21394,
+   "text": "Bob is the PM on the beacon team."
+  },
+  {
+   "id": 21395,
+   "text": "Liam is the QA lead on the harbor team."
+  },
+  {
+   "id": 21396,
+   "text": "Noah is the principal engineer on the fjord team."
+  },
+  {
+   "id": 21397,
+   "text": "Taylor is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 21398,
+   "text": "Olivia is the tech lead on the iris team."
+  },
+  {
+   "id": 21399,
+   "text": "Eve owns the infra surface."
+  },
+  {
+   "id": 21400,
+   "text": "Sam is the principal engineer on the delta team."
+  },
+  {
+   "id": 21401,
+   "text": "Noah is the QA lead on the quartz team."
+  },
+  {
+   "id": 21402,
+   "text": "Noah is the tech lead on the lattice team."
+  },
+  {
+   "id": 21403,
+   "text": "Riley is the PM on the glacier team."
+  },
+  {
+   "id": 21404,
+   "text": "Frank owns the dashboard surface."
+  },
+  {
+   "id": 21405,
+   "text": "Sam reports to Kate."
+  },
+  {
+   "id": 21406,
+   "text": "Pat is the designer on the kestrel team."
+  },
+  {
+   "id": 21407,
+   "text": "Bob reports to Ivy."
+  },
+  {
+   "id": 21408,
+   "text": "Alice is the senior engineer on the atlas team."
+  },
+  {
+   "id": 21409,
+   "text": "The user prefers dark mode as their color scheme in IntelliJ."
+  },
+  {
+   "id": 21410,
+   "text": "The user prefers gruvbox as their color scheme in Terminal.app."
+  },
+  {
+   "id": 21411,
+   "text": "The user prefers GitKraken as their git GUI in fish shell."
+  },
+  {
+   "id": 21412,
+   "text": "The user prefers tokyo night as their color scheme in fish shell."
+  },
+  {
+   "id": 21413,
+   "text": "The user prefers Hack as their font in alacritty."
+  },
+  {
+   "id": 21414,
+   "text": "The user prefers light mode as their color scheme in Windsurf."
+  },
+  {
+   "id": 21415,
+   "text": "The user prefers 15pt as their font size in bash."
+  },
+  {
+   "id": 21416,
+   "text": "The user prefers never as their auto-format in Terminal.app."
+  },
+  {
+   "id": 21417,
+   "text": "The user prefers Iosevka as their font in VS Code."
+  },
+  {
+   "id": 21418,
+   "text": "The user prefers Iosevka as their font in tmux."
+  },
+  {
+   "id": 21419,
+   "text": "The user prefers 16pt as their font size in Windsurf."
+  },
+  {
+   "id": 21420,
+   "text": "The user prefers catppuccin as their color scheme in Windsurf."
+  },
+  {
+   "id": 21421,
+   "text": "The user prefers high-contrast as their color scheme in Terminal.app."
+  },
+  {
+   "id": 21422,
+   "text": "The user prefers catppuccin as their color scheme in Emacs."
+  },
+  {
+   "id": 21423,
+   "text": "The user prefers 13pt as their font size in Terminal.app."
+  },
+  {
+   "id": 21424,
+   "text": "The user prefers catppuccin as their color scheme in tmux."
+  },
+  {
+   "id": 21425,
+   "text": "The user prefers lazygit as their git GUI in kitty."
+  },
+  {
+   "id": 21426,
+   "text": "The user prefers dark mode as their color scheme in iTerm2."
+  },
+  {
+   "id": 21427,
+   "text": "The user prefers solarized dark as their color scheme in fish shell."
+  },
+  {
+   "id": 21428,
+   "text": "Project glacier launches in June 2027."
+  },
+  {
+   "id": 21429,
+   "text": "Project iris uses Go for the orchestrator."
+  },
+  {
+   "id": 21430,
+   "text": "Project kestrel uses Prometheus for metrics."
+  },
+  {
+   "id": 21431,
+   "text": "Project iris uses Rust for performance-critical paths."
+  },
+  {
+   "id": 21432,
+   "text": "Project ridge uses Redis for caching."
+  },
+  {
+   "id": 21433,
+   "text": "Project delta uses TypeScript for the client."
+  },
+  {
+   "id": 21434,
+   "text": "Project harbor uses Kafka for event streaming."
+  },
+  {
+   "id": 21435,
+   "text": "Project beacon uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 21436,
+   "text": "Project iris uses Next.js for server-side rendering."
+  },
+  {
+   "id": 21437,
+   "text": "Project echo uses Kafka for event streaming."
+  },
+  {
+   "id": 21438,
+   "text": "Project monolith uses Redis for caching."
+  },
+  {
+   "id": 21439,
+   "text": "Project quartz uses React for the frontend."
+  },
+  {
+   "id": 21440,
+   "text": "Project iris supports 5 locales."
+  },
+  {
+   "id": 21441,
+   "text": "Project iris uses Tailwind for styling."
+  },
+  {
+   "id": 21442,
+   "text": "Project delta launches in September 2027."
+  },
+  {
+   "id": 21443,
+   "text": "Project delta uses ClickHouse for analytics."
+  },
+  {
+   "id": 21444,
+   "text": "Project fjord uses Go for the orchestrator."
+  },
+  {
+   "id": 21445,
+   "text": "Project prism uses Kubernetes for orchestration."
+  },
+  {
+   "id": 21446,
+   "text": "Project kestrel targets 10,000 monthly active users."
+  },
+  {
+   "id": 21447,
+   "text": "Project junction uses ClickHouse for analytics."
+  },
+  {
+   "id": 21448,
+   "text": "Project compass uses S3 for object storage."
+  },
+  {
+   "id": 21449,
+   "text": "Project lattice uses FastAPI for the API layer."
+  },
+  {
+   "id": 21450,
+   "text": "Project quartz uses FastAPI for the API layer."
+  },
+  {
+   "id": 21451,
+   "text": "Project glacier launches in November 2027."
+  },
+  {
+   "id": 21452,
+   "text": "Project iris uses Python for data pipelines."
+  },
+  {
+   "id": 21453,
+   "text": "Project harbor launches in June 2026."
+  },
+  {
+   "id": 21454,
+   "text": "Project lattice uses Rust for performance-critical paths."
+  },
+  {
+   "id": 21455,
+   "text": "Project iris uses Docker for containerization."
+  },
+  {
+   "id": 21456,
+   "text": "Jack owns the dashboard surface."
+  },
+  {
+   "id": 21457,
+   "text": "Eve reports to Dave."
+  },
+  {
+   "id": 21458,
+   "text": "Frank is the engineering manager on the delta team."
+  },
+  {
+   "id": 21459,
+   "text": "Mia reports to Grace."
+  },
+  {
+   "id": 21460,
+   "text": "Kate is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 21461,
+   "text": "Riley is the QA lead on the junction team."
+  },
+  {
+   "id": 21462,
+   "text": "Alice is the tech lead on the glacier team."
+  },
+  {
+   "id": 21463,
+   "text": "Olivia is the PM on the junction team."
+  },
+  {
+   "id": 21464,
+   "text": "Ivy is on PTO from Friday to Monday."
+  },
+  {
+   "id": 21465,
+   "text": "Olivia reports to Quinn."
+  },
+  {
+   "id": 21466,
+   "text": "Sam reports to Noah."
+  },
+  {
+   "id": 21467,
+   "text": "Olivia reports to Carol."
+  },
+  {
+   "id": 21468,
+   "text": "Kate is on PTO from Monday to Monday."
+  },
+  {
+   "id": 21469,
+   "text": "Alice is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 21470,
+   "text": "Alice is the principal engineer on the quartz team."
+  },
+  {
+   "id": 21471,
+   "text": "Taylor is the staff engineer on the echo team."
+  },
+  {
+   "id": 21472,
+   "text": "Riley reports to Dave."
+  },
+  {
+   "id": 21473,
+   "text": "Henry is the senior engineer on the iris team."
+  },
+  {
+   "id": 21474,
+   "text": "Grace is the designer on the echo team."
+  },
+  {
+   "id": 21475,
+   "text": "Eve is on PTO from Monday to Friday."
+  },
+  {
+   "id": 21476,
+   "text": "Henry reports to Ivy."
+  },
+  {
+   "id": 21477,
+   "text": "Grace is the staff engineer on the atlas team."
+  },
+  {
+   "id": 21478,
+   "text": "Noah is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 21479,
+   "text": "Ivy is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 21480,
+   "text": "Bob owns the dashboard surface."
+  },
+  {
+   "id": 21481,
+   "text": "Carol is the PM on the tundra team."
+  },
+  {
+   "id": 21482,
+   "text": "Frank reports to Liam."
+  },
+  {
+   "id": 21483,
+   "text": "Dave is on PTO from Monday to Friday."
+  },
+  {
+   "id": 21484,
+   "text": "Mia is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 21485,
+   "text": "Grace is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 21486,
+   "text": "Sam is the QA lead on the compass team."
+  },
+  {
+   "id": 21487,
+   "text": "Olivia is the staff engineer on the iris team."
+  },
+  {
+   "id": 21488,
+   "text": "Riley is the principal engineer on the harbor team."
+  },
+  {
+   "id": 21489,
+   "text": "Carol is the QA lead on the delta team."
+  },
+  {
+   "id": 21490,
+   "text": "Sam is the PM on the fjord team."
+  },
+  {
+   "id": 21491,
+   "text": "Riley is the staff engineer on the fjord team."
+  },
+  {
+   "id": 21492,
+   "text": "Quinn reports to Pat."
+  },
+  {
+   "id": 21493,
+   "text": "Sam is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 21494,
+   "text": "Kate reports to Liam."
+  },
+  {
+   "id": 21495,
+   "text": "Liam is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 21496,
+   "text": "Olivia reports to Henry."
+  },
+  {
+   "id": 21497,
+   "text": "Henry is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 21498,
+   "text": "Eve reports to Alice."
+  },
+  {
+   "id": 21499,
+   "text": "Pat is the staff engineer on the summit team."
+  },
+  {
+   "id": 21500,
+   "text": "Frank reports to Quinn."
+  },
+  {
+   "id": 21501,
+   "text": "Ivy is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 21502,
+   "text": "Dave is the engineering manager on the summit team."
+  },
+  {
+   "id": 21503,
+   "text": "Henry reports to Eve."
+  },
+  {
+   "id": 21504,
+   "text": "Quinn is the principal engineer on the lattice team."
+  },
+  {
+   "id": 21505,
+   "text": "Mia reports to Jack."
+  },
+  {
+   "id": 21506,
+   "text": "Quinn is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 21507,
+   "text": "Olivia is the principal engineer on the beacon team."
+  },
+  {
+   "id": 21508,
+   "text": "Eve is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 21509,
+   "text": "Jack is the tech lead on the orbit team."
+  },
+  {
+   "id": 21510,
+   "text": "Dave is the principal engineer on the summit team."
+  },
+  {
+   "id": 21511,
+   "text": "Grace is the designer on the delta team."
+  },
+  {
+   "id": 21512,
+   "text": "Bob is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 21513,
+   "text": "Henry owns the deploy surface."
+  },
+  {
+   "id": 21514,
+   "text": "Alice is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 21515,
+   "text": "Sam is the staff engineer on the lattice team."
+  },
+  {
+   "id": 21516,
+   "text": "Dave is the senior engineer on the junction team."
+  },
+  {
+   "id": 21517,
+   "text": "Pat is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 21518,
+   "text": "Henry is the engineering manager on the glacier team."
+  },
+  {
+   "id": 21519,
+   "text": "Henry is the tech lead on the glacier team."
+  },
+  {
+   "id": 21520,
+   "text": "Mia is the PM on the echo team."
+  },
+  {
+   "id": 21521,
+   "text": "Ivy reports to Jack."
+  },
+  {
+   "id": 21522,
+   "text": "Pat is the tech lead on the nexus team."
+  },
+  {
+   "id": 21523,
+   "text": "Sam is the PM on the echo team."
+  },
+  {
+   "id": 21524,
+   "text": "Henry owns the ingest surface."
+  },
+  {
+   "id": 21525,
+   "text": "Jack owns the auth surface."
+  },
+  {
+   "id": 21526,
+   "text": "Dave reports to Olivia."
+  },
+  {
+   "id": 21527,
+   "text": "Pat is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 21528,
+   "text": "Kate is the engineering manager on the monolith team."
+  },
+  {
+   "id": 21529,
+   "text": "Jack is the PM on the quartz team."
+  },
+  {
+   "id": 21530,
+   "text": "Dave is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 21531,
+   "text": "Mia is the tech lead on the harbor team."
+  },
+  {
+   "id": 21532,
+   "text": "Quinn is the principal engineer on the tundra team."
+  },
+  {
+   "id": 21533,
+   "text": "Alice is the staff engineer on the nexus team."
+  },
+  {
+   "id": 21534,
+   "text": "The user prefers 12pt as their font size in iTerm2."
+  },
+  {
+   "id": 21535,
+   "text": "The user prefers Source Code Pro as their font in VS Code."
+  },
+  {
+   "id": 21536,
+   "text": "The user prefers gruvbox as their color scheme in Neovim."
+  },
+  {
+   "id": 21537,
+   "text": "The user prefers nord as their color scheme in Cursor."
+  },
+  {
+   "id": 21538,
+   "text": "The user prefers solarized dark as their color scheme in iTerm2."
+  },
+  {
+   "id": 21539,
+   "text": "The user prefers 13pt as their font size in Zed."
+  },
+  {
+   "id": 21540,
+   "text": "The user prefers 14pt as their font size in alacritty."
+  },
+  {
+   "id": 21541,
+   "text": "The user prefers 15pt as their font size in Windsurf."
+  },
+  {
+   "id": 21542,
+   "text": "The user prefers lazygit as their git GUI in IntelliJ."
+  },
+  {
+   "id": 21543,
+   "text": "The user prefers Fira Code as their font in Zed."
+  },
+  {
+   "id": 21544,
+   "text": "The user prefers light mode as their color scheme in VS Code."
+  },
+  {
+   "id": 21545,
+   "text": "The user prefers dark mode as their color scheme in Neovim."
+  },
+  {
+   "id": 21546,
+   "text": "The user prefers Cascadia Code as their font in Neovim."
+  },
+  {
+   "id": 21547,
+   "text": "The user prefers GitKraken as their git GUI in Cursor."
+  },
+  {
+   "id": 21548,
+   "text": "The user prefers Iosevka as their font in bash."
+  },
+  {
+   "id": 21549,
+   "text": "The user prefers 12pt as their font size in Cursor."
+  },
+  {
+   "id": 21550,
+   "text": "The user prefers tig as their git GUI in fish shell."
+  },
+  {
+   "id": 21551,
+   "text": "Project nexus uses React for the frontend."
+  },
+  {
+   "id": 21552,
+   "text": "Project lattice uses Elasticsearch for search."
+  },
+  {
+   "id": 21553,
+   "text": "Project prism launches in June 2026."
+  },
+  {
+   "id": 21554,
+   "text": "Project nexus launches in November 2026."
+  },
+  {
+   "id": 21555,
+   "text": "Project kestrel uses FastAPI for the API layer."
+  },
+  {
+   "id": 21556,
+   "text": "Project beacon uses Go for the orchestrator."
+  },
+  {
+   "id": 21557,
+   "text": "Project beacon launches in June 2026."
+  },
+  {
+   "id": 21558,
+   "text": "Project atlas uses Rust for performance-critical paths."
+  },
+  {
+   "id": 21559,
+   "text": "Project lattice uses Next.js for server-side rendering."
+  },
+  {
+   "id": 21560,
+   "text": "Project iris uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 21561,
+   "text": "Project junction uses Tailwind for styling."
+  },
+  {
+   "id": 21562,
+   "text": "Project orbit uses ClickHouse for analytics."
+  },
+  {
+   "id": 21563,
+   "text": "Project ridge uses Grafana for dashboards."
+  },
+  {
+   "id": 21564,
+   "text": "Project prism launches in March 2026."
+  },
+  {
+   "id": 21565,
+   "text": "Project ridge uses Tailwind for styling."
+  },
+  {
+   "id": 21566,
+   "text": "Project nexus uses Grafana for dashboards."
+  },
+  {
+   "id": 21567,
+   "text": "Project harbor launches in March 2026."
+  },
+  {
+   "id": 21568,
+   "text": "Project tundra uses Grafana for dashboards."
+  },
+  {
+   "id": 21569,
+   "text": "Project prism uses ClickHouse for analytics."
+  },
+  {
+   "id": 21570,
+   "text": "Project junction uses Python for data pipelines."
+  },
+  {
+   "id": 21571,
+   "text": "Project echo uses Kubernetes for orchestration."
+  },
+  {
+   "id": 21572,
+   "text": "Project prism uses Python for data pipelines."
+  },
+  {
+   "id": 21573,
+   "text": "Project lattice uses Sentry for error tracking."
+  },
+  {
+   "id": 21574,
+   "text": "Project beacon uses S3 for object storage."
+  },
+  {
+   "id": 21575,
+   "text": "Project echo uses Elasticsearch for search."
+  },
+  {
+   "id": 21576,
+   "text": "Project glacier uses Go for the orchestrator."
+  },
+  {
+   "id": 21577,
+   "text": "Project monolith uses Go for the orchestrator."
+  },
+  {
+   "id": 21578,
+   "text": "Project glacier uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 21579,
+   "text": "Jack is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 21580,
+   "text": "Riley is the engineering manager on the ridge team."
+  },
+  {
+   "id": 21581,
+   "text": "Frank is the QA lead on the compass team."
+  },
+  {
+   "id": 21582,
+   "text": "Liam owns the billing surface."
+  },
+  {
+   "id": 21583,
+   "text": "Grace is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 21584,
+   "text": "Eve is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 21585,
+   "text": "Mia is the PM on the harbor team."
+  },
+  {
+   "id": 21586,
+   "text": "Henry is the principal engineer on the harbor team."
+  },
+  {
+   "id": 21587,
+   "text": "Riley is on PTO from Friday to Friday."
+  },
+  {
+   "id": 21588,
+   "text": "Kate is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 21589,
+   "text": "Ivy is on PTO from Friday to Friday."
+  },
+  {
+   "id": 21590,
+   "text": "Carol reports to Olivia."
+  },
+  {
+   "id": 21591,
+   "text": "Pat is the designer on the ridge team."
+  },
+  {
+   "id": 21592,
+   "text": "Jack is the PM on the ridge team."
+  },
+  {
+   "id": 21593,
+   "text": "Noah reports to Eve."
+  },
+  {
+   "id": 21594,
+   "text": "Ivy reports to Quinn."
+  },
+  {
+   "id": 21595,
+   "text": "Jack is the tech lead on the atlas team."
+  },
+  {
+   "id": 21596,
+   "text": "Frank reports to Dave."
+  },
+  {
+   "id": 21597,
+   "text": "Eve is the designer on the delta team."
+  },
+  {
+   "id": 21598,
+   "text": "Jack is the staff engineer on the atlas team."
+  },
+  {
+   "id": 21599,
+   "text": "Jack is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 21600,
+   "text": "Riley is the engineering manager on the harbor team."
+  },
+  {
+   "id": 21601,
+   "text": "Quinn is the staff engineer on the kestrel team."
+  },
+  {
+   "id": 21602,
+   "text": "Jack is the QA lead on the quartz team."
+  },
+  {
+   "id": 21603,
+   "text": "Bob reports to Frank."
+  },
+  {
+   "id": 21604,
+   "text": "Bob is the engineering manager on the iris team."
+  },
+  {
+   "id": 21605,
+   "text": "Bob is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 21606,
+   "text": "Carol reports to Dave."
+  },
+  {
+   "id": 21607,
+   "text": "Dave is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 21608,
+   "text": "Dave is on PTO from Friday to Monday."
+  },
+  {
+   "id": 21609,
+   "text": "Sam is the PM on the harbor team."
+  },
+  {
+   "id": 21610,
+   "text": "Ivy is the PM on the fjord team."
+  },
+  {
+   "id": 21611,
+   "text": "Frank is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 21612,
+   "text": "Noah is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 21613,
+   "text": "Carol is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 21614,
+   "text": "Liam is the engineering manager on the atlas team."
+  },
+  {
+   "id": 21615,
+   "text": "Riley is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 21616,
+   "text": "Pat is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 21617,
+   "text": "Kate reports to Ivy."
+  },
+  {
+   "id": 21618,
+   "text": "Kate is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 21619,
+   "text": "Ivy is the tech lead on the delta team."
+  },
+  {
+   "id": 21620,
+   "text": "Henry is on PTO from Friday to Monday."
+  },
+  {
+   "id": 21621,
+   "text": "Jack is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 21622,
+   "text": "Taylor is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 21623,
+   "text": "Kate reports to Bob."
+  },
+  {
+   "id": 21624,
+   "text": "Jack reports to Olivia."
+  },
+  {
+   "id": 21625,
+   "text": "Quinn reports to Taylor."
+  },
+  {
+   "id": 21626,
+   "text": "Taylor is the PM on the kestrel team."
+  },
+  {
+   "id": 21627,
+   "text": "Pat is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 21628,
+   "text": "Henry is the PM on the nexus team."
+  },
+  {
+   "id": 21629,
+   "text": "Taylor is on PTO from Monday to Monday."
+  },
+  {
+   "id": 21630,
+   "text": "Quinn is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 21631,
+   "text": "Frank is the designer on the glacier team."
+  },
+  {
+   "id": 21632,
+   "text": "Mia is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 21633,
+   "text": "Dave owns the ingest surface."
+  },
+  {
+   "id": 21634,
+   "text": "Quinn is the senior engineer on the ridge team."
+  },
+  {
+   "id": 21635,
+   "text": "Henry is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 21636,
+   "text": "Pat owns the ingest surface."
+  },
+  {
+   "id": 21637,
+   "text": "Noah is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 21638,
+   "text": "Riley reports to Alice."
+  },
+  {
+   "id": 21639,
+   "text": "Pat owns the deploy surface."
+  },
+  {
+   "id": 21640,
+   "text": "Liam owns the search surface."
+  },
+  {
+   "id": 21641,
+   "text": "Eve is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 21642,
+   "text": "Sam is the engineering manager on the beacon team."
+  },
+  {
+   "id": 21643,
+   "text": "Eve is the principal engineer on the glacier team."
+  },
+  {
+   "id": 21644,
+   "text": "Eve is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 21645,
+   "text": "Jack is the principal engineer on the compass team."
+  },
+  {
+   "id": 21646,
+   "text": "The user prefers tokyo night as their color scheme in Emacs."
+  },
+  {
+   "id": 21647,
+   "text": "The user prefers tig as their git GUI in Cursor."
+  },
+  {
+   "id": 21648,
+   "text": "The user prefers lazygit as their git GUI in Zed."
+  },
+  {
+   "id": 21649,
+   "text": "The user prefers Hack as their font in tmux."
+  },
+  {
+   "id": 21650,
+   "text": "The user prefers Iosevka as their font in Hyper."
+  },
+  {
+   "id": 21651,
+   "text": "The user prefers Fira Code as their font in Cursor."
+  },
+  {
+   "id": 21652,
+   "text": "The user prefers Hack as their font in bash."
+  },
+  {
+   "id": 21653,
+   "text": "The user prefers Source Code Pro as their font in Neovim."
+  },
+  {
+   "id": 21654,
+   "text": "The user prefers 13pt as their font size in Sublime Text."
+  },
+  {
+   "id": 21655,
+   "text": "The user prefers catppuccin as their color scheme in VS Code."
+  },
+  {
+   "id": 21656,
+   "text": "The user prefers high-contrast as their color scheme in Hyper."
+  },
+  {
+   "id": 21657,
+   "text": "The user prefers gruvbox as their color scheme in Warp."
+  },
+  {
+   "id": 21658,
+   "text": "The user prefers Fira Code as their font in Vim."
+  },
+  {
+   "id": 21659,
+   "text": "Project iris uses Elasticsearch for search."
+  },
+  {
+   "id": 21660,
+   "text": "Project junction uses Go for the orchestrator."
+  },
+  {
+   "id": 21661,
+   "text": "Project nexus uses Rust for performance-critical paths."
+  },
+  {
+   "id": 21662,
+   "text": "Project kestrel uses Rust for performance-critical paths."
+  },
+  {
+   "id": 21663,
+   "text": "Project lattice launches in November 2027."
+  },
+  {
+   "id": 21664,
+   "text": "Project atlas uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 21665,
+   "text": "Project atlas uses S3 for object storage."
+  },
+  {
+   "id": 21666,
+   "text": "Project echo uses Redis for caching."
+  },
+  {
+   "id": 21667,
+   "text": "Project junction uses Redis for caching."
+  },
+  {
+   "id": 21668,
+   "text": "Project lattice targets 1,000,000 monthly active users."
+  },
+  {
+   "id": 21669,
+   "text": "Project glacier uses Docker for containerization."
+  },
+  {
+   "id": 21670,
+   "text": "Project monolith uses Next.js for server-side rendering."
+  },
+  {
+   "id": 21671,
+   "text": "Project compass uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 21672,
+   "text": "Project quartz launches in March 2027."
+  },
+  {
+   "id": 21673,
+   "text": "Project echo uses Grafana for dashboards."
+  },
+  {
+   "id": 21674,
+   "text": "Project harbor uses Go for the orchestrator."
+  },
+  {
+   "id": 21675,
+   "text": "Project delta uses React for the frontend."
+  },
+  {
+   "id": 21676,
+   "text": "Project compass uses Prometheus for metrics."
+  },
+  {
+   "id": 21677,
+   "text": "Project monolith supports 12 locales."
+  },
+  {
+   "id": 21678,
+   "text": "Project tundra uses Tailwind for styling."
+  },
+  {
+   "id": 21679,
+   "text": "Project nexus uses Prometheus for metrics."
+  },
+  {
+   "id": 21680,
+   "text": "Project beacon uses FastAPI for the API layer."
+  },
+  {
+   "id": 21681,
+   "text": "Project lattice launches in September 2027."
+  },
+  {
+   "id": 21682,
+   "text": "Alice reports to Kate."
+  },
+  {
+   "id": 21683,
+   "text": "Olivia reports to Pat."
+  },
+  {
+   "id": 21684,
+   "text": "Frank is the senior engineer on the monolith team."
+  },
+  {
+   "id": 21685,
+   "text": "Carol is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 21686,
+   "text": "Jack is the engineering manager on the orbit team."
+  },
+  {
+   "id": 21687,
+   "text": "Olivia owns the search surface."
+  },
+  {
+   "id": 21688,
+   "text": "Frank is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 21689,
+   "text": "Mia is the QA lead on the echo team."
+  },
+  {
+   "id": 21690,
+   "text": "Quinn is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 21691,
+   "text": "Eve is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 21692,
+   "text": "Liam owns the infra surface."
+  },
+  {
+   "id": 21693,
+   "text": "Pat is the PM on the harbor team."
+  },
+  {
+   "id": 21694,
+   "text": "Olivia is the staff engineer on the echo team."
+  },
+  {
+   "id": 21695,
+   "text": "Bob is the engineering manager on the beacon team."
+  },
+  {
+   "id": 21696,
+   "text": "Olivia is the PM on the summit team."
+  },
+  {
+   "id": 21697,
+   "text": "Grace reports to Alice."
+  },
+  {
+   "id": 21698,
+   "text": "Noah reports to Riley."
+  },
+  {
+   "id": 21699,
+   "text": "Kate is the tech lead on the junction team."
+  },
+  {
+   "id": 21700,
+   "text": "Henry is the senior engineer on the nexus team."
+  },
+  {
+   "id": 21701,
+   "text": "Noah is the designer on the atlas team."
+  },
+  {
+   "id": 21702,
+   "text": "Dave is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 21703,
+   "text": "Sam is the QA lead on the prism team."
+  },
+  {
+   "id": 21704,
+   "text": "Taylor is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 21705,
+   "text": "Bob is the PM on the compass team."
+  },
+  {
+   "id": 21706,
+   "text": "Liam owns the API surface."
+  },
+  {
+   "id": 21707,
+   "text": "Taylor is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 21708,
+   "text": "Dave is the designer on the orbit team."
+  },
+  {
+   "id": 21709,
+   "text": "Liam is the QA lead on the echo team."
+  },
+  {
+   "id": 21710,
+   "text": "Jack is the principal engineer on the iris team."
+  },
+  {
+   "id": 21711,
+   "text": "Sam is the QA lead on the tundra team."
+  },
+  {
+   "id": 21712,
+   "text": "Taylor is the principal engineer on the echo team."
+  },
+  {
+   "id": 21713,
+   "text": "Noah is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 21714,
+   "text": "Riley is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 21715,
+   "text": "Quinn owns the infra surface."
+  },
+  {
+   "id": 21716,
+   "text": "Quinn is the staff engineer on the prism team."
+  },
+  {
+   "id": 21717,
+   "text": "Alice is the QA lead on the harbor team."
+  },
+  {
+   "id": 21718,
+   "text": "Carol is the PM on the echo team."
+  },
+  {
+   "id": 21719,
+   "text": "Eve is the senior engineer on the iris team."
+  },
+  {
+   "id": 21720,
+   "text": "Frank is the tech lead on the junction team."
+  },
+  {
+   "id": 21721,
+   "text": "Jack is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 21722,
+   "text": "Liam is the tech lead on the iris team."
+  },
+  {
+   "id": 21723,
+   "text": "Bob is the PM on the fjord team."
+  },
+  {
+   "id": 21724,
+   "text": "Riley is the staff engineer on the orbit team."
+  },
+  {
+   "id": 21725,
+   "text": "Henry is the engineering manager on the kestrel team."
+  },
+  {
+   "id": 21726,
+   "text": "Eve is the designer on the lattice team."
+  },
+  {
+   "id": 21727,
+   "text": "Dave reports to Ivy."
+  },
+  {
+   "id": 21728,
+   "text": "Alice reports to Dave."
+  },
+  {
+   "id": 21729,
+   "text": "Henry reports to Noah."
+  },
+  {
+   "id": 21730,
+   "text": "Pat is the staff engineer on the kestrel team."
+  },
+  {
+   "id": 21731,
+   "text": "Alice reports to Noah."
+  },
+  {
+   "id": 21732,
+   "text": "Henry is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 21733,
+   "text": "Taylor is the principal engineer on the summit team."
+  },
+  {
+   "id": 21734,
+   "text": "Liam reports to Jack."
+  },
+  {
+   "id": 21735,
+   "text": "Liam is the PM on the monolith team."
+  },
+  {
+   "id": 21736,
+   "text": "Sam reports to Alice."
+  },
+  {
+   "id": 21737,
+   "text": "Ivy is the senior engineer on the nexus team."
+  },
+  {
+   "id": 21738,
+   "text": "Jack is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 21739,
+   "text": "Jack is the senior engineer on the beacon team."
+  },
+  {
+   "id": 21740,
+   "text": "Olivia is the tech lead on the glacier team."
+  },
+  {
+   "id": 21741,
+   "text": "Grace reports to Henry."
+  },
+  {
+   "id": 21742,
+   "text": "Eve is the tech lead on the junction team."
+  },
+  {
+   "id": 21743,
+   "text": "Quinn reports to Kate."
+  },
+  {
+   "id": 21744,
+   "text": "Henry is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 21745,
+   "text": "Bob is the staff engineer on the iris team."
+  },
+  {
+   "id": 21746,
+   "text": "Ivy is the PM on the kestrel team."
+  },
+  {
+   "id": 21747,
+   "text": "Bob is the PM on the harbor team."
+  },
+  {
+   "id": 21748,
+   "text": "Kate is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 21749,
+   "text": "Noah is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 21750,
+   "text": "Noah is the engineering manager on the nexus team."
+  },
+  {
+   "id": 21751,
+   "text": "Frank is the QA lead on the delta team."
+  },
+  {
+   "id": 21752,
+   "text": "Eve reports to Quinn."
+  },
+  {
+   "id": 21753,
+   "text": "Mia is the tech lead on the beacon team."
+  },
+  {
+   "id": 21754,
+   "text": "The user prefers Source Code Pro as their font in Sublime Text."
+  },
+  {
+   "id": 21755,
+   "text": "The user prefers Fira Code as their font in zsh."
+  },
+  {
+   "id": 21756,
+   "text": "The user prefers GitKraken as their git GUI in tmux."
+  },
+  {
+   "id": 21757,
+   "text": "The user prefers catppuccin as their color scheme in Zed."
+  },
+  {
+   "id": 21758,
+   "text": "The user prefers gruvbox as their color scheme in VS Code."
+  },
+  {
+   "id": 21759,
+   "text": "The user prefers GitKraken as their git GUI in Vim."
+  },
+  {
+   "id": 21760,
+   "text": "The user prefers 12pt as their font size in alacritty."
+  },
+  {
+   "id": 21761,
+   "text": "The user prefers tokyo night as their color scheme in PyCharm."
+  },
+  {
+   "id": 21762,
+   "text": "The user prefers GitKraken as their git GUI in VS Code."
+  },
+  {
+   "id": 21763,
+   "text": "The user prefers Fork as their git GUI in PyCharm."
+  },
+  {
+   "id": 21764,
+   "text": "The user prefers nord as their color scheme in tmux."
+  },
+  {
+   "id": 21765,
+   "text": "The user prefers gruvbox as their color scheme in Hyper."
+  },
+  {
+   "id": 21766,
+   "text": "Project prism uses Rust for performance-critical paths."
+  },
+  {
+   "id": 21767,
+   "text": "Project glacier uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 21768,
+   "text": "Project glacier uses Python for data pipelines."
+  },
+  {
+   "id": 21769,
+   "text": "Project summit uses FastAPI for the API layer."
+  },
+  {
+   "id": 21770,
+   "text": "Project lattice launches in November 2026."
+  },
+  {
+   "id": 21771,
+   "text": "Project delta launches in September 2026."
+  },
+  {
+   "id": 21772,
+   "text": "Project lattice uses React for the frontend."
+  },
+  {
+   "id": 21773,
+   "text": "Project nexus uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 21774,
+   "text": "Project lattice uses ClickHouse for analytics."
+  },
+  {
+   "id": 21775,
+   "text": "Project tundra uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 21776,
+   "text": "Project atlas uses Prometheus for metrics."
+  },
+  {
+   "id": 21777,
+   "text": "Project tundra launches in June 2026."
+  },
+  {
+   "id": 21778,
+   "text": "Project glacier uses Redis for caching."
+  },
+  {
+   "id": 21779,
+   "text": "Project junction uses Prometheus for metrics."
+  },
+  {
+   "id": 21780,
+   "text": "Project iris uses Sentry for error tracking."
+  },
+  {
+   "id": 21781,
+   "text": "Project prism uses S3 for object storage."
+  },
+  {
+   "id": 21782,
+   "text": "Project summit launches in November 2026."
+  },
+  {
+   "id": 21783,
+   "text": "Project delta uses Redis for caching."
+  },
+  {
+   "id": 21784,
+   "text": "Frank is the principal engineer on the glacier team."
+  },
+  {
+   "id": 21785,
+   "text": "Mia is the designer on the iris team."
+  },
+  {
+   "id": 21786,
+   "text": "Taylor is the PM on the glacier team."
+  },
+  {
+   "id": 21787,
+   "text": "Kate reports to Sam."
+  },
+  {
+   "id": 21788,
+   "text": "Riley is the QA lead on the delta team."
+  },
+  {
+   "id": 21789,
+   "text": "Liam is the designer on the atlas team."
+  },
+  {
+   "id": 21790,
+   "text": "Bob is the designer on the compass team."
+  },
+  {
+   "id": 21791,
+   "text": "Olivia is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 21792,
+   "text": "Eve is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 21793,
+   "text": "Alice is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 21794,
+   "text": "Dave is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 21795,
+   "text": "Dave reports to Mia."
+  },
+  {
+   "id": 21796,
+   "text": "Jack is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 21797,
+   "text": "Kate is the senior engineer on the fjord team."
+  },
+  {
+   "id": 21798,
+   "text": "Jack reports to Henry."
+  },
+  {
+   "id": 21799,
+   "text": "Bob is the QA lead on the ridge team."
+  },
+  {
+   "id": 21800,
+   "text": "Ivy reports to Noah."
+  },
+  {
+   "id": 21801,
+   "text": "Jack is the PM on the monolith team."
+  },
+  {
+   "id": 21802,
+   "text": "Kate is the staff engineer on the junction team."
+  },
+  {
+   "id": 21803,
+   "text": "Sam is the principal engineer on the beacon team."
+  },
+  {
+   "id": 21804,
+   "text": "Eve reports to Frank."
+  },
+  {
+   "id": 21805,
+   "text": "Noah is the PM on the ridge team."
+  },
+  {
+   "id": 21806,
+   "text": "Bob is the engineering manager on the monolith team."
+  },
+  {
+   "id": 21807,
+   "text": "Liam is the senior engineer on the ridge team."
+  },
+  {
+   "id": 21808,
+   "text": "Eve is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 21809,
+   "text": "Sam is the tech lead on the summit team."
+  },
+  {
+   "id": 21810,
+   "text": "Carol reports to Grace."
+  },
+  {
+   "id": 21811,
+   "text": "Kate reports to Olivia."
+  },
+  {
+   "id": 21812,
+   "text": "Ivy is the senior engineer on the atlas team."
+  },
+  {
+   "id": 21813,
+   "text": "Henry reports to Taylor."
+  },
+  {
+   "id": 21814,
+   "text": "Henry is the engineering manager on the atlas team."
+  },
+  {
+   "id": 21815,
+   "text": "Eve reports to Pat."
+  },
+  {
+   "id": 21816,
+   "text": "Carol is the QA lead on the beacon team."
+  },
+  {
+   "id": 21817,
+   "text": "Kate is the staff engineer on the iris team."
+  },
+  {
+   "id": 21818,
+   "text": "Eve is the PM on the ridge team."
+  },
+  {
+   "id": 21819,
+   "text": "Bob is the designer on the beacon team."
+  },
+  {
+   "id": 21820,
+   "text": "Olivia is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 21821,
+   "text": "Taylor is the principal engineer on the ridge team."
+  },
+  {
+   "id": 21822,
+   "text": "Bob is the staff engineer on the ridge team."
+  },
+  {
+   "id": 21823,
+   "text": "Liam reports to Ivy."
+  },
+  {
+   "id": 21824,
+   "text": "Jack is the QA lead on the fjord team."
+  },
+  {
+   "id": 21825,
+   "text": "Taylor is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 21826,
+   "text": "Noah is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 21827,
+   "text": "Sam reports to Olivia."
+  },
+  {
+   "id": 21828,
+   "text": "Alice is the QA lead on the beacon team."
+  },
+  {
+   "id": 21829,
+   "text": "Pat is on PTO from Friday to Monday."
+  },
+  {
+   "id": 21830,
+   "text": "Kate is the tech lead on the quartz team."
+  },
+  {
+   "id": 21831,
+   "text": "Ivy reports to Riley."
+  },
+  {
+   "id": 21832,
+   "text": "Olivia owns the infra surface."
+  },
+  {
+   "id": 21833,
+   "text": "Noah is the senior engineer on the echo team."
+  },
+  {
+   "id": 21834,
+   "text": "Liam is the principal engineer on the junction team."
+  },
+  {
+   "id": 21835,
+   "text": "Mia is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 21836,
+   "text": "Dave is the PM on the ridge team."
+  },
+  {
+   "id": 21837,
+   "text": "Grace is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 21838,
+   "text": "Kate is the senior engineer on the prism team."
+  },
+  {
+   "id": 21839,
+   "text": "Noah is the tech lead on the kestrel team."
+  },
+  {
+   "id": 21840,
+   "text": "Grace owns the search surface."
+  },
+  {
+   "id": 21841,
+   "text": "Liam is the PM on the quartz team."
+  },
+  {
+   "id": 21842,
+   "text": "Liam is the senior engineer on the beacon team."
+  },
+  {
+   "id": 21843,
+   "text": "Jack is the QA lead on the beacon team."
+  },
+  {
+   "id": 21844,
+   "text": "Carol is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 21845,
+   "text": "Grace reports to Eve."
+  },
+  {
+   "id": 21846,
+   "text": "Ivy reports to Eve."
+  },
+  {
+   "id": 21847,
+   "text": "Alice is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 21848,
+   "text": "Jack is the tech lead on the echo team."
+  },
+  {
+   "id": 21849,
+   "text": "Taylor is the principal engineer on the glacier team."
+  },
+  {
+   "id": 21850,
+   "text": "Pat is the QA lead on the atlas team."
+  },
+  {
+   "id": 21851,
+   "text": "Jack is on PTO from Monday to Monday."
+  },
+  {
+   "id": 21852,
+   "text": "Henry is the staff engineer on the orbit team."
+  },
+  {
+   "id": 21853,
+   "text": "Sam is the tech lead on the orbit team."
+  },
+  {
+   "id": 21854,
+   "text": "Riley is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 21855,
+   "text": "The user prefers Iosevka as their font in Emacs."
+  },
+  {
+   "id": 21856,
+   "text": "The user prefers dark mode as their color scheme in alacritty."
+  },
+  {
+   "id": 21857,
+   "text": "The user prefers catppuccin as their color scheme in kitty."
+  },
+  {
+   "id": 21858,
+   "text": "The user prefers dark mode as their color scheme in tmux."
+  },
+  {
+   "id": 21859,
+   "text": "Project nexus uses Docker for containerization."
+  },
+  {
+   "id": 21860,
+   "text": "Project summit uses Grafana for dashboards."
+  },
+  {
+   "id": 21861,
+   "text": "Project compass uses Grafana for dashboards."
+  },
+  {
+   "id": 21862,
+   "text": "Project harbor uses Prometheus for metrics."
+  },
+  {
+   "id": 21863,
+   "text": "Project echo uses S3 for object storage."
+  },
+  {
+   "id": 21864,
+   "text": "Project fjord uses Elasticsearch for search."
+  },
+  {
+   "id": 21865,
+   "text": "Project atlas supports 27 locales."
+  },
+  {
+   "id": 21866,
+   "text": "Project monolith uses Tailwind for styling."
+  },
+  {
+   "id": 21867,
+   "text": "Project echo uses FastAPI for the API layer."
+  },
+  {
+   "id": 21868,
+   "text": "Project kestrel uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 21869,
+   "text": "Bob is the tech lead on the tundra team."
+  },
+  {
+   "id": 21870,
+   "text": "Eve is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 21871,
+   "text": "Liam is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 21872,
+   "text": "Riley is the PM on the prism team."
+  },
+  {
+   "id": 21873,
+   "text": "Pat is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 21874,
+   "text": "Bob is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 21875,
+   "text": "Jack is the QA lead on the harbor team."
+  },
+  {
+   "id": 21876,
+   "text": "Eve is the staff engineer on the orbit team."
+  },
+  {
+   "id": 21877,
+   "text": "Kate is the staff engineer on the fjord team."
+  },
+  {
+   "id": 21878,
+   "text": "Alice is on PTO from Monday to Friday."
+  },
+  {
+   "id": 21879,
+   "text": "Alice is the QA lead on the junction team."
+  },
+  {
+   "id": 21880,
+   "text": "Dave reports to Kate."
+  },
+  {
+   "id": 21881,
+   "text": "Pat is the staff engineer on the delta team."
+  },
+  {
+   "id": 21882,
+   "text": "Jack is the tech lead on the summit team."
+  },
+  {
+   "id": 21883,
+   "text": "Ivy is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 21884,
+   "text": "Eve is the principal engineer on the summit team."
+  },
+  {
+   "id": 21885,
+   "text": "Olivia is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 21886,
+   "text": "Ivy is the principal engineer on the summit team."
+  },
+  {
+   "id": 21887,
+   "text": "Pat reports to Grace."
+  },
+  {
+   "id": 21888,
+   "text": "Eve is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 21889,
+   "text": "Alice is the PM on the nexus team."
+  },
+  {
+   "id": 21890,
+   "text": "Kate is the principal engineer on the glacier team."
+  },
+  {
+   "id": 21891,
+   "text": "Jack is the staff engineer on the beacon team."
+  },
+  {
+   "id": 21892,
+   "text": "Jack is the tech lead on the compass team."
+  },
+  {
+   "id": 21893,
+   "text": "Carol reports to Bob."
+  },
+  {
+   "id": 21894,
+   "text": "Grace is the senior engineer on the orbit team."
+  },
+  {
+   "id": 21895,
+   "text": "Grace is the engineering manager on the tundra team."
+  },
+  {
+   "id": 21896,
+   "text": "Henry is the senior engineer on the fjord team."
+  },
+  {
+   "id": 21897,
+   "text": "Frank is the designer on the kestrel team."
+  },
+  {
+   "id": 21898,
+   "text": "Bob is the designer on the summit team."
+  },
+  {
+   "id": 21899,
+   "text": "Ivy is the tech lead on the nexus team."
+  },
+  {
+   "id": 21900,
+   "text": "Frank is the QA lead on the prism team."
+  },
+  {
+   "id": 21901,
+   "text": "Henry is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 21902,
+   "text": "Ivy is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 21903,
+   "text": "Grace is the PM on the compass team."
+  },
+  {
+   "id": 21904,
+   "text": "Frank is on PTO from Friday to Friday."
+  },
+  {
+   "id": 21905,
+   "text": "Noah is the designer on the prism team."
+  },
+  {
+   "id": 21906,
+   "text": "Kate is the principal engineer on the orbit team."
+  },
+  {
+   "id": 21907,
+   "text": "Frank is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 21908,
+   "text": "Ivy reports to Frank."
+  },
+  {
+   "id": 21909,
+   "text": "Eve is the designer on the echo team."
+  },
+  {
+   "id": 21910,
+   "text": "Grace is the engineering manager on the orbit team."
+  },
+  {
+   "id": 21911,
+   "text": "Dave is the designer on the lattice team."
+  },
+  {
+   "id": 21912,
+   "text": "Ivy is the engineering manager on the beacon team."
+  },
+  {
+   "id": 21913,
+   "text": "Taylor is the tech lead on the harbor team."
+  },
+  {
+   "id": 21914,
+   "text": "Noah reports to Frank."
+  },
+  {
+   "id": 21915,
+   "text": "Noah is the designer on the lattice team."
+  },
+  {
+   "id": 21916,
+   "text": "Frank reports to Mia."
+  },
+  {
+   "id": 21917,
+   "text": "Sam is the principal engineer on the orbit team."
+  },
+  {
+   "id": 21918,
+   "text": "Alice is the designer on the harbor team."
+  },
+  {
+   "id": 21919,
+   "text": "Bob reports to Sam."
+  },
+  {
+   "id": 21920,
+   "text": "Sam is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 21921,
+   "text": "Liam reports to Dave."
+  },
+  {
+   "id": 21922,
+   "text": "Quinn is on PTO from Monday to Friday."
+  },
+  {
+   "id": 21923,
+   "text": "Henry is the senior engineer on the prism team."
+  },
+  {
+   "id": 21924,
+   "text": "Olivia is the senior engineer on the tundra team."
+  },
+  {
+   "id": 21925,
+   "text": "Jack is the staff engineer on the delta team."
+  },
+  {
+   "id": 21926,
+   "text": "Noah reports to Grace."
+  },
+  {
+   "id": 21927,
+   "text": "Alice is the principal engineer on the lattice team."
+  },
+  {
+   "id": 21928,
+   "text": "Carol owns the billing surface."
+  },
+  {
+   "id": 21929,
+   "text": "Kate is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 21930,
+   "text": "Ivy is on PTO from Monday to Monday."
+  },
+  {
+   "id": 21931,
+   "text": "Henry reports to Mia."
+  },
+  {
+   "id": 21932,
+   "text": "Pat is the senior engineer on the junction team."
+  },
+  {
+   "id": 21933,
+   "text": "Olivia is the principal engineer on the fjord team."
+  },
+  {
+   "id": 21934,
+   "text": "Noah is the designer on the beacon team."
+  },
+  {
+   "id": 21935,
+   "text": "Mia reports to Henry."
+  },
+  {
+   "id": 21936,
+   "text": "Liam is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 21937,
+   "text": "Grace is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 21938,
+   "text": "Riley is the designer on the delta team."
+  },
+  {
+   "id": 21939,
+   "text": "Alice is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 21940,
+   "text": "Kate is the senior engineer on the ridge team."
+  },
+  {
+   "id": 21941,
+   "text": "The user prefers tokyo night as their color scheme in alacritty."
+  },
+  {
+   "id": 21942,
+   "text": "The user prefers high-contrast as their color scheme in Vim."
+  },
+  {
+   "id": 21943,
+   "text": "The user prefers nord as their color scheme in alacritty."
+  },
+  {
+   "id": 21944,
+   "text": "The user prefers command line only as their git GUI in VS Code."
+  },
+  {
+   "id": 21945,
+   "text": "The user prefers 16pt as their font size in Warp."
+  },
+  {
+   "id": 21946,
+   "text": "The user prefers Fira Code as their font in tmux."
+  },
+  {
+   "id": 21947,
+   "text": "Project junction uses Kubernetes for orchestration."
+  },
+  {
+   "id": 21948,
+   "text": "Project ridge uses Kubernetes for orchestration."
+  },
+  {
+   "id": 21949,
+   "text": "Project ridge uses Next.js for server-side rendering."
+  },
+  {
+   "id": 21950,
+   "text": "Project harbor uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 21951,
+   "text": "Project quartz uses Sentry for error tracking."
+  },
+  {
+   "id": 21952,
+   "text": "Project harbor uses Grafana for dashboards."
+  },
+  {
+   "id": 21953,
+   "text": "Project quartz uses Kafka for event streaming."
+  },
+  {
+   "id": 21954,
+   "text": "Project summit uses Prometheus for metrics."
+  },
+  {
+   "id": 21955,
+   "text": "Project compass uses Tailwind for styling."
+  },
+  {
+   "id": 21956,
+   "text": "Project harbor uses Next.js for server-side rendering."
+  },
+  {
+   "id": 21957,
+   "text": "Project iris uses ClickHouse for analytics."
+  },
+  {
+   "id": 21958,
+   "text": "Project tundra supports 12 locales."
+  },
+  {
+   "id": 21959,
+   "text": "Project atlas uses Next.js for server-side rendering."
+  },
+  {
+   "id": 21960,
+   "text": "Project summit supports 3 locales."
+  },
+  {
+   "id": 21961,
+   "text": "Dave is the principal engineer on the monolith team."
+  },
+  {
+   "id": 21962,
+   "text": "Carol reports to Noah."
+  },
+  {
+   "id": 21963,
+   "text": "Jack reports to Ivy."
+  },
+  {
+   "id": 21964,
+   "text": "Carol is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 21965,
+   "text": "Ivy reports to Sam."
+  },
+  {
+   "id": 21966,
+   "text": "Noah is the tech lead on the quartz team."
+  },
+  {
+   "id": 21967,
+   "text": "Eve is the designer on the tundra team."
+  },
+  {
+   "id": 21968,
+   "text": "Ivy is on PTO from Monday to Friday."
+  },
+  {
+   "id": 21969,
+   "text": "Bob reports to Eve."
+  },
+  {
+   "id": 21970,
+   "text": "Henry is the principal engineer on the prism team."
+  },
+  {
+   "id": 21971,
+   "text": "Frank is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 21972,
+   "text": "Quinn is the staff engineer on the lattice team."
+  },
+  {
+   "id": 21973,
+   "text": "Riley is the tech lead on the beacon team."
+  },
+  {
+   "id": 21974,
+   "text": "Kate is the designer on the echo team."
+  },
+  {
+   "id": 21975,
+   "text": "Quinn is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 21976,
+   "text": "Taylor is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 21977,
+   "text": "Sam is the PM on the ridge team."
+  },
+  {
+   "id": 21978,
+   "text": "Sam reports to Bob."
+  },
+  {
+   "id": 21979,
+   "text": "Riley is the QA lead on the beacon team."
+  },
+  {
+   "id": 21980,
+   "text": "Liam is the PM on the junction team."
+  },
+  {
+   "id": 21981,
+   "text": "Ivy owns the deploy surface."
+  },
+  {
+   "id": 21982,
+   "text": "Frank reports to Taylor."
+  },
+  {
+   "id": 21983,
+   "text": "Frank is the staff engineer on the beacon team."
+  },
+  {
+   "id": 21984,
+   "text": "Bob is the designer on the harbor team."
+  },
+  {
+   "id": 21985,
+   "text": "Jack is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 21986,
+   "text": "Kate is the designer on the monolith team."
+  },
+  {
+   "id": 21987,
+   "text": "Grace is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 21988,
+   "text": "Henry reports to Dave."
+  },
+  {
+   "id": 21989,
+   "text": "Kate is the tech lead on the atlas team."
+  },
+  {
+   "id": 21990,
+   "text": "Pat is the tech lead on the kestrel team."
+  },
+  {
+   "id": 21991,
+   "text": "Taylor is the senior engineer on the compass team."
+  },
+  {
+   "id": 21992,
+   "text": "Carol is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 21993,
+   "text": "Bob owns the billing surface."
+  },
+  {
+   "id": 21994,
+   "text": "Kate reports to Dave."
+  },
+  {
+   "id": 21995,
+   "text": "Quinn is the QA lead on the junction team."
+  },
+  {
+   "id": 21996,
+   "text": "Liam is the QA lead on the junction team."
+  },
+  {
+   "id": 21997,
+   "text": "Kate is the designer on the lattice team."
+  },
+  {
+   "id": 21998,
+   "text": "Jack is the senior engineer on the quartz team."
+  },
+  {
+   "id": 21999,
+   "text": "Eve is the PM on the summit team."
+  },
+  {
+   "id": 22000,
+   "text": "Pat is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 22001,
+   "text": "Dave is the senior engineer on the tundra team."
+  },
+  {
+   "id": 22002,
+   "text": "Taylor reports to Henry."
+  },
+  {
+   "id": 22003,
+   "text": "Henry is the principal engineer on the nexus team."
+  },
+  {
+   "id": 22004,
+   "text": "Jack is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 22005,
+   "text": "Grace is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 22006,
+   "text": "Quinn is the tech lead on the iris team."
+  },
+  {
+   "id": 22007,
+   "text": "Henry reports to Frank."
+  },
+  {
+   "id": 22008,
+   "text": "Mia reports to Pat."
+  },
+  {
+   "id": 22009,
+   "text": "Henry is the designer on the summit team."
+  },
+  {
+   "id": 22010,
+   "text": "Frank is the engineering manager on the summit team."
+  },
+  {
+   "id": 22011,
+   "text": "Eve is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 22012,
+   "text": "Dave is the QA lead on the compass team."
+  },
+  {
+   "id": 22013,
+   "text": "Dave is the PM on the harbor team."
+  },
+  {
+   "id": 22014,
+   "text": "Carol is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 22015,
+   "text": "Riley reports to Liam."
+  },
+  {
+   "id": 22016,
+   "text": "Riley reports to Taylor."
+  },
+  {
+   "id": 22017,
+   "text": "Grace is the designer on the monolith team."
+  },
+  {
+   "id": 22018,
+   "text": "Olivia is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 22019,
+   "text": "Bob is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 22020,
+   "text": "Eve is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 22021,
+   "text": "Carol reports to Liam."
+  },
+  {
+   "id": 22022,
+   "text": "Henry is the QA lead on the delta team."
+  },
+  {
+   "id": 22023,
+   "text": "Grace is on PTO from Monday to Friday."
+  },
+  {
+   "id": 22024,
+   "text": "Riley is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 22025,
+   "text": "Taylor owns the infra surface."
+  },
+  {
+   "id": 22026,
+   "text": "Mia is the designer on the harbor team."
+  },
+  {
+   "id": 22027,
+   "text": "Henry is the principal engineer on the echo team."
+  },
+  {
+   "id": 22028,
+   "text": "Taylor is the engineering manager on the iris team."
+  },
+  {
+   "id": 22029,
+   "text": "Frank is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 22030,
+   "text": "The user prefers light mode as their color scheme in Emacs."
+  },
+  {
+   "id": 22031,
+   "text": "The user prefers tig as their git GUI in Terminal.app."
+  },
+  {
+   "id": 22032,
+   "text": "The user prefers solarized dark as their color scheme in Sublime Text."
+  },
+  {
+   "id": 22033,
+   "text": "The user prefers gruvbox as their color scheme in tmux."
+  },
+  {
+   "id": 22034,
+   "text": "The user prefers Cascadia Code as their font in Windsurf."
+  },
+  {
+   "id": 22035,
+   "text": "The user prefers light mode as their color scheme in Hyper."
+  },
+  {
+   "id": 22036,
+   "text": "The user prefers solarized dark as their color scheme in Hyper."
+  },
+  {
+   "id": 22037,
+   "text": "The user prefers solarized dark as their color scheme in Terminal.app."
+  },
+  {
+   "id": 22038,
+   "text": "The user prefers light mode as their color scheme in iTerm2."
+  },
+  {
+   "id": 22039,
+   "text": "The user prefers solarized dark as their color scheme in Emacs."
+  },
+  {
+   "id": 22040,
+   "text": "The user prefers gruvbox as their color scheme in Vim."
+  },
+  {
+   "id": 22041,
+   "text": "Project lattice uses Go for the orchestrator."
+  },
+  {
+   "id": 22042,
+   "text": "Project fjord uses TypeScript for the client."
+  },
+  {
+   "id": 22043,
+   "text": "Project beacon launches in November 2026."
+  },
+  {
+   "id": 22044,
+   "text": "Project beacon uses Kubernetes for orchestration."
+  },
+  {
+   "id": 22045,
+   "text": "Project tundra uses React for the frontend."
+  },
+  {
+   "id": 22046,
+   "text": "Project delta uses Kafka for event streaming."
+  },
+  {
+   "id": 22047,
+   "text": "Project summit uses TypeScript for the client."
+  },
+  {
+   "id": 22048,
+   "text": "Frank is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 22049,
+   "text": "Carol reports to Taylor."
+  },
+  {
+   "id": 22050,
+   "text": "Carol reports to Frank."
+  },
+  {
+   "id": 22051,
+   "text": "Carol is the tech lead on the lattice team."
+  },
+  {
+   "id": 22052,
+   "text": "Alice is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 22053,
+   "text": "Mia is the principal engineer on the monolith team."
+  },
+  {
+   "id": 22054,
+   "text": "Bob is the staff engineer on the delta team."
+  },
+  {
+   "id": 22055,
+   "text": "Carol is the PM on the compass team."
+  },
+  {
+   "id": 22056,
+   "text": "Pat reports to Bob."
+  },
+  {
+   "id": 22057,
+   "text": "Noah reports to Ivy."
+  },
+  {
+   "id": 22058,
+   "text": "Pat is the PM on the beacon team."
+  },
+  {
+   "id": 22059,
+   "text": "Carol is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 22060,
+   "text": "Bob is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 22061,
+   "text": "Jack is the senior engineer on the lattice team."
+  },
+  {
+   "id": 22062,
+   "text": "Alice is the staff engineer on the atlas team."
+  },
+  {
+   "id": 22063,
+   "text": "Carol is the senior engineer on the iris team."
+  },
+  {
+   "id": 22064,
+   "text": "Quinn is the designer on the lattice team."
+  },
+  {
+   "id": 22065,
+   "text": "Bob is the staff engineer on the monolith team."
+  },
+  {
+   "id": 22066,
+   "text": "Grace is the principal engineer on the quartz team."
+  },
+  {
+   "id": 22067,
+   "text": "Liam reports to Alice."
+  },
+  {
+   "id": 22068,
+   "text": "Grace reports to Frank."
+  },
+  {
+   "id": 22069,
+   "text": "Alice is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 22070,
+   "text": "Olivia is the PM on the kestrel team."
+  },
+  {
+   "id": 22071,
+   "text": "Mia is the QA lead on the delta team."
+  },
+  {
+   "id": 22072,
+   "text": "Bob reports to Liam."
+  },
+  {
+   "id": 22073,
+   "text": "Sam is the tech lead on the kestrel team."
+  },
+  {
+   "id": 22074,
+   "text": "Grace is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 22075,
+   "text": "Grace reports to Pat."
+  },
+  {
+   "id": 22076,
+   "text": "Grace is the QA lead on the fjord team."
+  },
+  {
+   "id": 22077,
+   "text": "Quinn is the designer on the atlas team."
+  },
+  {
+   "id": 22078,
+   "text": "Eve reports to Bob."
+  },
+  {
+   "id": 22079,
+   "text": "Noah is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 22080,
+   "text": "Noah is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 22081,
+   "text": "Jack owns the infra surface."
+  },
+  {
+   "id": 22082,
+   "text": "Frank is the designer on the atlas team."
+  },
+  {
+   "id": 22083,
+   "text": "Quinn is the senior engineer on the delta team."
+  },
+  {
+   "id": 22084,
+   "text": "Liam is the tech lead on the lattice team."
+  },
+  {
+   "id": 22085,
+   "text": "Taylor is on PTO from Friday to Friday."
+  },
+  {
+   "id": 22086,
+   "text": "Jack is the tech lead on the prism team."
+  },
+  {
+   "id": 22087,
+   "text": "Pat is the senior engineer on the harbor team."
+  },
+  {
+   "id": 22088,
+   "text": "Kate is the PM on the prism team."
+  },
+  {
+   "id": 22089,
+   "text": "Pat is the senior engineer on the nexus team."
+  },
+  {
+   "id": 22090,
+   "text": "Noah is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 22091,
+   "text": "Quinn reports to Olivia."
+  },
+  {
+   "id": 22092,
+   "text": "Bob reports to Noah."
+  },
+  {
+   "id": 22093,
+   "text": "Grace is the senior engineer on the glacier team."
+  },
+  {
+   "id": 22094,
+   "text": "Bob is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 22095,
+   "text": "Henry is on PTO from Monday to Friday."
+  },
+  {
+   "id": 22096,
+   "text": "Liam is the QA lead on the orbit team."
+  },
+  {
+   "id": 22097,
+   "text": "Eve reports to Sam."
+  },
+  {
+   "id": 22098,
+   "text": "Riley is the staff engineer on the atlas team."
+  },
+  {
+   "id": 22099,
+   "text": "The user prefers Fork as their git GUI in Terminal.app."
+  },
+  {
+   "id": 22100,
+   "text": "The user prefers solarized dark as their color scheme in Windsurf."
+  },
+  {
+   "id": 22101,
+   "text": "The user prefers high-contrast as their color scheme in Emacs."
+  },
+  {
+   "id": 22102,
+   "text": "Project orbit uses React for the frontend."
+  },
+  {
+   "id": 22103,
+   "text": "Project tundra uses Kubernetes for orchestration."
+  },
+  {
+   "id": 22104,
+   "text": "Project prism uses FastAPI for the API layer."
+  },
+  {
+   "id": 22105,
+   "text": "Project harbor uses Rust for performance-critical paths."
+  },
+  {
+   "id": 22106,
+   "text": "Project delta uses Tailwind for styling."
+  },
+  {
+   "id": 22107,
+   "text": "Project beacon uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 22108,
+   "text": "Project tundra uses Rust for performance-critical paths."
+  },
+  {
+   "id": 22109,
+   "text": "Project ridge uses Python for data pipelines."
+  },
+  {
+   "id": 22110,
+   "text": "Project atlas uses Python for data pipelines."
+  },
+  {
+   "id": 22111,
+   "text": "Noah is the principal engineer on the echo team."
+  },
+  {
+   "id": 22112,
+   "text": "Frank is the principal engineer on the lattice team."
+  },
+  {
+   "id": 22113,
+   "text": "Riley is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 22114,
+   "text": "Riley is the PM on the orbit team."
+  },
+  {
+   "id": 22115,
+   "text": "Riley is the staff engineer on the echo team."
+  },
+  {
+   "id": 22116,
+   "text": "Bob is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 22117,
+   "text": "Kate is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 22118,
+   "text": "Pat reports to Frank."
+  },
+  {
+   "id": 22119,
+   "text": "Mia is the engineering manager on the kestrel team."
+  },
+  {
+   "id": 22120,
+   "text": "Kate reports to Henry."
+  },
+  {
+   "id": 22121,
+   "text": "Sam is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 22122,
+   "text": "Taylor is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 22123,
+   "text": "Ivy is the designer on the quartz team."
+  },
+  {
+   "id": 22124,
+   "text": "Taylor owns the dashboard surface."
+  },
+  {
+   "id": 22125,
+   "text": "Carol is the principal engineer on the monolith team."
+  },
+  {
+   "id": 22126,
+   "text": "Mia is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 22127,
+   "text": "Mia is the tech lead on the monolith team."
+  },
+  {
+   "id": 22128,
+   "text": "Frank reports to Ivy."
+  },
+  {
+   "id": 22129,
+   "text": "Riley is on PTO from Monday to Monday."
+  },
+  {
+   "id": 22130,
+   "text": "Ivy is the tech lead on the lattice team."
+  },
+  {
+   "id": 22131,
+   "text": "Frank is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 22132,
+   "text": "Jack is the QA lead on the orbit team."
+  },
+  {
+   "id": 22133,
+   "text": "Bob is the QA lead on the iris team."
+  },
+  {
+   "id": 22134,
+   "text": "Taylor is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 22135,
+   "text": "Taylor reports to Grace."
+  },
+  {
+   "id": 22136,
+   "text": "Pat is the PM on the atlas team."
+  },
+  {
+   "id": 22137,
+   "text": "Alice is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 22138,
+   "text": "Henry is the designer on the ridge team."
+  },
+  {
+   "id": 22139,
+   "text": "Mia reports to Sam."
+  },
+  {
+   "id": 22140,
+   "text": "Sam reports to Carol."
+  },
+  {
+   "id": 22141,
+   "text": "Olivia is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 22142,
+   "text": "Pat is the staff engineer on the monolith team."
+  },
+  {
+   "id": 22143,
+   "text": "Mia is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 22144,
+   "text": "Liam reports to Bob."
+  },
+  {
+   "id": 22145,
+   "text": "Noah is the tech lead on the compass team."
+  },
+  {
+   "id": 22146,
+   "text": "Olivia reports to Bob."
+  },
+  {
+   "id": 22147,
+   "text": "Quinn reports to Ivy."
+  },
+  {
+   "id": 22148,
+   "text": "Riley is the PM on the beacon team."
+  },
+  {
+   "id": 22149,
+   "text": "Henry is the tech lead on the echo team."
+  },
+  {
+   "id": 22150,
+   "text": "Mia is the PM on the ridge team."
+  },
+  {
+   "id": 22151,
+   "text": "Jack is the PM on the kestrel team."
+  },
+  {
+   "id": 22152,
+   "text": "Carol reports to Pat."
+  },
+  {
+   "id": 22153,
+   "text": "Jack is the tech lead on the kestrel team."
+  },
+  {
+   "id": 22154,
+   "text": "Taylor is the tech lead on the iris team."
+  },
+  {
+   "id": 22155,
+   "text": "Sam reports to Jack."
+  },
+  {
+   "id": 22156,
+   "text": "Ivy is the QA lead on the monolith team."
+  },
+  {
+   "id": 22157,
+   "text": "Grace is on PTO from Monday to Monday."
+  },
+  {
+   "id": 22158,
+   "text": "Kate is the designer on the orbit team."
+  },
+  {
+   "id": 22159,
+   "text": "Jack reports to Sam."
+  },
+  {
+   "id": 22160,
+   "text": "Taylor is the tech lead on the beacon team."
+  },
+  {
+   "id": 22161,
+   "text": "Carol is the engineering manager on the atlas team."
+  },
+  {
+   "id": 22162,
+   "text": "Quinn is the designer on the harbor team."
+  },
+  {
+   "id": 22163,
+   "text": "Carol is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 22164,
+   "text": "Alice is the QA lead on the orbit team."
+  },
+  {
+   "id": 22165,
+   "text": "Mia is the PM on the tundra team."
+  },
+  {
+   "id": 22166,
+   "text": "The user prefers Cascadia Code as their font in Vim."
+  },
+  {
+   "id": 22167,
+   "text": "The user prefers tokyo night as their color scheme in bash."
+  },
+  {
+   "id": 22168,
+   "text": "Project atlas uses Grafana for dashboards."
+  },
+  {
+   "id": 22169,
+   "text": "Project orbit uses S3 for object storage."
+  },
+  {
+   "id": 22170,
+   "text": "Project iris uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 22171,
+   "text": "Project iris uses Kubernetes for orchestration."
+  },
+  {
+   "id": 22172,
+   "text": "Project kestrel uses Kubernetes for orchestration."
+  },
+  {
+   "id": 22173,
+   "text": "Project delta uses Grafana for dashboards."
+  },
+  {
+   "id": 22174,
+   "text": "Project tundra uses Kafka for event streaming."
+  },
+  {
+   "id": 22175,
+   "text": "Project atlas uses Kubernetes for orchestration."
+  },
+  {
+   "id": 22176,
+   "text": "Project tundra uses Go for the orchestrator."
+  },
+  {
+   "id": 22177,
+   "text": "Project beacon uses Next.js for server-side rendering."
+  },
+  {
+   "id": 22178,
+   "text": "Pat is the PM on the echo team."
+  },
+  {
+   "id": 22179,
+   "text": "Noah is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 22180,
+   "text": "Taylor is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 22181,
+   "text": "Riley is the QA lead on the fjord team."
+  },
+  {
+   "id": 22182,
+   "text": "Pat is the principal engineer on the echo team."
+  },
+  {
+   "id": 22183,
+   "text": "Bob is the PM on the quartz team."
+  },
+  {
+   "id": 22184,
+   "text": "Liam is the engineering manager on the nexus team."
+  },
+  {
+   "id": 22185,
+   "text": "Henry is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 22186,
+   "text": "Pat is the senior engineer on the kestrel team."
+  },
+  {
+   "id": 22187,
+   "text": "Eve reports to Kate."
+  },
+  {
+   "id": 22188,
+   "text": "Sam is the principal engineer on the iris team."
+  },
+  {
+   "id": 22189,
+   "text": "Alice is the senior engineer on the ridge team."
+  },
+  {
+   "id": 22190,
+   "text": "Grace is the principal engineer on the summit team."
+  },
+  {
+   "id": 22191,
+   "text": "Quinn reports to Noah."
+  },
+  {
+   "id": 22192,
+   "text": "Jack reports to Taylor."
+  },
+  {
+   "id": 22193,
+   "text": "Mia is the principal engineer on the atlas team."
+  },
+  {
+   "id": 22194,
+   "text": "Quinn is the tech lead on the echo team."
+  },
+  {
+   "id": 22195,
+   "text": "Carol is the tech lead on the ridge team."
+  },
+  {
+   "id": 22196,
+   "text": "Eve is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 22197,
+   "text": "Eve is the tech lead on the atlas team."
+  },
+  {
+   "id": 22198,
+   "text": "Taylor is the tech lead on the compass team."
+  },
+  {
+   "id": 22199,
+   "text": "Mia is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 22200,
+   "text": "Mia reports to Kate."
+  },
+  {
+   "id": 22201,
+   "text": "Kate is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 22202,
+   "text": "Sam reports to Riley."
+  },
+  {
+   "id": 22203,
+   "text": "Henry reports to Grace."
+  },
+  {
+   "id": 22204,
+   "text": "Taylor is the designer on the prism team."
+  },
+  {
+   "id": 22205,
+   "text": "Olivia reports to Frank."
+  },
+  {
+   "id": 22206,
+   "text": "Eve is the tech lead on the fjord team."
+  },
+  {
+   "id": 22207,
+   "text": "Kate is the PM on the orbit team."
+  },
+  {
+   "id": 22208,
+   "text": "Eve is the engineering manager on the ridge team."
+  },
+  {
+   "id": 22209,
+   "text": "Pat is the staff engineer on the harbor team."
+  },
+  {
+   "id": 22210,
+   "text": "Ivy is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 22211,
+   "text": "Quinn reports to Mia."
+  },
+  {
+   "id": 22212,
+   "text": "Bob is the senior engineer on the harbor team."
+  },
+  {
+   "id": 22213,
+   "text": "Taylor is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 22214,
+   "text": "Taylor is the PM on the fjord team."
+  },
+  {
+   "id": 22215,
+   "text": "Pat is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 22216,
+   "text": "Mia is the designer on the fjord team."
+  },
+  {
+   "id": 22217,
+   "text": "Kate is the principal engineer on the ridge team."
+  },
+  {
+   "id": 22218,
+   "text": "Kate is the tech lead on the glacier team."
+  },
+  {
+   "id": 22219,
+   "text": "Pat is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 22220,
+   "text": "Noah is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 22221,
+   "text": "Mia is the tech lead on the tundra team."
+  },
+  {
+   "id": 22222,
+   "text": "Carol is on PTO from Friday to Monday."
+  },
+  {
+   "id": 22223,
+   "text": "Alice reports to Henry."
+  },
+  {
+   "id": 22224,
+   "text": "Mia is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 22225,
+   "text": "Riley is on PTO from Friday to Monday."
+  },
+  {
+   "id": 22226,
+   "text": "Kate is on PTO from Monday to Friday."
+  },
+  {
+   "id": 22227,
+   "text": "Mia is the tech lead on the iris team."
+  },
+  {
+   "id": 22228,
+   "text": "Alice is the PM on the harbor team."
+  },
+  {
+   "id": 22229,
+   "text": "Henry is the staff engineer on the prism team."
+  },
+  {
+   "id": 22230,
+   "text": "Pat is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 22231,
+   "text": "Quinn is the PM on the summit team."
+  },
+  {
+   "id": 22232,
+   "text": "Noah is the PM on the monolith team."
+  },
+  {
+   "id": 22233,
+   "text": "Henry is the tech lead on the atlas team."
+  },
+  {
+   "id": 22234,
+   "text": "Dave is the designer on the iris team."
+  },
+  {
+   "id": 22235,
+   "text": "Liam is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 22236,
+   "text": "Henry is the principal engineer on the summit team."
+  },
+  {
+   "id": 22237,
+   "text": "Alice is the senior engineer on the monolith team."
+  },
+  {
+   "id": 22238,
+   "text": "Dave is the PM on the monolith team."
+  },
+  {
+   "id": 22239,
+   "text": "Frank is on PTO from Friday to Monday."
+  },
+  {
+   "id": 22240,
+   "text": "Frank is the tech lead on the kestrel team."
+  },
+  {
+   "id": 22241,
+   "text": "Henry is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 22242,
+   "text": "The user prefers tokyo night as their color scheme in Terminal.app."
+  },
+  {
+   "id": 22243,
+   "text": "The user prefers Hack as their font in Terminal.app."
+  },
+  {
+   "id": 22244,
+   "text": "The user prefers high-contrast as their color scheme in Warp."
+  },
+  {
+   "id": 22245,
+   "text": "The user prefers light mode as their color scheme in tmux."
+  },
+  {
+   "id": 22246,
+   "text": "Project orbit uses Go for the orchestrator."
+  },
+  {
+   "id": 22247,
+   "text": "Project tundra uses Next.js for server-side rendering."
+  },
+  {
+   "id": 22248,
+   "text": "Project beacon uses Sentry for error tracking."
+  },
+  {
+   "id": 22249,
+   "text": "Project delta uses FastAPI for the API layer."
+  },
+  {
+   "id": 22250,
+   "text": "Project compass uses FastAPI for the API layer."
+  },
+  {
+   "id": 22251,
+   "text": "Project harbor uses Redis for caching."
+  },
+  {
+   "id": 22252,
+   "text": "Liam reports to Carol."
+  },
+  {
+   "id": 22253,
+   "text": "Sam is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 22254,
+   "text": "Frank is the staff engineer on the summit team."
+  },
+  {
+   "id": 22255,
+   "text": "Quinn is the principal engineer on the iris team."
+  },
+  {
+   "id": 22256,
+   "text": "Bob reports to Quinn."
+  },
+  {
+   "id": 22257,
+   "text": "Grace is the engineering manager on the lattice team."
+  },
+  {
+   "id": 22258,
+   "text": "Riley is the senior engineer on the nexus team."
+  },
+  {
+   "id": 22259,
+   "text": "Mia is the staff engineer on the prism team."
+  },
+  {
+   "id": 22260,
+   "text": "Dave is the tech lead on the atlas team."
+  },
+  {
+   "id": 22261,
+   "text": "Alice reports to Carol."
+  },
+  {
+   "id": 22262,
+   "text": "Dave is the QA lead on the echo team."
+  },
+  {
+   "id": 22263,
+   "text": "Kate is the principal engineer on the summit team."
+  },
+  {
+   "id": 22264,
+   "text": "Quinn is the engineering manager on the harbor team."
+  },
+  {
+   "id": 22265,
+   "text": "Henry is the QA lead on the summit team."
+  },
+  {
+   "id": 22266,
+   "text": "Pat is the QA lead on the summit team."
+  },
+  {
+   "id": 22267,
+   "text": "Liam is the QA lead on the iris team."
+  },
+  {
+   "id": 22268,
+   "text": "Olivia is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 22269,
+   "text": "Riley reports to Carol."
+  },
+  {
+   "id": 22270,
+   "text": "Ivy is the principal engineer on the glacier team."
+  },
+  {
+   "id": 22271,
+   "text": "Eve is the tech lead on the glacier team."
+  },
+  {
+   "id": 22272,
+   "text": "Dave reports to Alice."
+  },
+  {
+   "id": 22273,
+   "text": "Dave reports to Bob."
+  },
+  {
+   "id": 22274,
+   "text": "Ivy is the staff engineer on the ridge team."
+  },
+  {
+   "id": 22275,
+   "text": "Ivy is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 22276,
+   "text": "Carol is the principal engineer on the atlas team."
+  },
+  {
+   "id": 22277,
+   "text": "Eve is the senior engineer on the lattice team."
+  },
+  {
+   "id": 22278,
+   "text": "Henry is the designer on the orbit team."
+  },
+  {
+   "id": 22279,
+   "text": "Liam is the senior engineer on the summit team."
+  },
+  {
+   "id": 22280,
+   "text": "Carol is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 22281,
+   "text": "Noah is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 22282,
+   "text": "Olivia is the principal engineer on the echo team."
+  },
+  {
+   "id": 22283,
+   "text": "Quinn is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 22284,
+   "text": "Grace is the PM on the monolith team."
+  },
+  {
+   "id": 22285,
+   "text": "Bob is the principal engineer on the echo team."
+  },
+  {
+   "id": 22286,
+   "text": "Bob reports to Taylor."
+  },
+  {
+   "id": 22287,
+   "text": "Ivy is the engineering manager on the junction team."
+  },
+  {
+   "id": 22288,
+   "text": "Pat is the tech lead on the harbor team."
+  },
+  {
+   "id": 22289,
+   "text": "Ivy is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 22290,
+   "text": "Mia is the senior engineer on the junction team."
+  },
+  {
+   "id": 22291,
+   "text": "Olivia is the PM on the iris team."
+  },
+  {
+   "id": 22292,
+   "text": "Dave is the staff engineer on the echo team."
+  },
+  {
+   "id": 22293,
+   "text": "Taylor is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 22294,
+   "text": "Frank reports to Olivia."
+  },
+  {
+   "id": 22295,
+   "text": "Jack is the PM on the prism team."
+  },
+  {
+   "id": 22296,
+   "text": "Eve is the designer on the monolith team."
+  },
+  {
+   "id": 22297,
+   "text": "Noah is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 22298,
+   "text": "Henry reports to Carol."
+  },
+  {
+   "id": 22299,
+   "text": "Sam is the QA lead on the beacon team."
+  },
+  {
+   "id": 22300,
+   "text": "Quinn is the QA lead on the fjord team."
+  },
+  {
+   "id": 22301,
+   "text": "Ivy is the engineering manager on the orbit team."
+  },
+  {
+   "id": 22302,
+   "text": "Bob is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 22303,
+   "text": "Carol is on PTO from Monday to Monday."
+  },
+  {
+   "id": 22304,
+   "text": "Olivia reports to Riley."
+  },
+  {
+   "id": 22305,
+   "text": "Quinn reports to Frank."
+  },
+  {
+   "id": 22306,
+   "text": "The user prefers Hack as their font in Windsurf."
+  },
+  {
+   "id": 22307,
+   "text": "The user prefers Fira Code as their font in Sublime Text."
+  },
+  {
+   "id": 22308,
+   "text": "Project kestrel uses Docker for containerization."
+  },
+  {
+   "id": 22309,
+   "text": "Frank is the designer on the ridge team."
+  },
+  {
+   "id": 22310,
+   "text": "Noah is the principal engineer on the glacier team."
+  },
+  {
+   "id": 22311,
+   "text": "Noah is the engineering manager on the echo team."
+  },
+  {
+   "id": 22312,
+   "text": "Noah is the staff engineer on the beacon team."
+  },
+  {
+   "id": 22313,
+   "text": "Pat is the staff engineer on the orbit team."
+  },
+  {
+   "id": 22314,
+   "text": "Jack is the PM on the tundra team."
+  },
+  {
+   "id": 22315,
+   "text": "Sam is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 22316,
+   "text": "Quinn reports to Liam."
+  },
+  {
+   "id": 22317,
+   "text": "Sam is the engineering manager on the fjord team."
+  },
+  {
+   "id": 22318,
+   "text": "Noah is the principal engineer on the orbit team."
+  },
+  {
+   "id": 22319,
+   "text": "Liam is the principal engineer on the delta team."
+  },
+  {
+   "id": 22320,
+   "text": "Liam is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 22321,
+   "text": "Liam is the principal engineer on the quartz team."
+  },
+  {
+   "id": 22322,
+   "text": "Henry is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 22323,
+   "text": "Liam is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 22324,
+   "text": "Ivy is the tech lead on the iris team."
+  },
+  {
+   "id": 22325,
+   "text": "Olivia is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 22326,
+   "text": "Olivia is the engineering manager on the beacon team."
+  },
+  {
+   "id": 22327,
+   "text": "Carol is the PM on the monolith team."
+  },
+  {
+   "id": 22328,
+   "text": "Riley is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 22329,
+   "text": "Henry is the tech lead on the kestrel team."
+  },
+  {
+   "id": 22330,
+   "text": "Quinn is the QA lead on the ridge team."
+  },
+  {
+   "id": 22331,
+   "text": "Bob is the senior engineer on the glacier team."
+  },
+  {
+   "id": 22332,
+   "text": "Henry is the senior engineer on the glacier team."
+  },
+  {
+   "id": 22333,
+   "text": "Grace is the tech lead on the lattice team."
+  },
+  {
+   "id": 22334,
+   "text": "Grace is the principal engineer on the fjord team."
+  },
+  {
+   "id": 22335,
+   "text": "Olivia is the PM on the glacier team."
+  },
+  {
+   "id": 22336,
+   "text": "Taylor is the engineering manager on the summit team."
+  },
+  {
+   "id": 22337,
+   "text": "Eve is the engineering manager on the compass team."
+  },
+  {
+   "id": 22338,
+   "text": "Jack is the tech lead on the tundra team."
+  },
+  {
+   "id": 22339,
+   "text": "Liam is the principal engineer on the nexus team."
+  },
+  {
+   "id": 22340,
+   "text": "Noah is the PM on the junction team."
+  },
+  {
+   "id": 22341,
+   "text": "Jack is the staff engineer on the iris team."
+  },
+  {
+   "id": 22342,
+   "text": "Olivia is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 22343,
+   "text": "Liam reports to Pat."
+  },
+  {
+   "id": 22344,
+   "text": "Olivia is the engineering manager on the kestrel team."
+  },
+  {
+   "id": 22345,
+   "text": "Taylor is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 22346,
+   "text": "Grace is the staff engineer on the compass team."
+  },
+  {
+   "id": 22347,
+   "text": "Pat is on PTO from Monday to Friday."
+  },
+  {
+   "id": 22348,
+   "text": "Liam reports to Henry."
+  },
+  {
+   "id": 22349,
+   "text": "Olivia is the designer on the ridge team."
+  },
+  {
+   "id": 22350,
+   "text": "Sam is the staff engineer on the fjord team."
+  },
+  {
+   "id": 22351,
+   "text": "Quinn is the engineering manager on the lattice team."
+  },
+  {
+   "id": 22352,
+   "text": "Sam is the tech lead on the glacier team."
+  },
+  {
+   "id": 22353,
+   "text": "Sam is the principal engineer on the nexus team."
+  },
+  {
+   "id": 22354,
+   "text": "Mia is the PM on the compass team."
+  },
+  {
+   "id": 22355,
+   "text": "Taylor is the principal engineer on the lattice team."
+  },
+  {
+   "id": 22356,
+   "text": "Pat is the staff engineer on the compass team."
+  },
+  {
+   "id": 22357,
+   "text": "Liam reports to Frank."
+  },
+  {
+   "id": 22358,
+   "text": "The user prefers Hack as their font in Emacs."
+  },
+  {
+   "id": 22359,
+   "text": "Project delta uses Prometheus for metrics."
+  },
+  {
+   "id": 22360,
+   "text": "Dave is the staff engineer on the tundra team."
+  },
+  {
+   "id": 22361,
+   "text": "Dave is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 22362,
+   "text": "Olivia is the QA lead on the summit team."
+  },
+  {
+   "id": 22363,
+   "text": "Alice is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 22364,
+   "text": "Carol is the tech lead on the fjord team."
+  },
+  {
+   "id": 22365,
+   "text": "Liam is the principal engineer on the ridge team."
+  },
+  {
+   "id": 22366,
+   "text": "Olivia is the engineering manager on the lattice team."
+  },
+  {
+   "id": 22367,
+   "text": "Jack is the tech lead on the beacon team."
+  },
+  {
+   "id": 22368,
+   "text": "Noah is the staff engineer on the nexus team."
+  },
+  {
+   "id": 22369,
+   "text": "Noah is on PTO from Friday to Friday."
+  },
+  {
+   "id": 22370,
+   "text": "Dave is the QA lead on the nexus team."
+  },
+  {
+   "id": 22371,
+   "text": "Kate is the tech lead on the harbor team."
+  },
+  {
+   "id": 22372,
+   "text": "Grace is the QA lead on the iris team."
+  },
+  {
+   "id": 22373,
+   "text": "Eve is the QA lead on the quartz team."
+  },
+  {
+   "id": 22374,
+   "text": "Jack is the engineering manager on the compass team."
+  },
+  {
+   "id": 22375,
+   "text": "Mia is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 22376,
+   "text": "Riley is the tech lead on the kestrel team."
+  },
+  {
+   "id": 22377,
+   "text": "Mia is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 22378,
+   "text": "Henry is the staff engineer on the summit team."
+  },
+  {
+   "id": 22379,
+   "text": "Frank reports to Pat."
+  },
+  {
+   "id": 22380,
+   "text": "Jack is the PM on the glacier team."
+  },
+  {
+   "id": 22381,
+   "text": "Mia is the engineering manager on the echo team."
+  },
+  {
+   "id": 22382,
+   "text": "Mia is the PM on the monolith team."
+  },
+  {
+   "id": 22383,
+   "text": "Noah is the senior engineer on the glacier team."
+  },
+  {
+   "id": 22384,
+   "text": "Mia is the engineering manager on the atlas team."
+  },
+  {
+   "id": 22385,
+   "text": "Sam is on PTO from Monday to Monday."
+  },
+  {
+   "id": 22386,
+   "text": "Liam is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 22387,
+   "text": "Dave is the engineering manager on the monolith team."
+  },
+  {
+   "id": 22388,
+   "text": "Carol is the PM on the glacier team."
+  },
+  {
+   "id": 22389,
+   "text": "Quinn is the engineering manager on the nexus team."
+  },
+  {
+   "id": 22390,
+   "text": "Quinn is the senior engineer on the atlas team."
+  },
+  {
+   "id": 22391,
+   "text": "Taylor is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 22392,
+   "text": "Dave is the engineering manager on the orbit team."
+  },
+  {
+   "id": 22393,
+   "text": "Dave is the PM on the kestrel team."
+  },
+  {
+   "id": 22394,
+   "text": "Alice is the staff engineer on the echo team."
+  },
+  {
+   "id": 22395,
+   "text": "Riley is the engineering manager on the kestrel team."
+  },
+  {
+   "id": 22396,
+   "text": "Frank is the tech lead on the nexus team."
+  },
+  {
+   "id": 22397,
+   "text": "Noah reports to Carol."
+  },
+  {
+   "id": 22398,
+   "text": "Taylor is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 22399,
+   "text": "Alice is the QA lead on the echo team."
+  },
+  {
+   "id": 22400,
+   "text": "Olivia is the principal engineer on the nexus team."
+  },
+  {
+   "id": 22401,
+   "text": "Noah is the staff engineer on the harbor team."
+  },
+  {
+   "id": 22402,
+   "text": "Riley is the staff engineer on the harbor team."
+  },
+  {
+   "id": 22403,
+   "text": "Henry is the senior engineer on the echo team."
+  },
+  {
+   "id": 22404,
+   "text": "Jack is the staff engineer on the orbit team."
+  },
+  {
+   "id": 22405,
+   "text": "Liam is the principal engineer on the compass team."
+  },
+  {
+   "id": 22406,
+   "text": "Liam reports to Kate."
+  },
+  {
+   "id": 22407,
+   "text": "Kate reports to Frank."
+  },
+  {
+   "id": 22408,
+   "text": "Dave is the staff engineer on the delta team."
+  },
+  {
+   "id": 22409,
+   "text": "Sam reports to Liam."
+  },
+  {
+   "id": 22410,
+   "text": "Mia owns the deploy surface."
+  },
+  {
+   "id": 22411,
+   "text": "The user prefers Source Code Pro as their font in Windsurf."
+  },
+  {
+   "id": 22412,
+   "text": "Project monolith uses Python for data pipelines."
+  },
+  {
+   "id": 22413,
+   "text": "Project summit uses Elasticsearch for search."
+  },
+  {
+   "id": 22414,
+   "text": "Project junction uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 22415,
+   "text": "Project echo uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 22416,
+   "text": "Project kestrel launches in March 2027."
+  },
+  {
+   "id": 22417,
+   "text": "Project fjord launches in November 2026."
+  },
+  {
+   "id": 22418,
+   "text": "Mia is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 22419,
+   "text": "Riley is the engineering manager on the summit team."
+  },
+  {
+   "id": 22420,
+   "text": "Quinn is the senior engineer on the quartz team."
+  },
+  {
+   "id": 22421,
+   "text": "Pat is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 22422,
+   "text": "Carol is the principal engineer on the iris team."
+  },
+  {
+   "id": 22423,
+   "text": "Liam is the tech lead on the orbit team."
+  },
+  {
+   "id": 22424,
+   "text": "Mia is the staff engineer on the nexus team."
+  },
+  {
+   "id": 22425,
+   "text": "Olivia is on PTO from Monday to Monday."
+  },
+  {
+   "id": 22426,
+   "text": "Henry is the tech lead on the ridge team."
+  },
+  {
+   "id": 22427,
+   "text": "Riley is the designer on the orbit team."
+  },
+  {
+   "id": 22428,
+   "text": "Quinn is the staff engineer on the ridge team."
+  },
+  {
+   "id": 22429,
+   "text": "Frank is the designer on the lattice team."
+  },
+  {
+   "id": 22430,
+   "text": "Ivy is the senior engineer on the fjord team."
+  },
+  {
+   "id": 22431,
+   "text": "Frank is the principal engineer on the echo team."
+  },
+  {
+   "id": 22432,
+   "text": "Bob is the principal engineer on the orbit team."
+  },
+  {
+   "id": 22433,
+   "text": "Olivia reports to Noah."
+  },
+  {
+   "id": 22434,
+   "text": "Riley is the senior engineer on the prism team."
+  },
+  {
+   "id": 22435,
+   "text": "Ivy is the principal engineer on the orbit team."
+  },
+  {
+   "id": 22436,
+   "text": "Noah is the tech lead on the ridge team."
+  },
+  {
+   "id": 22437,
+   "text": "Dave is the senior engineer on the prism team."
+  },
+  {
+   "id": 22438,
+   "text": "Carol is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 22439,
+   "text": "Taylor is the PM on the atlas team."
+  },
+  {
+   "id": 22440,
+   "text": "Grace is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 22441,
+   "text": "Eve reports to Liam."
+  },
+  {
+   "id": 22442,
+   "text": "Ivy is the staff engineer on the prism team."
+  },
+  {
+   "id": 22443,
+   "text": "Ivy is the senior engineer on the beacon team."
+  },
+  {
+   "id": 22444,
+   "text": "Alice is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 22445,
+   "text": "Henry is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 22446,
+   "text": "Grace is the tech lead on the glacier team."
+  },
+  {
+   "id": 22447,
+   "text": "Taylor is the PM on the delta team."
+  },
+  {
+   "id": 22448,
+   "text": "Riley is the principal engineer on the prism team."
+  },
+  {
+   "id": 22449,
+   "text": "Kate is the designer on the compass team."
+  },
+  {
+   "id": 22450,
+   "text": "Bob is the staff engineer on the prism team."
+  },
+  {
+   "id": 22451,
+   "text": "Riley is the QA lead on the harbor team."
+  },
+  {
+   "id": 22452,
+   "text": "Riley is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 22453,
+   "text": "Olivia is the designer on the quartz team."
+  },
+  {
+   "id": 22454,
+   "text": "Frank is the senior engineer on the atlas team."
+  },
+  {
+   "id": 22455,
+   "text": "Riley reports to Kate."
+  },
+  {
+   "id": 22456,
+   "text": "Frank is the engineering manager on the beacon team."
+  },
+  {
+   "id": 22457,
+   "text": "Mia is the PM on the lattice team."
+  },
+  {
+   "id": 22458,
+   "text": "Henry is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 22459,
+   "text": "Henry is the designer on the iris team."
+  },
+  {
+   "id": 22460,
+   "text": "Eve is the PM on the compass team."
+  },
+  {
+   "id": 22461,
+   "text": "Riley is the PM on the junction team."
+  },
+  {
+   "id": 22462,
+   "text": "Henry is the tech lead on the summit team."
+  },
+  {
+   "id": 22463,
+   "text": "Alice is the PM on the glacier team."
+  },
+  {
+   "id": 22464,
+   "text": "Noah reports to Quinn."
+  },
+  {
+   "id": 22465,
+   "text": "Olivia is the tech lead on the fjord team."
+  },
+  {
+   "id": 22466,
+   "text": "Riley is the principal engineer on the nexus team."
+  },
+  {
+   "id": 22467,
+   "text": "Mia reports to Dave."
+  },
+  {
+   "id": 22468,
+   "text": "Kate reports to Carol."
+  },
+  {
+   "id": 22469,
+   "text": "Taylor reports to Quinn."
+  },
+  {
+   "id": 22470,
+   "text": "Dave is the senior engineer on the atlas team."
+  },
+  {
+   "id": 22471,
+   "text": "The user prefers gruvbox as their color scheme in fish shell."
+  },
+  {
+   "id": 22472,
+   "text": "The user prefers Iosevka as their font in kitty."
+  },
+  {
+   "id": 22473,
+   "text": "Project ridge uses Elasticsearch for search."
+  },
+  {
+   "id": 22474,
+   "text": "Project tundra uses Sentry for error tracking."
+  },
+  {
+   "id": 22475,
+   "text": "Project delta uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 22476,
+   "text": "Riley is the principal engineer on the junction team."
+  },
+  {
+   "id": 22477,
+   "text": "Carol owns the deploy surface."
+  },
+  {
+   "id": 22478,
+   "text": "Sam is the designer on the harbor team."
+  },
+  {
+   "id": 22479,
+   "text": "Eve is the engineering manager on the glacier team."
+  },
+  {
+   "id": 22480,
+   "text": "Quinn is the principal engineer on the nexus team."
+  },
+  {
+   "id": 22481,
+   "text": "Sam is the engineering manager on the ridge team."
+  },
+  {
+   "id": 22482,
+   "text": "Pat is the tech lead on the fjord team."
+  },
+  {
+   "id": 22483,
+   "text": "Olivia is the senior engineer on the summit team."
+  },
+  {
+   "id": 22484,
+   "text": "Sam is the staff engineer on the compass team."
+  },
+  {
+   "id": 22485,
+   "text": "Noah is the staff engineer on the summit team."
+  },
+  {
+   "id": 22486,
+   "text": "Carol is the designer on the beacon team."
+  },
+  {
+   "id": 22487,
+   "text": "Sam is the principal engineer on the monolith team."
+  },
+  {
+   "id": 22488,
+   "text": "Sam reports to Pat."
+  },
+  {
+   "id": 22489,
+   "text": "Sam is the tech lead on the fjord team."
+  },
+  {
+   "id": 22490,
+   "text": "Pat is the principal engineer on the tundra team."
+  },
+  {
+   "id": 22491,
+   "text": "Ivy is the PM on the ridge team."
+  },
+  {
+   "id": 22492,
+   "text": "Bob reports to Henry."
+  },
+  {
+   "id": 22493,
+   "text": "Quinn is the principal engineer on the prism team."
+  },
+  {
+   "id": 22494,
+   "text": "Alice is the tech lead on the summit team."
+  },
+  {
+   "id": 22495,
+   "text": "Grace is the engineering manager on the glacier team."
+  },
+  {
+   "id": 22496,
+   "text": "Ivy is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 22497,
+   "text": "Bob is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 22498,
+   "text": "Taylor is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 22499,
+   "text": "Pat is the senior engineer on the ridge team."
+  },
+  {
+   "id": 22500,
+   "text": "Grace is the QA lead on the summit team."
+  },
+  {
+   "id": 22501,
+   "text": "Bob reports to Alice."
+  },
+  {
+   "id": 22502,
+   "text": "Dave is the engineering manager on the echo team."
+  },
+  {
+   "id": 22503,
+   "text": "Olivia reports to Alice."
+  },
+  {
+   "id": 22504,
+   "text": "Ivy is the engineering manager on the kestrel team."
+  },
+  {
+   "id": 22505,
+   "text": "Frank is the principal engineer on the tundra team."
+  },
+  {
+   "id": 22506,
+   "text": "Grace is the staff engineer on the lattice team."
+  },
+  {
+   "id": 22507,
+   "text": "Mia is the staff engineer on the quartz team."
+  },
+  {
+   "id": 22508,
+   "text": "Noah is the tech lead on the prism team."
+  },
+  {
+   "id": 22509,
+   "text": "Kate is the senior engineer on the summit team."
+  },
+  {
+   "id": 22510,
+   "text": "Taylor is the staff engineer on the fjord team."
+  },
+  {
+   "id": 22511,
+   "text": "Frank is the senior engineer on the nexus team."
+  },
+  {
+   "id": 22512,
+   "text": "Mia is on PTO from Monday to Monday."
+  },
+  {
+   "id": 22513,
+   "text": "Ivy is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 22514,
+   "text": "Frank is the senior engineer on the fjord team."
+  },
+  {
+   "id": 22515,
+   "text": "Taylor is the senior engineer on the lattice team."
+  },
+  {
+   "id": 22516,
+   "text": "Mia is the QA lead on the junction team."
+  },
+  {
+   "id": 22517,
+   "text": "Kate is the principal engineer on the fjord team."
+  },
+  {
+   "id": 22518,
+   "text": "Bob is the staff engineer on the lattice team."
+  },
+  {
+   "id": 22519,
+   "text": "Jack is the engineering manager on the summit team."
+  },
+  {
+   "id": 22520,
+   "text": "Olivia is the principal engineer on the lattice team."
+  },
+  {
+   "id": 22521,
+   "text": "Olivia is the QA lead on the iris team."
+  },
+  {
+   "id": 22522,
+   "text": "Ivy is the designer on the junction team."
+  },
+  {
+   "id": 22523,
+   "text": "Olivia is the staff engineer on the summit team."
+  },
+  {
+   "id": 22524,
+   "text": "Liam is the engineering manager on the junction team."
+  },
+  {
+   "id": 22525,
+   "text": "Kate is the principal engineer on the compass team."
+  },
+  {
+   "id": 22526,
+   "text": "Kate is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 22527,
+   "text": "Jack is the principal engineer on the orbit team."
+  },
+  {
+   "id": 22528,
+   "text": "Quinn is the senior engineer on the tundra team."
+  },
+  {
+   "id": 22529,
+   "text": "Quinn is the engineering manager on the monolith team."
+  },
+  {
+   "id": 22530,
+   "text": "Bob is the engineering manager on the quartz team."
+  },
+  {
+   "id": 22531,
+   "text": "Bob is the designer on the delta team."
+  },
+  {
+   "id": 22532,
+   "text": "Mia is the senior engineer on the atlas team."
+  },
+  {
+   "id": 22533,
+   "text": "Riley is the designer on the summit team."
+  },
+  {
+   "id": 22534,
+   "text": "Mia is the QA lead on the beacon team."
+  },
+  {
+   "id": 22535,
+   "text": "Ivy is the senior engineer on the summit team."
+  },
+  {
+   "id": 22536,
+   "text": "Mia is the engineering manager on the monolith team."
+  },
+  {
+   "id": 22537,
+   "text": "Ivy is the PM on the monolith team."
+  },
+  {
+   "id": 22538,
+   "text": "Quinn is the tech lead on the monolith team."
+  },
+  {
+   "id": 22539,
+   "text": "Jack reports to Pat."
+  },
+  {
+   "id": 22540,
+   "text": "Dave is the PM on the tundra team."
+  },
+  {
+   "id": 22541,
+   "text": "Sam is the PM on the atlas team."
+  },
+  {
+   "id": 22542,
+   "text": "Sam is the designer on the compass team."
+  },
+  {
+   "id": 22543,
+   "text": "Quinn is the senior engineer on the junction team."
+  },
+  {
+   "id": 22544,
+   "text": "Olivia is the designer on the junction team."
+  },
+  {
+   "id": 22545,
+   "text": "Noah is the principal engineer on the kestrel team."
+  },
+  {
+   "id": 22546,
+   "text": "Bob is the principal engineer on the iris team."
+  },
+  {
+   "id": 22547,
+   "text": "Alice is the tech lead on the delta team."
+  },
+  {
+   "id": 22548,
+   "text": "Liam is the principal engineer on the beacon team."
+  },
+  {
+   "id": 22549,
+   "text": "Ivy is the engineering manager on the summit team."
+  },
+  {
+   "id": 22550,
+   "text": "Jack is the principal engineer on the lattice team."
+  },
+  {
+   "id": 22551,
+   "text": "Eve is the principal engineer on the nexus team."
+  },
+  {
+   "id": 22552,
+   "text": "Riley is the QA lead on the orbit team."
+  },
+  {
+   "id": 22553,
+   "text": "Bob owns the search surface."
+  },
+  {
+   "id": 22554,
+   "text": "Taylor is the tech lead on the prism team."
+  },
+  {
+   "id": 22555,
+   "text": "Alice is the tech lead on the quartz team."
+  },
+  {
+   "id": 22556,
+   "text": "Henry is the tech lead on the fjord team."
+  },
+  {
+   "id": 22557,
+   "text": "Liam is the engineering manager on the echo team."
+  },
+  {
+   "id": 22558,
+   "text": "Grace is the engineering manager on the nexus team."
+  },
+  {
+   "id": 22559,
+   "text": "Riley is the designer on the lattice team."
+  },
+  {
+   "id": 22560,
+   "text": "Taylor is the principal engineer on the fjord team."
+  },
+  {
+   "id": 22561,
+   "text": "Eve is the QA lead on the delta team."
+  },
+  {
+   "id": 22562,
+   "text": "Ivy is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 22563,
+   "text": "Frank is the principal engineer on the quartz team."
+  },
+  {
+   "id": 22564,
+   "text": "Noah is the QA lead on the monolith team."
+  },
+  {
+   "id": 22565,
+   "text": "Bob is the tech lead on the atlas team."
+  },
+  {
+   "id": 22566,
+   "text": "Eve is the designer on the junction team."
+  },
+  {
+   "id": 22567,
+   "text": "Mia is the tech lead on the quartz team."
+  },
+  {
+   "id": 22568,
+   "text": "Pat is the PM on the junction team."
+  },
+  {
+   "id": 22569,
+   "text": "Project monolith uses Prometheus for metrics."
+  },
+  {
+   "id": 22570,
+   "text": "Project harbor uses Elasticsearch for search."
+  },
+  {
+   "id": 22571,
+   "text": "Project nexus uses Tailwind for styling."
+  },
+  {
+   "id": 22572,
+   "text": "Project harbor uses Docker for containerization."
+  },
+  {
+   "id": 22573,
+   "text": "Mia is the PM on the kestrel team."
+  },
+  {
+   "id": 22574,
+   "text": "Alice is the PM on the junction team."
+  },
+  {
+   "id": 22575,
+   "text": "Eve reports to Taylor."
+  },
+  {
+   "id": 22576,
+   "text": "Quinn is the engineering manager on the beacon team."
+  },
+  {
+   "id": 22577,
+   "text": "Alice reports to Frank."
+  },
+  {
+   "id": 22578,
+   "text": "Carol is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 22579,
+   "text": "Pat is the senior engineer on the compass team."
+  },
+  {
+   "id": 22580,
+   "text": "Frank is the staff engineer on the iris team."
+  },
+  {
+   "id": 22581,
+   "text": "Mia is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 22582,
+   "text": "Jack owns the API surface."
+  },
+  {
+   "id": 22583,
+   "text": "Frank is the PM on the iris team."
+  },
+  {
+   "id": 22584,
+   "text": "Alice is the tech lead on the kestrel team."
+  },
+  {
+   "id": 22585,
+   "text": "Taylor is the senior engineer on the monolith team."
+  },
+  {
+   "id": 22586,
+   "text": "Noah is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 22587,
+   "text": "Olivia is the QA lead on the atlas team."
+  },
+  {
+   "id": 22588,
+   "text": "Dave is the PM on the beacon team."
+  },
+  {
+   "id": 22589,
+   "text": "Jack is the staff engineer on the ridge team."
+  },
+  {
+   "id": 22590,
+   "text": "Grace reports to Sam."
+  },
+  {
+   "id": 22591,
+   "text": "Jack is the designer on the iris team."
+  },
+  {
+   "id": 22592,
+   "text": "Pat is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 22593,
+   "text": "Frank is the engineering manager on the nexus team."
+  },
+  {
+   "id": 22594,
+   "text": "Quinn is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 22595,
+   "text": "Noah is the principal engineer on the summit team."
+  },
+  {
+   "id": 22596,
+   "text": "Pat reports to Alice."
+  },
+  {
+   "id": 22597,
+   "text": "Alice is the QA lead on the monolith team."
+  },
+  {
+   "id": 22598,
+   "text": "Dave is the PM on the lattice team."
+  },
+  {
+   "id": 22599,
+   "text": "Riley is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 22600,
+   "text": "Kate is the QA lead on the nexus team."
+  },
+  {
+   "id": 22601,
+   "text": "Dave is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 22602,
+   "text": "Liam is the designer on the compass team."
+  },
+  {
+   "id": 22603,
+   "text": "Dave is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 22604,
+   "text": "Eve is the staff engineer on the atlas team."
+  },
+  {
+   "id": 22605,
+   "text": "Sam is the staff engineer on the summit team."
+  },
+  {
+   "id": 22606,
+   "text": "Jack reports to Quinn."
+  },
+  {
+   "id": 22607,
+   "text": "Bob is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 22608,
+   "text": "Carol reports to Alice."
+  },
+  {
+   "id": 22609,
+   "text": "Eve is the QA lead on the echo team."
+  },
+  {
+   "id": 22610,
+   "text": "The user prefers solarized dark as their color scheme in Warp."
+  },
+  {
+   "id": 22611,
+   "text": "Project quartz uses Tailwind for styling."
+  },
+  {
+   "id": 22612,
+   "text": "Project atlas uses React for the frontend."
+  },
+  {
+   "id": 22613,
+   "text": "Alice is the designer on the junction team."
+  },
+  {
+   "id": 22614,
+   "text": "Dave reports to Carol."
+  },
+  {
+   "id": 22615,
+   "text": "Noah is the QA lead on the junction team."
+  },
+  {
+   "id": 22616,
+   "text": "Dave is the senior engineer on the beacon team."
+  },
+  {
+   "id": 22617,
+   "text": "Quinn is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 22618,
+   "text": "Kate is the principal engineer on the prism team."
+  },
+  {
+   "id": 22619,
+   "text": "Kate is the QA lead on the echo team."
+  },
+  {
+   "id": 22620,
+   "text": "Jack is the QA lead on the kestrel team."
+  },
+  {
+   "id": 22621,
+   "text": "Quinn is the PM on the harbor team."
+  },
+  {
+   "id": 22622,
+   "text": "Pat is the staff engineer on the atlas team."
+  },
+  {
+   "id": 22623,
+   "text": "Pat is the PM on the iris team."
+  },
+  {
+   "id": 22624,
+   "text": "Grace reports to Noah."
+  },
+  {
+   "id": 22625,
+   "text": "Carol is the PM on the ridge team."
+  },
+  {
+   "id": 22626,
+   "text": "Liam is the staff engineer on the nexus team."
+  },
+  {
+   "id": 22627,
+   "text": "Alice is the staff engineer on the lattice team."
+  },
+  {
+   "id": 22628,
+   "text": "Bob is the tech lead on the compass team."
+  },
+  {
+   "id": 22629,
+   "text": "Noah is the QA lead on the lattice team."
+  },
+  {
+   "id": 22630,
+   "text": "Frank is on PTO from Thursday to Thursday."
+  },
+  {
+   "id": 22631,
+   "text": "Mia is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 22632,
+   "text": "Pat is the staff engineer on the quartz team."
+  },
+  {
+   "id": 22633,
+   "text": "Olivia is the principal engineer on the atlas team."
+  },
+  {
+   "id": 22634,
+   "text": "Dave is the engineering manager on the tundra team."
+  },
+  {
+   "id": 22635,
+   "text": "Olivia is the QA lead on the ridge team."
+  },
+  {
+   "id": 22636,
+   "text": "Carol is the senior engineer on the compass team."
+  },
+  {
+   "id": 22637,
+   "text": "Riley is the tech lead on the iris team."
+  },
+  {
+   "id": 22638,
+   "text": "Frank is the QA lead on the harbor team."
+  },
+  {
+   "id": 22639,
+   "text": "Dave is the QA lead on the kestrel team."
+  },
+  {
+   "id": 22640,
+   "text": "Eve is the senior engineer on the beacon team."
+  },
+  {
+   "id": 22641,
+   "text": "Grace is the principal engineer on the delta team."
+  },
+  {
+   "id": 22642,
+   "text": "Henry is the engineering manager on the delta team."
+  },
+  {
+   "id": 22643,
+   "text": "Noah reports to Olivia."
+  },
+  {
+   "id": 22644,
+   "text": "Ivy is the staff engineer on the lattice team."
+  },
+  {
+   "id": 22645,
+   "text": "Bob is the staff engineer on the glacier team."
+  },
+  {
+   "id": 22646,
+   "text": "Jack is the QA lead on the compass team."
+  },
+  {
+   "id": 22647,
+   "text": "Noah is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 22648,
+   "text": "Pat is the staff engineer on the lattice team."
+  },
+  {
+   "id": 22649,
+   "text": "Quinn is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 22650,
+   "text": "Alice is the PM on the orbit team."
+  },
+  {
+   "id": 22651,
+   "text": "Riley is the principal engineer on the kestrel team."
+  },
+  {
+   "id": 22652,
+   "text": "Ivy is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 22653,
+   "text": "Frank is the senior engineer on the kestrel team."
+  },
+  {
+   "id": 22654,
+   "text": "Noah is the senior engineer on the ridge team."
+  },
+  {
+   "id": 22655,
+   "text": "Kate is the principal engineer on the tundra team."
+  },
+  {
+   "id": 22656,
+   "text": "Henry reports to Riley."
+  },
+  {
+   "id": 22657,
+   "text": "Frank is the principal engineer on the summit team."
+  },
+  {
+   "id": 22658,
+   "text": "Taylor is the principal engineer on the iris team."
+  },
+  {
+   "id": 22659,
+   "text": "Olivia is the engineering manager on the compass team."
+  },
+  {
+   "id": 22660,
+   "text": "Quinn is the engineering manager on the echo team."
+  },
+  {
+   "id": 22661,
+   "text": "Olivia is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 22662,
+   "text": "Liam is the engineering manager on the ridge team."
+  },
+  {
+   "id": 22663,
+   "text": "Sam is the senior engineer on the compass team."
+  },
+  {
+   "id": 22664,
+   "text": "Carol is on PTO from Monday to Friday."
+  },
+  {
+   "id": 22665,
+   "text": "Henry is the senior engineer on the quartz team."
+  },
+  {
+   "id": 22666,
+   "text": "Pat is the principal engineer on the compass team."
+  },
+  {
+   "id": 22667,
+   "text": "Quinn is the tech lead on the glacier team."
+  },
+  {
+   "id": 22668,
+   "text": "Olivia is the staff engineer on the beacon team."
+  },
+  {
+   "id": 22669,
+   "text": "Mia is the tech lead on the delta team."
+  },
+  {
+   "id": 22670,
+   "text": "Carol is the tech lead on the kestrel team."
+  },
+  {
+   "id": 22671,
+   "text": "Eve is the principal engineer on the echo team."
+  },
+  {
+   "id": 22672,
+   "text": "Noah is the QA lead on the tundra team."
+  },
+  {
+   "id": 22673,
+   "text": "Riley is the PM on the fjord team."
+  },
+  {
+   "id": 22674,
+   "text": "Kate is the tech lead on the compass team."
+  },
+  {
+   "id": 22675,
+   "text": "Liam is the staff engineer on the atlas team."
+  },
+  {
+   "id": 22676,
+   "text": "Olivia is the senior engineer on the ridge team."
+  },
+  {
+   "id": 22677,
+   "text": "Olivia is on PTO from Monday to Friday."
+  },
+  {
+   "id": 22678,
+   "text": "Liam is the designer on the orbit team."
+  },
+  {
+   "id": 22679,
+   "text": "Olivia is the designer on the iris team."
+  },
+  {
+   "id": 22680,
+   "text": "Liam is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 22681,
+   "text": "Bob is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 22682,
+   "text": "Pat is the designer on the glacier team."
+  },
+  {
+   "id": 22683,
+   "text": "Sam is the engineering manager on the delta team."
+  },
+  {
+   "id": 22684,
+   "text": "Carol is the engineering manager on the echo team."
+  },
+  {
+   "id": 22685,
+   "text": "Alice is the tech lead on the atlas team."
+  },
+  {
+   "id": 22686,
+   "text": "Dave is the QA lead on the monolith team."
+  },
+  {
+   "id": 22687,
+   "text": "Alice is the staff engineer on the quartz team."
+  },
+  {
+   "id": 22688,
+   "text": "Taylor is the QA lead on the prism team."
+  },
+  {
+   "id": 22689,
+   "text": "Bob is the staff engineer on the beacon team."
+  },
+  {
+   "id": 22690,
+   "text": "Jack reports to Mia."
+  },
+  {
+   "id": 22691,
+   "text": "Riley is the engineering manager on the atlas team."
+  },
+  {
+   "id": 22692,
+   "text": "Sam is the QA lead on the harbor team."
+  },
+  {
+   "id": 22693,
+   "text": "Carol is the staff engineer on the monolith team."
+  },
+  {
+   "id": 22694,
+   "text": "Grace is the principal engineer on the ridge team."
+  },
+  {
+   "id": 22695,
+   "text": "Quinn is on PTO from Friday to Monday."
+  },
+  {
+   "id": 22696,
+   "text": "Taylor reports to Eve."
+  },
+  {
+   "id": 22697,
+   "text": "Pat is on PTO from Friday to Friday."
+  },
+  {
+   "id": 22698,
+   "text": "Project delta uses Elasticsearch for search."
+  },
+  {
+   "id": 22699,
+   "text": "Project summit uses Tailwind for styling."
+  },
+  {
+   "id": 22700,
+   "text": "Project summit uses Python for data pipelines."
+  },
+  {
+   "id": 22701,
+   "text": "Quinn is the staff engineer on the iris team."
+  },
+  {
+   "id": 22702,
+   "text": "Kate is the tech lead on the prism team."
+  },
+  {
+   "id": 22703,
+   "text": "Quinn is the QA lead on the harbor team."
+  },
+  {
+   "id": 22704,
+   "text": "Pat is the principal engineer on the iris team."
+  },
+  {
+   "id": 22705,
+   "text": "Sam is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 22706,
+   "text": "Noah is the senior engineer on the iris team."
+  },
+  {
+   "id": 22707,
+   "text": "Henry is the senior engineer on the ridge team."
+  },
+  {
+   "id": 22708,
+   "text": "Alice is the PM on the atlas team."
+  },
+  {
+   "id": 22709,
+   "text": "Pat is the designer on the nexus team."
+  },
+  {
+   "id": 22710,
+   "text": "Carol is the QA lead on the orbit team."
+  },
+  {
+   "id": 22711,
+   "text": "Taylor is the QA lead on the beacon team."
+  },
+  {
+   "id": 22712,
+   "text": "Frank is the QA lead on the beacon team."
+  },
+  {
+   "id": 22713,
+   "text": "Noah is the QA lead on the atlas team."
+  },
+  {
+   "id": 22714,
+   "text": "Carol is the designer on the iris team."
+  },
+  {
+   "id": 22715,
+   "text": "Quinn is the engineering manager on the iris team."
+  },
+  {
+   "id": 22716,
+   "text": "Pat reports to Henry."
+  },
+  {
+   "id": 22717,
+   "text": "Kate is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 22718,
+   "text": "Alice is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 22719,
+   "text": "Kate is the principal engineer on the nexus team."
+  },
+  {
+   "id": 22720,
+   "text": "Olivia is on PTO from Friday to Friday."
+  },
+  {
+   "id": 22721,
+   "text": "Carol is the engineering manager on the nexus team."
+  },
+  {
+   "id": 22722,
+   "text": "Dave is the PM on the quartz team."
+  },
+  {
+   "id": 22723,
+   "text": "Ivy reports to Pat."
+  },
+  {
+   "id": 22724,
+   "text": "Carol reports to Jack."
+  },
+  {
+   "id": 22725,
+   "text": "Liam is the staff engineer on the orbit team."
+  },
+  {
+   "id": 22726,
+   "text": "Noah is the PM on the tundra team."
+  },
+  {
+   "id": 22727,
+   "text": "Bob is the senior engineer on the fjord team."
+  },
+  {
+   "id": 22728,
+   "text": "Taylor is the engineering manager on the delta team."
+  },
+  {
+   "id": 22729,
+   "text": "Grace is the PM on the kestrel team."
+  },
+  {
+   "id": 22730,
+   "text": "Alice is the staff engineer on the tundra team."
+  },
+  {
+   "id": 22731,
+   "text": "Pat is the designer on the echo team."
+  },
+  {
+   "id": 22732,
+   "text": "Pat is the principal engineer on the lattice team."
+  },
+  {
+   "id": 22733,
+   "text": "Grace is the QA lead on the compass team."
+  },
+  {
+   "id": 22734,
+   "text": "Quinn is the PM on the junction team."
+  },
+  {
+   "id": 22735,
+   "text": "Quinn is the tech lead on the compass team."
+  },
+  {
+   "id": 22736,
+   "text": "Olivia is the QA lead on the prism team."
+  },
+  {
+   "id": 22737,
+   "text": "Taylor is the PM on the nexus team."
+  },
+  {
+   "id": 22738,
+   "text": "Noah is the PM on the glacier team."
+  },
+  {
+   "id": 22739,
+   "text": "Frank is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 22740,
+   "text": "Project delta uses OpenTelemetry for tracing."
+  },
+  {
+   "id": 22741,
+   "text": "Project compass uses React for the frontend."
+  },
+  {
+   "id": 22742,
+   "text": "Noah is on PTO from Monday to Monday."
+  },
+  {
+   "id": 22743,
+   "text": "Quinn is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 22744,
+   "text": "Henry is the senior engineer on the orbit team."
+  },
+  {
+   "id": 22745,
+   "text": "Noah is the engineering manager on the orbit team."
+  },
+  {
+   "id": 22746,
+   "text": "Liam is the designer on the lattice team."
+  },
+  {
+   "id": 22747,
+   "text": "Pat is the QA lead on the harbor team."
+  },
+  {
+   "id": 22748,
+   "text": "Bob is the staff engineer on the compass team."
+  },
+  {
+   "id": 22749,
+   "text": "Frank is the QA lead on the glacier team."
+  },
+  {
+   "id": 22750,
+   "text": "Quinn is the PM on the fjord team."
+  },
+  {
+   "id": 22751,
+   "text": "Carol is the PM on the lattice team."
+  },
+  {
+   "id": 22752,
+   "text": "Jack is the PM on the fjord team."
+  },
+  {
+   "id": 22753,
+   "text": "Jack reports to Liam."
+  },
+  {
+   "id": 22754,
+   "text": "Taylor reports to Frank."
+  },
+  {
+   "id": 22755,
+   "text": "Quinn is the PM on the glacier team."
+  },
+  {
+   "id": 22756,
+   "text": "Dave is the staff engineer on the compass team."
+  },
+  {
+   "id": 22757,
+   "text": "Henry is the PM on the prism team."
+  },
+  {
+   "id": 22758,
+   "text": "Jack is the designer on the delta team."
+  },
+  {
+   "id": 22759,
+   "text": "Eve is the principal engineer on the fjord team."
+  },
+  {
+   "id": 22760,
+   "text": "Pat is the PM on the fjord team."
+  },
+  {
+   "id": 22761,
+   "text": "Olivia is the tech lead on the junction team."
+  },
+  {
+   "id": 22762,
+   "text": "Alice is on PTO from Friday to Friday."
+  },
+  {
+   "id": 22763,
+   "text": "Jack is the principal engineer on the ridge team."
+  },
+  {
+   "id": 22764,
+   "text": "Alice is the PM on the lattice team."
+  },
+  {
+   "id": 22765,
+   "text": "Frank is the principal engineer on the orbit team."
+  },
+  {
+   "id": 22766,
+   "text": "Noah is the QA lead on the summit team."
+  },
+  {
+   "id": 22767,
+   "text": "Carol is the senior engineer on the echo team."
+  },
+  {
+   "id": 22768,
+   "text": "Sam is the principal engineer on the compass team."
+  },
+  {
+   "id": 22769,
+   "text": "Noah is the PM on the orbit team."
+  },
+  {
+   "id": 22770,
+   "text": "Pat reports to Taylor."
+  },
+  {
+   "id": 22771,
+   "text": "Kate is the staff engineer on the summit team."
+  },
+  {
+   "id": 22772,
+   "text": "Pat is the principal engineer on the fjord team."
+  },
+  {
+   "id": 22773,
+   "text": "Pat is the PM on the orbit team."
+  },
+  {
+   "id": 22774,
+   "text": "Dave is the staff engineer on the nexus team."
+  },
+  {
+   "id": 22775,
+   "text": "Pat is the tech lead on the atlas team."
+  },
+  {
+   "id": 22776,
+   "text": "Frank is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 22777,
+   "text": "Riley is the designer on the junction team."
+  },
+  {
+   "id": 22778,
+   "text": "Liam is the staff engineer on the summit team."
+  },
+  {
+   "id": 22779,
+   "text": "Bob is the senior engineer on the monolith team."
+  },
+  {
+   "id": 22780,
+   "text": "Frank is the engineering manager on the glacier team."
+  },
+  {
+   "id": 22781,
+   "text": "Quinn reports to Dave."
+  },
+  {
+   "id": 22782,
+   "text": "Noah is the staff engineer on the ridge team."
+  },
+  {
+   "id": 22783,
+   "text": "Kate is the engineering manager on the compass team."
+  },
+  {
+   "id": 22784,
+   "text": "Olivia is the principal engineer on the quartz team."
+  },
+  {
+   "id": 22785,
+   "text": "Grace is the principal engineer on the orbit team."
+  },
+  {
+   "id": 22786,
+   "text": "Henry reports to Sam."
+  },
+  {
+   "id": 22787,
+   "text": "Bob is the tech lead on the beacon team."
+  },
+  {
+   "id": 22788,
+   "text": "Taylor is the designer on the glacier team."
+  },
+  {
+   "id": 22789,
+   "text": "The user prefers high-contrast as their color scheme in VS Code."
+  },
+  {
+   "id": 22790,
+   "text": "Project echo uses Python for data pipelines."
+  },
+  {
+   "id": 22791,
+   "text": "Pat is the designer on the delta team."
+  },
+  {
+   "id": 22792,
+   "text": "Olivia is the designer on the echo team."
+  },
+  {
+   "id": 22793,
+   "text": "Alice is the engineering manager on the kestrel team."
+  },
+  {
+   "id": 22794,
+   "text": "Carol is on PTO from Monday to Thursday."
+  },
+  {
+   "id": 22795,
+   "text": "Carol is the engineering manager on the kestrel team."
+  },
+  {
+   "id": 22796,
+   "text": "Pat is the tech lead on the orbit team."
+  },
+  {
+   "id": 22797,
+   "text": "Grace is the staff engineer on the ridge team."
+  },
+  {
+   "id": 22798,
+   "text": "Quinn is the staff engineer on the tundra team."
+  },
+  {
+   "id": 22799,
+   "text": "Taylor is the PM on the beacon team."
+  },
+  {
+   "id": 22800,
+   "text": "Eve is the staff engineer on the kestrel team."
+  },
+  {
+   "id": 22801,
+   "text": "Quinn is the engineering manager on the quartz team."
+  },
+  {
+   "id": 22802,
+   "text": "Liam is the PM on the fjord team."
+  },
+  {
+   "id": 22803,
+   "text": "Grace is the QA lead on the kestrel team."
+  },
+  {
+   "id": 22804,
+   "text": "Olivia is the senior engineer on the harbor team."
+  },
+  {
+   "id": 22805,
+   "text": "Jack is the QA lead on the summit team."
+  },
+  {
+   "id": 22806,
+   "text": "Henry is on PTO from Wednesday to Wednesday."
+  },
+  {
+   "id": 22807,
+   "text": "Olivia is the senior engineer on the prism team."
+  },
+  {
+   "id": 22808,
+   "text": "Henry is the staff engineer on the iris team."
+  },
+  {
+   "id": 22809,
+   "text": "Riley is the staff engineer on the kestrel team."
+  },
+  {
+   "id": 22810,
+   "text": "Eve is the senior engineer on the quartz team."
+  },
+  {
+   "id": 22811,
+   "text": "Grace is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 22812,
+   "text": "Bob is the senior engineer on the nexus team."
+  },
+  {
+   "id": 22813,
+   "text": "Ivy is the designer on the ridge team."
+  },
+  {
+   "id": 22814,
+   "text": "Sam is the designer on the summit team."
+  },
+  {
+   "id": 22815,
+   "text": "Taylor is the engineering manager on the glacier team."
+  },
+  {
+   "id": 22816,
+   "text": "Olivia is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 22817,
+   "text": "Taylor is the staff engineer on the delta team."
+  },
+  {
+   "id": 22818,
+   "text": "Quinn is the tech lead on the quartz team."
+  },
+  {
+   "id": 22819,
+   "text": "Bob is the principal engineer on the kestrel team."
+  },
+  {
+   "id": 22820,
+   "text": "Alice is the engineering manager on the harbor team."
+  },
+  {
+   "id": 22821,
+   "text": "Ivy is the engineering manager on the fjord team."
+  },
+  {
+   "id": 22822,
+   "text": "Project prism uses Sentry for error tracking."
+  },
+  {
+   "id": 22823,
+   "text": "Henry reports to Olivia."
+  },
+  {
+   "id": 22824,
+   "text": "Pat is the QA lead on the nexus team."
+  },
+  {
+   "id": 22825,
+   "text": "Frank is the engineering manager on the monolith team."
+  },
+  {
+   "id": 22826,
+   "text": "Alice is the staff engineer on the ridge team."
+  },
+  {
+   "id": 22827,
+   "text": "Kate reports to Taylor."
+  },
+  {
+   "id": 22828,
+   "text": "Sam is the tech lead on the tundra team."
+  },
+  {
+   "id": 22829,
+   "text": "Sam is on PTO from Thursday to Friday."
+  },
+  {
+   "id": 22830,
+   "text": "Taylor is the designer on the junction team."
+  },
+  {
+   "id": 22831,
+   "text": "Grace is the designer on the glacier team."
+  },
+  {
+   "id": 22832,
+   "text": "Taylor is the principal engineer on the nexus team."
+  },
+  {
+   "id": 22833,
+   "text": "Frank reports to Noah."
+  },
+  {
+   "id": 22834,
+   "text": "Frank is the staff engineer on the glacier team."
+  },
+  {
+   "id": 22835,
+   "text": "Mia is the tech lead on the prism team."
+  },
+  {
+   "id": 22836,
+   "text": "Quinn is the senior engineer on the kestrel team."
+  },
+  {
+   "id": 22837,
+   "text": "Liam is the principal engineer on the kestrel team."
+  },
+  {
+   "id": 22838,
+   "text": "Noah is the tech lead on the fjord team."
+  },
+  {
+   "id": 22839,
+   "text": "Quinn is the designer on the ridge team."
+  },
+  {
+   "id": 22840,
+   "text": "Mia is on PTO from Friday to Friday."
+  },
+  {
+   "id": 22841,
+   "text": "Eve is the PM on the prism team."
+  },
+  {
+   "id": 22842,
+   "text": "Olivia is the tech lead on the harbor team."
+  },
+  {
+   "id": 22843,
+   "text": "Liam is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 22844,
+   "text": "Bob is the designer on the junction team."
+  },
+  {
+   "id": 22845,
+   "text": "Liam is on PTO from Wednesday to Thursday."
+  },
+  {
+   "id": 22846,
+   "text": "Frank is the designer on the prism team."
+  },
+  {
+   "id": 22847,
+   "text": "Liam is the tech lead on the fjord team."
+  },
+  {
+   "id": 22848,
+   "text": "Frank is on PTO from Monday to Friday."
+  },
+  {
+   "id": 22849,
+   "text": "Bob is the tech lead on the harbor team."
+  },
+  {
+   "id": 22850,
+   "text": "Grace is the tech lead on the atlas team."
+  },
+  {
+   "id": 22851,
+   "text": "Riley is the PM on the lattice team."
+  },
+  {
+   "id": 22852,
+   "text": "Mia is the engineering manager on the ridge team."
+  },
+  {
+   "id": 22853,
+   "text": "Project prism uses Docker for containerization."
+  },
+  {
+   "id": 22854,
+   "text": "Project summit uses Sentry for error tracking."
+  },
+  {
+   "id": 22855,
+   "text": "Project quartz uses Kubernetes for orchestration."
+  },
+  {
+   "id": 22856,
+   "text": "Ivy is the tech lead on the glacier team."
+  },
+  {
+   "id": 22857,
+   "text": "Eve is the designer on the quartz team."
+  },
+  {
+   "id": 22858,
+   "text": "Sam is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 22859,
+   "text": "Bob is the senior engineer on the delta team."
+  },
+  {
+   "id": 22860,
+   "text": "Ivy is the engineering manager on the iris team."
+  },
+  {
+   "id": 22861,
+   "text": "Sam is the designer on the fjord team."
+  },
+  {
+   "id": 22862,
+   "text": "Olivia is the principal engineer on the junction team."
+  },
+  {
+   "id": 22863,
+   "text": "Dave reports to Pat."
+  },
+  {
+   "id": 22864,
+   "text": "Noah is the principal engineer on the nexus team."
+  },
+  {
+   "id": 22865,
+   "text": "Bob is the QA lead on the atlas team."
+  },
+  {
+   "id": 22866,
+   "text": "Ivy is the staff engineer on the harbor team."
+  },
+  {
+   "id": 22867,
+   "text": "Carol is the tech lead on the junction team."
+  },
+  {
+   "id": 22868,
+   "text": "Bob is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 22869,
+   "text": "Ivy is the principal engineer on the monolith team."
+  },
+  {
+   "id": 22870,
+   "text": "Kate is the designer on the beacon team."
+  },
+  {
+   "id": 22871,
+   "text": "Riley is on PTO from Thursday to Monday."
+  },
+  {
+   "id": 22872,
+   "text": "Grace is the senior engineer on the tundra team."
+  },
+  {
+   "id": 22873,
+   "text": "Jack is the PM on the summit team."
+  },
+  {
+   "id": 22874,
+   "text": "Dave is the principal engineer on the echo team."
+  },
+  {
+   "id": 22875,
+   "text": "Dave is the engineering manager on the fjord team."
+  },
+  {
+   "id": 22876,
+   "text": "Ivy is the QA lead on the iris team."
+  },
+  {
+   "id": 22877,
+   "text": "Frank is the principal engineer on the ridge team."
+  },
+  {
+   "id": 22878,
+   "text": "Quinn is the senior engineer on the orbit team."
+  },
+  {
+   "id": 22879,
+   "text": "Sam reports to Eve."
+  },
+  {
+   "id": 22880,
+   "text": "Liam is the designer on the ridge team."
+  },
+  {
+   "id": 22881,
+   "text": "Mia is the engineering manager on the beacon team."
+  },
+  {
+   "id": 22882,
+   "text": "Liam is the designer on the junction team."
+  },
+  {
+   "id": 22883,
+   "text": "Henry is the engineering manager on the beacon team."
+  },
+  {
+   "id": 22884,
+   "text": "Kate is the designer on the delta team."
+  },
+  {
+   "id": 22885,
+   "text": "Mia is the engineering manager on the delta team."
+  },
+  {
+   "id": 22886,
+   "text": "Riley reports to Eve."
+  },
+  {
+   "id": 22887,
+   "text": "Grace is the tech lead on the fjord team."
+  },
+  {
+   "id": 22888,
+   "text": "Noah is the engineering manager on the iris team."
+  },
+  {
+   "id": 22889,
+   "text": "Alice is the designer on the fjord team."
+  },
+  {
+   "id": 22890,
+   "text": "Alice is the principal engineer on the fjord team."
+  },
+  {
+   "id": 22891,
+   "text": "Pat is the tech lead on the delta team."
+  },
+  {
+   "id": 22892,
+   "text": "Frank is the designer on the delta team."
+  },
+  {
+   "id": 22893,
+   "text": "Henry is the staff engineer on the fjord team."
+  },
+  {
+   "id": 22894,
+   "text": "Alice is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 22895,
+   "text": "Eve is the QA lead on the atlas team."
+  },
+  {
+   "id": 22896,
+   "text": "Noah is the designer on the harbor team."
+  },
+  {
+   "id": 22897,
+   "text": "Riley is the QA lead on the nexus team."
+  },
+  {
+   "id": 22898,
+   "text": "Frank is on PTO from Monday to Monday."
+  },
+  {
+   "id": 22899,
+   "text": "Quinn is the senior engineer on the compass team."
+  },
+  {
+   "id": 22900,
+   "text": "Dave is on PTO from Monday to Monday."
+  },
+  {
+   "id": 22901,
+   "text": "Taylor is the principal engineer on the orbit team."
+  },
+  {
+   "id": 22902,
+   "text": "Riley is the senior engineer on the orbit team."
+  },
+  {
+   "id": 22903,
+   "text": "Noah is the staff engineer on the fjord team."
+  },
+  {
+   "id": 22904,
+   "text": "Carol reports to Quinn."
+  },
+  {
+   "id": 22905,
+   "text": "Mia is the designer on the atlas team."
+  },
+  {
+   "id": 22906,
+   "text": "Carol is the designer on the monolith team."
+  },
+  {
+   "id": 22907,
+   "text": "Eve is the designer on the kestrel team."
+  },
+  {
+   "id": 22908,
+   "text": "Noah is the senior engineer on the kestrel team."
+  },
+  {
+   "id": 22909,
+   "text": "Ivy is the designer on the beacon team."
+  },
+  {
+   "id": 22910,
+   "text": "Alice is the PM on the kestrel team."
+  },
+  {
+   "id": 22911,
+   "text": "Frank is the tech lead on the lattice team."
+  },
+  {
+   "id": 22912,
+   "text": "Sam is the tech lead on the quartz team."
+  },
+  {
+   "id": 22913,
+   "text": "Kate is the senior engineer on the junction team."
+  },
+  {
+   "id": 22914,
+   "text": "Ivy is the PM on the echo team."
+  },
+  {
+   "id": 22915,
+   "text": "Ivy is the QA lead on the ridge team."
+  },
+  {
+   "id": 22916,
+   "text": "Noah is the engineering manager on the atlas team."
+  },
+  {
+   "id": 22917,
+   "text": "Olivia is the engineering manager on the quartz team."
+  },
+  {
+   "id": 22918,
+   "text": "Sam is the senior engineer on the nexus team."
+  },
+  {
+   "id": 22919,
+   "text": "Olivia is the engineering manager on the atlas team."
+  },
+  {
+   "id": 22920,
+   "text": "Quinn is the designer on the kestrel team."
+  },
+  {
+   "id": 22921,
+   "text": "The user prefers Cascadia Code as their font in VS Code."
+  },
+  {
+   "id": 22922,
+   "text": "Jack is the PM on the compass team."
+  },
+  {
+   "id": 22923,
+   "text": "Sam is the tech lead on the beacon team."
+  },
+  {
+   "id": 22924,
+   "text": "Taylor is the senior engineer on the nexus team."
+  },
+  {
+   "id": 22925,
+   "text": "Carol is the tech lead on the prism team."
+  },
+  {
+   "id": 22926,
+   "text": "Mia is the engineering manager on the lattice team."
+  },
+  {
+   "id": 22927,
+   "text": "Quinn is the engineering manager on the delta team."
+  },
+  {
+   "id": 22928,
+   "text": "Bob is the tech lead on the ridge team."
+  },
+  {
+   "id": 22929,
+   "text": "Grace is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 22930,
+   "text": "Sam is the QA lead on the delta team."
+  },
+  {
+   "id": 22931,
+   "text": "Henry is the engineering manager on the summit team."
+  },
+  {
+   "id": 22932,
+   "text": "Kate is the QA lead on the monolith team."
+  },
+  {
+   "id": 22933,
+   "text": "Jack is the staff engineer on the compass team."
+  },
+  {
+   "id": 22934,
+   "text": "Riley is the PM on the iris team."
+  },
+  {
+   "id": 22935,
+   "text": "Carol is the principal engineer on the compass team."
+  },
+  {
+   "id": 22936,
+   "text": "Eve is the QA lead on the junction team."
+  },
+  {
+   "id": 22937,
+   "text": "Liam is the designer on the delta team."
+  },
+  {
+   "id": 22938,
+   "text": "Noah is the staff engineer on the prism team."
+  },
+  {
+   "id": 22939,
+   "text": "Dave is the PM on the junction team."
+  },
+  {
+   "id": 22940,
+   "text": "Olivia is the designer on the lattice team."
+  },
+  {
+   "id": 22941,
+   "text": "Bob is the QA lead on the monolith team."
+  },
+  {
+   "id": 22942,
+   "text": "Jack is the staff engineer on the glacier team."
+  },
+  {
+   "id": 22943,
+   "text": "Taylor is the tech lead on the atlas team."
+  },
+  {
+   "id": 22944,
+   "text": "Liam is the engineering manager on the fjord team."
+  },
+  {
+   "id": 22945,
+   "text": "Liam is the tech lead on the nexus team."
+  },
+  {
+   "id": 22946,
+   "text": "Bob is the staff engineer on the nexus team."
+  },
+  {
+   "id": 22947,
+   "text": "Liam is the QA lead on the kestrel team."
+  },
+  {
+   "id": 22948,
+   "text": "Kate is the PM on the delta team."
+  },
+  {
+   "id": 22949,
+   "text": "Mia reports to Carol."
+  },
+  {
+   "id": 22950,
+   "text": "Grace is the tech lead on the summit team."
+  },
+  {
+   "id": 22951,
+   "text": "Noah is the QA lead on the kestrel team."
+  },
+  {
+   "id": 22952,
+   "text": "Pat is the staff engineer on the nexus team."
+  },
+  {
+   "id": 22953,
+   "text": "Bob is the QA lead on the compass team."
+  },
+  {
+   "id": 22954,
+   "text": "Dave is the designer on the harbor team."
+  },
+  {
+   "id": 22955,
+   "text": "Eve is the designer on the nexus team."
+  },
+  {
+   "id": 22956,
+   "text": "Noah is the tech lead on the beacon team."
+  },
+  {
+   "id": 22957,
+   "text": "Liam is the QA lead on the delta team."
+  },
+  {
+   "id": 22958,
+   "text": "Kate is the staff engineer on the orbit team."
+  },
+  {
+   "id": 22959,
+   "text": "Alice is the QA lead on the kestrel team."
+  },
+  {
+   "id": 22960,
+   "text": "Pat is the senior engineer on the beacon team."
+  },
+  {
+   "id": 22961,
+   "text": "Sam is the designer on the tundra team."
+  },
+  {
+   "id": 22962,
+   "text": "Eve is the PM on the quartz team."
+  },
+  {
+   "id": 22963,
+   "text": "Kate reports to Eve."
+  },
+  {
+   "id": 22964,
+   "text": "Eve is on PTO from Monday to Monday."
+  },
+  {
+   "id": 22965,
+   "text": "Alice is the PM on the ridge team."
+  },
+  {
+   "id": 22966,
+   "text": "Olivia is the principal engineer on the glacier team."
+  },
+  {
+   "id": 22967,
+   "text": "Riley is the PM on the delta team."
+  },
+  {
+   "id": 22968,
+   "text": "Olivia is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 22969,
+   "text": "Carol reports to Kate."
+  },
+  {
+   "id": 22970,
+   "text": "Dave is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 22971,
+   "text": "Quinn is the PM on the quartz team."
+  },
+  {
+   "id": 22972,
+   "text": "Olivia is the senior engineer on the lattice team."
+  },
+  {
+   "id": 22973,
+   "text": "Dave is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 22974,
+   "text": "Olivia is the staff engineer on the nexus team."
+  },
+  {
+   "id": 22975,
+   "text": "Dave is the tech lead on the echo team."
+  },
+  {
+   "id": 22976,
+   "text": "Pat is the tech lead on the junction team."
+  },
+  {
+   "id": 22977,
+   "text": "Olivia is the engineering manager on the ridge team."
+  },
+  {
+   "id": 22978,
+   "text": "Frank is the PM on the lattice team."
+  },
+  {
+   "id": 22979,
+   "text": "Pat is the engineering manager on the fjord team."
+  },
+  {
+   "id": 22980,
+   "text": "Jack is the PM on the delta team."
+  },
+  {
+   "id": 22981,
+   "text": "Carol is the principal engineer on the delta team."
+  },
+  {
+   "id": 22982,
+   "text": "Mia is the engineering manager on the fjord team."
+  },
+  {
+   "id": 22983,
+   "text": "Sam is the engineering manager on the prism team."
+  },
+  {
+   "id": 22984,
+   "text": "Carol is on PTO from Tuesday to Monday."
+  },
+  {
+   "id": 22985,
+   "text": "Eve is the QA lead on the kestrel team."
+  },
+  {
+   "id": 22986,
+   "text": "Dave is the principal engineer on the atlas team."
+  },
+  {
+   "id": 22987,
+   "text": "Riley is the tech lead on the glacier team."
+  },
+  {
+   "id": 22988,
+   "text": "Bob is the engineering manager on the glacier team."
+  },
+  {
+   "id": 22989,
+   "text": "Frank is the staff engineer on the orbit team."
+  },
+  {
+   "id": 22990,
+   "text": "Riley is the engineering manager on the nexus team."
+  },
+  {
+   "id": 22991,
+   "text": "Quinn is the QA lead on the echo team."
+  },
+  {
+   "id": 22992,
+   "text": "Kate is the principal engineer on the quartz team."
+  },
+  {
+   "id": 22993,
+   "text": "Liam is the QA lead on the atlas team."
+  },
+  {
+   "id": 22994,
+   "text": "Riley is the designer on the ridge team."
+  },
+  {
+   "id": 22995,
+   "text": "Quinn reports to Riley."
+  },
+  {
+   "id": 22996,
+   "text": "Kate is the principal engineer on the echo team."
+  },
+  {
+   "id": 22997,
+   "text": "Taylor is the designer on the iris team."
+  },
+  {
+   "id": 22998,
+   "text": "Noah is the staff engineer on the monolith team."
+  },
+  {
+   "id": 22999,
+   "text": "Carol is the QA lead on the harbor team."
+  },
+  {
+   "id": 23000,
+   "text": "Henry is the engineering manager on the monolith team."
+  },
+  {
+   "id": 23001,
+   "text": "Dave is the PM on the iris team."
+  },
+  {
+   "id": 23002,
+   "text": "Mia is the PM on the quartz team."
+  },
+  {
+   "id": 23003,
+   "text": "Henry is the designer on the kestrel team."
+  },
+  {
+   "id": 23004,
+   "text": "Olivia is the engineering manager on the glacier team."
+  },
+  {
+   "id": 23005,
+   "text": "Dave is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 23006,
+   "text": "Grace is the QA lead on the atlas team."
+  },
+  {
+   "id": 23007,
+   "text": "Dave is on PTO from Tuesday to Tuesday."
+  },
+  {
+   "id": 23008,
+   "text": "Jack is the tech lead on the iris team."
+  },
+  {
+   "id": 23009,
+   "text": "Sam reports to Mia."
+  },
+  {
+   "id": 23010,
+   "text": "Liam is the staff engineer on the kestrel team."
+  },
+  {
+   "id": 23011,
+   "text": "Carol is the QA lead on the fjord team."
+  },
+  {
+   "id": 23012,
+   "text": "Alice is the designer on the monolith team."
+  },
+  {
+   "id": 23013,
+   "text": "Noah is the PM on the echo team."
+  },
+  {
+   "id": 23014,
+   "text": "Mia is the staff engineer on the echo team."
+  },
+  {
+   "id": 23015,
+   "text": "Grace is the principal engineer on the echo team."
+  },
+  {
+   "id": 23016,
+   "text": "Grace is the senior engineer on the monolith team."
+  },
+  {
+   "id": 23017,
+   "text": "Liam is the tech lead on the ridge team."
+  },
+  {
+   "id": 23018,
+   "text": "Olivia is the QA lead on the delta team."
+  },
+  {
+   "id": 23019,
+   "text": "Frank is the staff engineer on the delta team."
+  },
+  {
+   "id": 23020,
+   "text": "Frank is the designer on the summit team."
+  },
+  {
+   "id": 23021,
+   "text": "Alice is the designer on the ridge team."
+  },
+  {
+   "id": 23022,
+   "text": "Eve is the senior engineer on the compass team."
+  },
+  {
+   "id": 23023,
+   "text": "Kate is the designer on the tundra team."
+  },
+  {
+   "id": 23024,
+   "text": "Sam is the tech lead on the nexus team."
+  },
+  {
+   "id": 23025,
+   "text": "Riley is the tech lead on the nexus team."
+  },
+  {
+   "id": 23026,
+   "text": "Frank is the PM on the ridge team."
+  },
+  {
+   "id": 23027,
+   "text": "Kate is the QA lead on the glacier team."
+  },
+  {
+   "id": 23028,
+   "text": "Eve is the designer on the glacier team."
+  },
+  {
+   "id": 23029,
+   "text": "Carol is the staff engineer on the prism team."
+  },
+  {
+   "id": 23030,
+   "text": "Alice is the principal engineer on the junction team."
+  },
+  {
+   "id": 23031,
+   "text": "Alice is the staff engineer on the kestrel team."
+  },
+  {
+   "id": 23032,
+   "text": "Riley is the QA lead on the monolith team."
+  },
+  {
+   "id": 23033,
+   "text": "Riley is the principal engineer on the beacon team."
+  },
+  {
+   "id": 23034,
+   "text": "Sam is the staff engineer on the prism team."
+  },
+  {
+   "id": 23035,
+   "text": "Kate is the tech lead on the delta team."
+  },
+  {
+   "id": 23036,
+   "text": "Taylor is the staff engineer on the lattice team."
+  },
+  {
+   "id": 23037,
+   "text": "Alice is the designer on the summit team."
+  },
+  {
+   "id": 23038,
+   "text": "Noah is the engineering manager on the harbor team."
+  },
+  {
+   "id": 23039,
+   "text": "Kate reports to Jack."
+  },
+  {
+   "id": 23040,
+   "text": "Eve is the staff engineer on the fjord team."
+  },
+  {
+   "id": 23041,
+   "text": "Jack is the senior engineer on the orbit team."
+  },
+  {
+   "id": 23042,
+   "text": "Taylor is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 23043,
+   "text": "Liam is the staff engineer on the junction team."
+  },
+  {
+   "id": 23044,
+   "text": "Ivy is on PTO from Monday to Tuesday."
+  },
+  {
+   "id": 23045,
+   "text": "Kate is the tech lead on the monolith team."
+  },
+  {
+   "id": 23046,
+   "text": "Ivy is the designer on the lattice team."
+  },
+  {
+   "id": 23047,
+   "text": "Ivy is the QA lead on the lattice team."
+  },
+  {
+   "id": 23048,
+   "text": "Alice is the PM on the echo team."
+  },
+  {
+   "id": 23049,
+   "text": "Riley is the engineering manager on the echo team."
+  },
+  {
+   "id": 23050,
+   "text": "Mia is the QA lead on the orbit team."
+  },
+  {
+   "id": 23051,
+   "text": "Kate is the PM on the ridge team."
+  },
+  {
+   "id": 23052,
+   "text": "Liam is the tech lead on the prism team."
+  },
+  {
+   "id": 23053,
+   "text": "Kate is the designer on the ridge team."
+  },
+  {
+   "id": 23054,
+   "text": "Bob is the engineering manager on the orbit team."
+  },
+  {
+   "id": 23055,
+   "text": "Olivia is the PM on the tundra team."
+  },
+  {
+   "id": 23056,
+   "text": "Noah is the tech lead on the atlas team."
+  },
+  {
+   "id": 23057,
+   "text": "Olivia is the engineering manager on the junction team."
+  },
+  {
+   "id": 23058,
+   "text": "Dave is the designer on the junction team."
+  },
+  {
+   "id": 23059,
+   "text": "Henry is the tech lead on the delta team."
+  },
+  {
+   "id": 23060,
+   "text": "Alice is the tech lead on the nexus team."
+  },
+  {
+   "id": 23061,
+   "text": "Eve is the principal engineer on the tundra team."
+  },
+  {
+   "id": 23062,
+   "text": "Olivia is the PM on the compass team."
+  },
+  {
+   "id": 23063,
+   "text": "Frank is the staff engineer on the harbor team."
+  },
+  {
+   "id": 23064,
+   "text": "Pat is on PTO from Wednesday to Monday."
+  },
+  {
+   "id": 23065,
+   "text": "Henry is the QA lead on the glacier team."
+  },
+  {
+   "id": 23066,
+   "text": "Taylor is the senior engineer on the junction team."
+  },
+  {
+   "id": 23067,
+   "text": "Liam is the principal engineer on the monolith team."
+  },
+  {
+   "id": 23068,
+   "text": "Taylor is the senior engineer on the echo team."
+  },
+  {
+   "id": 23069,
+   "text": "Alice is the QA lead on the atlas team."
+  },
+  {
+   "id": 23070,
+   "text": "Eve is the staff engineer on the summit team."
+  },
+  {
+   "id": 23071,
+   "text": "Bob is the tech lead on the nexus team."
+  },
+  {
+   "id": 23072,
+   "text": "Liam is the tech lead on the kestrel team."
+  },
+  {
+   "id": 23073,
+   "text": "Sam is the QA lead on the quartz team."
+  },
+  {
+   "id": 23074,
+   "text": "Taylor is the principal engineer on the tundra team."
+  },
+  {
+   "id": 23075,
+   "text": "Henry is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 23076,
+   "text": "Noah is the senior engineer on the quartz team."
+  },
+  {
+   "id": 23077,
+   "text": "Quinn is the principal engineer on the kestrel team."
+  },
+  {
+   "id": 23078,
+   "text": "Liam is the tech lead on the glacier team."
+  },
+  {
+   "id": 23079,
+   "text": "Alice is the QA lead on the iris team."
+  },
+  {
+   "id": 23080,
+   "text": "Kate is the principal engineer on the monolith team."
+  },
+  {
+   "id": 23081,
+   "text": "Mia is the PM on the beacon team."
+  },
+  {
+   "id": 23082,
+   "text": "Taylor is the senior engineer on the orbit team."
+  },
+  {
+   "id": 23083,
+   "text": "Ivy is the senior engineer on the glacier team."
+  },
+  {
+   "id": 23084,
+   "text": "Bob is the senior engineer on the compass team."
+  },
+  {
+   "id": 23085,
+   "text": "Noah is the principal engineer on the beacon team."
+  },
+  {
+   "id": 23086,
+   "text": "Grace is the QA lead on the glacier team."
+  },
+  {
+   "id": 23087,
+   "text": "Quinn is the designer on the compass team."
+  },
+  {
+   "id": 23088,
+   "text": "Henry is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 23089,
+   "text": "Henry is the tech lead on the tundra team."
+  },
+  {
+   "id": 23090,
+   "text": "Bob is on PTO from Friday to Monday."
+  },
+  {
+   "id": 23091,
+   "text": "Kate is on PTO from Tuesday to Thursday."
+  },
+  {
+   "id": 23092,
+   "text": "Noah is the QA lead on the nexus team."
+  },
+  {
+   "id": 23093,
+   "text": "Olivia is the senior engineer on the atlas team."
+  },
+  {
+   "id": 23094,
+   "text": "Grace is the designer on the tundra team."
+  },
+  {
+   "id": 23095,
+   "text": "Frank is the principal engineer on the harbor team."
+  },
+  {
+   "id": 23096,
+   "text": "Sam is the principal engineer on the prism team."
+  },
+  {
+   "id": 23097,
+   "text": "Dave is the designer on the kestrel team."
+  },
+  {
+   "id": 23098,
+   "text": "Sam is the QA lead on the fjord team."
+  },
+  {
+   "id": 23099,
+   "text": "Project nexus uses PostgreSQL for primary storage."
+  },
+  {
+   "id": 23100,
+   "text": "Taylor is the principal engineer on the harbor team."
+  },
+  {
+   "id": 23101,
+   "text": "Riley reports to Grace."
+  },
+  {
+   "id": 23102,
+   "text": "Olivia is the tech lead on the orbit team."
+  },
+  {
+   "id": 23103,
+   "text": "Sam is the principal engineer on the lattice team."
+  },
+  {
+   "id": 23104,
+   "text": "Riley is the tech lead on the tundra team."
+  },
+  {
+   "id": 23105,
+   "text": "Taylor is the engineering manager on the nexus team."
+  },
+  {
+   "id": 23106,
+   "text": "Pat is the engineering manager on the tundra team."
+  },
+  {
+   "id": 23107,
+   "text": "Grace is the PM on the harbor team."
+  },
+  {
+   "id": 23108,
+   "text": "Riley is the senior engineer on the summit team."
+  },
+  {
+   "id": 23109,
+   "text": "Bob is the designer on the ridge team."
+  },
+  {
+   "id": 23110,
+   "text": "Liam is the engineering manager on the orbit team."
+  },
+  {
+   "id": 23111,
+   "text": "Mia is the PM on the iris team."
+  },
+  {
+   "id": 23112,
+   "text": "Mia is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 23113,
+   "text": "Eve is the QA lead on the orbit team."
+  },
+  {
+   "id": 23114,
+   "text": "Liam is the QA lead on the tundra team."
+  },
+  {
+   "id": 23115,
+   "text": "Dave is the staff engineer on the orbit team."
+  },
+  {
+   "id": 23116,
+   "text": "Alice is the principal engineer on the delta team."
+  },
+  {
+   "id": 23117,
+   "text": "Ivy is on PTO from Thursday to Tuesday."
+  },
+  {
+   "id": 23118,
+   "text": "Sam is the PM on the compass team."
+  },
+  {
+   "id": 23119,
+   "text": "Carol is the principal engineer on the summit team."
+  },
+  {
+   "id": 23120,
+   "text": "Liam is on PTO from Friday to Thursday."
+  },
+  {
+   "id": 23121,
+   "text": "Carol is the principal engineer on the junction team."
+  },
+  {
+   "id": 23122,
+   "text": "Dave is the QA lead on the iris team."
+  },
+  {
+   "id": 23123,
+   "text": "Taylor is the QA lead on the quartz team."
+  },
+  {
+   "id": 23124,
+   "text": "Alice is the PM on the summit team."
+  },
+  {
+   "id": 23125,
+   "text": "Frank is on PTO from Monday to Wednesday."
+  },
+  {
+   "id": 23126,
+   "text": "Project tundra uses ClickHouse for analytics."
+  },
+  {
+   "id": 23127,
+   "text": "Project ridge uses Rust for performance-critical paths."
+  },
+  {
+   "id": 23128,
+   "text": "Sam is the PM on the beacon team."
+  },
+  {
+   "id": 23129,
+   "text": "Quinn is the engineering manager on the tundra team."
+  },
+  {
+   "id": 23130,
+   "text": "Ivy is on PTO from Friday to Wednesday."
+  },
+  {
+   "id": 23131,
+   "text": "Bob is the QA lead on the quartz team."
+  },
+  {
+   "id": 23132,
+   "text": "Bob is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 23133,
+   "text": "Henry is the designer on the echo team."
+  },
+  {
+   "id": 23134,
+   "text": "Liam is the PM on the glacier team."
+  },
+  {
+   "id": 23135,
+   "text": "Taylor is the staff engineer on the tundra team."
+  },
+  {
+   "id": 23136,
+   "text": "Quinn is the QA lead on the tundra team."
+  },
+  {
+   "id": 23137,
+   "text": "Kate is the senior engineer on the monolith team."
+  },
+  {
+   "id": 23138,
+   "text": "Taylor is the designer on the harbor team."
+  },
+  {
+   "id": 23139,
+   "text": "Mia is the QA lead on the nexus team."
+  },
+  {
+   "id": 23140,
+   "text": "Kate reports to Grace."
+  },
+  {
+   "id": 23141,
+   "text": "Liam is the QA lead on the glacier team."
+  },
+  {
+   "id": 23142,
+   "text": "Olivia is on PTO from Friday to Monday."
+  },
+  {
+   "id": 23143,
+   "text": "Grace is the QA lead on the junction team."
+  },
+  {
+   "id": 23144,
+   "text": "Eve is the staff engineer on the lattice team."
+  },
+  {
+   "id": 23145,
+   "text": "Olivia is the QA lead on the harbor team."
+  },
+  {
+   "id": 23146,
+   "text": "Pat is the senior engineer on the summit team."
+  },
+  {
+   "id": 23147,
+   "text": "Dave is the tech lead on the lattice team."
+  },
+  {
+   "id": 23148,
+   "text": "Sam is the engineering manager on the glacier team."
+  },
+  {
+   "id": 23149,
+   "text": "Mia is the engineering manager on the summit team."
+  },
+  {
+   "id": 23150,
+   "text": "Grace is the PM on the prism team."
+  },
+  {
+   "id": 23151,
+   "text": "Dave is the QA lead on the atlas team."
+  },
+  {
+   "id": 23152,
+   "text": "Sam reports to Ivy."
+  },
+  {
+   "id": 23153,
+   "text": "Kate is the principal engineer on the harbor team."
+  },
+  {
+   "id": 23154,
+   "text": "Noah is the engineering manager on the tundra team."
+  },
+  {
+   "id": 23155,
+   "text": "Eve is the principal engineer on the kestrel team."
+  },
+  {
+   "id": 23156,
+   "text": "Ivy is the engineering manager on the atlas team."
+  },
+  {
+   "id": 23157,
+   "text": "Grace is the engineering manager on the ridge team."
+  },
+  {
+   "id": 23158,
+   "text": "Kate is the PM on the atlas team."
+  },
+  {
+   "id": 23159,
+   "text": "Frank is the staff engineer on the tundra team."
+  },
+  {
+   "id": 23160,
+   "text": "Carol is the tech lead on the orbit team."
+  },
+  {
+   "id": 23161,
+   "text": "Riley is the engineering manager on the compass team."
+  },
+  {
+   "id": 23162,
+   "text": "Grace is the staff engineer on the nexus team."
+  },
+  {
+   "id": 23163,
+   "text": "Carol is the QA lead on the nexus team."
+  },
+  {
+   "id": 23164,
+   "text": "Grace is the QA lead on the delta team."
+  },
+  {
+   "id": 23165,
+   "text": "Eve is the PM on the glacier team."
+  },
+  {
+   "id": 23166,
+   "text": "Sam is the QA lead on the echo team."
+  },
+  {
+   "id": 23167,
+   "text": "Jack is the staff engineer on the prism team."
+  },
+  {
+   "id": 23168,
+   "text": "Alice is the senior engineer on the glacier team."
+  },
+  {
+   "id": 23169,
+   "text": "Kate is the designer on the summit team."
+  },
+  {
+   "id": 23170,
+   "text": "Eve is the engineering manager on the prism team."
+  },
+  {
+   "id": 23171,
+   "text": "Henry is the engineering manager on the junction team."
+  },
+  {
+   "id": 23172,
+   "text": "Eve is the designer on the beacon team."
+  },
+  {
+   "id": 23173,
+   "text": "Noah is the senior engineer on the lattice team."
+  },
+  {
+   "id": 23174,
+   "text": "Eve is the tech lead on the delta team."
+  },
+  {
+   "id": 23175,
+   "text": "Frank is the designer on the harbor team."
+  },
+  {
+   "id": 23176,
+   "text": "Noah is the tech lead on the nexus team."
+  },
+  {
+   "id": 23177,
+   "text": "Taylor is the principal engineer on the beacon team."
+  },
+  {
+   "id": 23178,
+   "text": "Mia is the principal engineer on the beacon team."
+  },
+  {
+   "id": 23179,
+   "text": "Riley is the senior engineer on the kestrel team."
+  },
+  {
+   "id": 23180,
+   "text": "Carol is the principal engineer on the orbit team."
+  },
+  {
+   "id": 23181,
+   "text": "Frank is the tech lead on the echo team."
+  },
+  {
+   "id": 23182,
+   "text": "Jack is the QA lead on the tundra team."
+  },
+  {
+   "id": 23183,
+   "text": "Olivia is the principal engineer on the monolith team."
+  },
+  {
+   "id": 23184,
+   "text": "Olivia is the engineering manager on the prism team."
+  },
+  {
+   "id": 23185,
+   "text": "Dave is the engineering manager on the quartz team."
+  },
+  {
+   "id": 23186,
+   "text": "Ivy is the senior engineer on the harbor team."
+  },
+  {
+   "id": 23187,
+   "text": "Mia is the designer on the tundra team."
+  },
+  {
+   "id": 23188,
+   "text": "Bob is the engineering manager on the kestrel team."
+  },
+  {
+   "id": 23189,
+   "text": "Pat reports to Mia."
+  },
+  {
+   "id": 23190,
+   "text": "Bob is the engineering manager on the atlas team."
+  },
+  {
+   "id": 23191,
+   "text": "Eve is the senior engineer on the orbit team."
+  },
+  {
+   "id": 23192,
+   "text": "Mia is the PM on the atlas team."
+  },
+  {
+   "id": 23193,
+   "text": "Quinn is the senior engineer on the beacon team."
+  },
+  {
+   "id": 23194,
+   "text": "Ivy is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 23195,
+   "text": "Mia is the principal engineer on the orbit team."
+  },
+  {
+   "id": 23196,
+   "text": "Sam is the principal engineer on the harbor team."
+  },
+  {
+   "id": 23197,
+   "text": "Quinn is the senior engineer on the prism team."
+  },
+  {
+   "id": 23198,
+   "text": "Ivy is the senior engineer on the compass team."
+  },
+  {
+   "id": 23199,
+   "text": "Bob is the senior engineer on the beacon team."
+  },
+  {
+   "id": 23200,
+   "text": "Ivy is the designer on the harbor team."
+  },
+  {
+   "id": 23201,
+   "text": "Pat is the designer on the fjord team."
+  },
+  {
+   "id": 23202,
+   "text": "Carol is the QA lead on the iris team."
+  },
+  {
+   "id": 23203,
+   "text": "Taylor is the QA lead on the lattice team."
+  },
+  {
+   "id": 23204,
+   "text": "Riley is the PM on the ridge team."
+  },
+  {
+   "id": 23205,
+   "text": "Sam is the designer on the prism team."
+  },
+  {
+   "id": 23206,
+   "text": "Alice is the tech lead on the harbor team."
+  },
+  {
+   "id": 23207,
+   "text": "Alice is the principal engineer on the kestrel team."
+  },
+  {
+   "id": 23208,
+   "text": "Noah is the principal engineer on the lattice team."
+  },
+  {
+   "id": 23209,
+   "text": "Riley is the QA lead on the glacier team."
+  },
+  {
+   "id": 23210,
+   "text": "Kate is the PM on the nexus team."
+  },
+  {
+   "id": 23211,
+   "text": "Quinn is the PM on the ridge team."
+  },
+  {
+   "id": 23212,
+   "text": "Henry is the PM on the glacier team."
+  },
+  {
+   "id": 23213,
+   "text": "Frank is the QA lead on the nexus team."
+  },
+  {
+   "id": 23214,
+   "text": "Carol is the designer on the compass team."
+  },
+  {
+   "id": 23215,
+   "text": "Liam is the QA lead on the beacon team."
+  },
+  {
+   "id": 23216,
+   "text": "Project compass uses Next.js for server-side rendering."
+  },
+  {
+   "id": 23217,
+   "text": "Liam is the tech lead on the harbor team."
+  },
+  {
+   "id": 23218,
+   "text": "Sam is the designer on the delta team."
+  },
+  {
+   "id": 23219,
+   "text": "Grace is the designer on the atlas team."
+  },
+  {
+   "id": 23220,
+   "text": "Alice is the QA lead on the lattice team."
+  },
+  {
+   "id": 23221,
+   "text": "Noah is the designer on the echo team."
+  },
+  {
+   "id": 23222,
+   "text": "Taylor is the staff engineer on the monolith team."
+  },
+  {
+   "id": 23223,
+   "text": "Olivia is the senior engineer on the iris team."
+  },
+  {
+   "id": 23224,
+   "text": "Ivy is the engineering manager on the tundra team."
+  },
+  {
+   "id": 23225,
+   "text": "Olivia is the staff engineer on the tundra team."
+  },
+  {
+   "id": 23226,
+   "text": "Pat is the engineering manager on the kestrel team."
+  },
+  {
+   "id": 23227,
+   "text": "Noah is the QA lead on the ridge team."
+  },
+  {
+   "id": 23228,
+   "text": "Carol is the staff engineer on the quartz team."
+  },
+  {
+   "id": 23229,
+   "text": "Taylor is on PTO from Wednesday to Friday."
+  },
+  {
+   "id": 23230,
+   "text": "Jack is on PTO from Tuesday to Wednesday."
+  },
+  {
+   "id": 23231,
+   "text": "Henry is the senior engineer on the atlas team."
+  },
+  {
+   "id": 23232,
+   "text": "Sam is the tech lead on the compass team."
+  },
+  {
+   "id": 23233,
+   "text": "Quinn is the staff engineer on the harbor team."
+  },
+  {
+   "id": 23234,
+   "text": "Carol is the QA lead on the glacier team."
+  },
+  {
+   "id": 23235,
+   "text": "Kate is the PM on the kestrel team."
+  },
+  {
+   "id": 23236,
+   "text": "Dave is the staff engineer on the fjord team."
+  },
+  {
+   "id": 23237,
+   "text": "Ivy is the principal engineer on the nexus team."
+  },
+  {
+   "id": 23238,
+   "text": "Pat is the engineering manager on the atlas team."
+  },
+  {
+   "id": 23239,
+   "text": "Noah is the QA lead on the compass team."
+  },
+  {
+   "id": 23240,
+   "text": "Frank is the QA lead on the quartz team."
+  },
+  {
+   "id": 23241,
+   "text": "Carol is the principal engineer on the tundra team."
+  },
+  {
+   "id": 23242,
+   "text": "Henry is the staff engineer on the beacon team."
+  },
+  {
+   "id": 23243,
+   "text": "Dave is the staff engineer on the summit team."
+  },
+  {
+   "id": 23244,
+   "text": "Henry is the tech lead on the harbor team."
+  },
+  {
+   "id": 23245,
+   "text": "Jack is the designer on the quartz team."
+  },
+  {
+   "id": 23246,
+   "text": "Carol is the designer on the tundra team."
+  },
+  {
+   "id": 23247,
+   "text": "Dave is on PTO from Thursday to Wednesday."
+  },
+  {
+   "id": 23248,
+   "text": "Carol is the QA lead on the prism team."
+  },
+  {
+   "id": 23249,
+   "text": "Olivia is the QA lead on the tundra team."
+  },
+  {
+   "id": 23250,
+   "text": "Eve is the senior engineer on the prism team."
+  },
+  {
+   "id": 23251,
+   "text": "Bob is the senior engineer on the summit team."
+  },
+  {
+   "id": 23252,
+   "text": "Eve is the tech lead on the orbit team."
+  },
+  {
+   "id": 23253,
+   "text": "Kate is the PM on the compass team."
+  },
+  {
+   "id": 23254,
+   "text": "Henry is the QA lead on the tundra team."
+  },
+  {
+   "id": 23255,
+   "text": "Jack is the principal engineer on the nexus team."
+  },
+  {
+   "id": 23256,
+   "text": "Ivy is on PTO from Tuesday to Friday."
+  },
+  {
+   "id": 23257,
+   "text": "Alice reports to Jack."
+  },
+  {
+   "id": 23258,
+   "text": "Eve is the tech lead on the monolith team."
+  },
+  {
+   "id": 23259,
+   "text": "Liam is the principal engineer on the tundra team."
+  },
+  {
+   "id": 23260,
+   "text": "Taylor is the senior engineer on the atlas team."
+  },
+  {
+   "id": 23261,
+   "text": "Quinn is the designer on the iris team."
+  },
+  {
+   "id": 23262,
+   "text": "Olivia is the tech lead on the delta team."
+  },
+  {
+   "id": 23263,
+   "text": "Riley is the principal engineer on the compass team."
+  },
+  {
+   "id": 23264,
+   "text": "Bob is the senior engineer on the junction team."
+  },
+  {
+   "id": 23265,
+   "text": "Dave is the QA lead on the orbit team."
+  },
+  {
+   "id": 23266,
+   "text": "Carol is the engineering manager on the summit team."
+  },
+  {
+   "id": 23267,
+   "text": "Olivia is the staff engineer on the monolith team."
+  },
+  {
+   "id": 23268,
+   "text": "Sam is the tech lead on the prism team."
+  },
+  {
+   "id": 23269,
+   "text": "Olivia is the tech lead on the atlas team."
+  },
+  {
+   "id": 23270,
+   "text": "Liam is the PM on the summit team."
+  },
+  {
+   "id": 23271,
+   "text": "Carol is the QA lead on the ridge team."
+  },
+  {
+   "id": 23272,
+   "text": "Eve is the QA lead on the harbor team."
+  },
+  {
+   "id": 23273,
+   "text": "Frank is the QA lead on the fjord team."
+  },
+  {
+   "id": 23274,
+   "text": "Kate is the tech lead on the echo team."
+  },
+  {
+   "id": 23275,
+   "text": "Olivia is the tech lead on the lattice team."
+  },
+  {
+   "id": 23276,
+   "text": "Quinn is the principal engineer on the fjord team."
+  },
+  {
+   "id": 23277,
+   "text": "Bob is the tech lead on the fjord team."
+  },
+  {
+   "id": 23278,
+   "text": "Grace is the principal engineer on the prism team."
+  },
+  {
+   "id": 23279,
+   "text": "Sam is the PM on the lattice team."
+  },
+  {
+   "id": 23280,
+   "text": "Henry is the senior engineer on the harbor team."
+  },
+  {
+   "id": 23281,
+   "text": "Noah is the QA lead on the orbit team."
+  },
+  {
+   "id": 23282,
+   "text": "Mia is the senior engineer on the harbor team."
+  },
+  {
+   "id": 23283,
+   "text": "Carol is the designer on the harbor team."
+  },
+  {
+   "id": 23284,
+   "text": "Jack is the QA lead on the junction team."
+  },
+  {
+   "id": 23285,
+   "text": "Grace is the QA lead on the echo team."
+  },
+  {
+   "id": 23286,
+   "text": "Noah is the staff engineer on the atlas team."
+  },
+  {
+   "id": 23287,
+   "text": "Riley is the principal engineer on the lattice team."
+  },
+  {
+   "id": 23288,
+   "text": "Henry is the principal engineer on the kestrel team."
+  },
+  {
+   "id": 23289,
+   "text": "Riley is the staff engineer on the quartz team."
+  },
+  {
+   "id": 23290,
+   "text": "Riley is the principal engineer on the summit team."
+  },
+  {
+   "id": 23291,
+   "text": "Quinn is the PM on the kestrel team."
+  },
+  {
+   "id": 23292,
+   "text": "Quinn is the tech lead on the fjord team."
+  },
+  {
+   "id": 23293,
+   "text": "Eve is the designer on the prism team."
+  },
+  {
+   "id": 23294,
+   "text": "Ivy is the staff engineer on the monolith team."
+  },
+  {
+   "id": 23295,
+   "text": "Mia is the tech lead on the fjord team."
+  },
+  {
+   "id": 23296,
+   "text": "Dave is the tech lead on the ridge team."
+  },
+  {
+   "id": 23297,
+   "text": "Sam is the QA lead on the iris team."
+  },
+  {
+   "id": 23298,
+   "text": "Dave is the designer on the glacier team."
+  },
+  {
+   "id": 23299,
+   "text": "Frank is the engineering manager on the ridge team."
+  },
+  {
+   "id": 23300,
+   "text": "Noah is the principal engineer on the prism team."
+  },
+  {
+   "id": 23301,
+   "text": "Mia is the principal engineer on the kestrel team."
+  },
+  {
+   "id": 23302,
+   "text": "Pat is the engineering manager on the prism team."
+  },
+  {
+   "id": 23303,
+   "text": "Grace is on PTO from Friday to Tuesday."
+  },
+  {
+   "id": 23304,
+   "text": "Henry is the senior engineer on the beacon team."
+  },
+  {
+   "id": 23305,
+   "text": "Alice is the tech lead on the tundra team."
+  },
+  {
+   "id": 23306,
+   "text": "Dave is the designer on the summit team."
+  },
+  {
+   "id": 23307,
+   "text": "Alice is the principal engineer on the compass team."
+  },
+  {
+   "id": 23308,
+   "text": "Ivy is the senior engineer on the iris team."
+  },
+  {
+   "id": 23309,
+   "text": "Jack is the designer on the fjord team."
+  },
+  {
+   "id": 23310,
+   "text": "Ivy is the tech lead on the ridge team."
+  },
+  {
+   "id": 23311,
+   "text": "Riley is the designer on the tundra team."
+  },
+  {
+   "id": 23312,
+   "text": "Grace is the staff engineer on the beacon team."
+  },
+  {
+   "id": 23313,
+   "text": "Taylor is the tech lead on the delta team."
+  },
+  {
+   "id": 23314,
+   "text": "Bob is the QA lead on the summit team."
+  },
+  {
+   "id": 23315,
+   "text": "Project lattice uses Kafka for event streaming."
+  },
+  {
+   "id": 23316,
+   "text": "Mia is the principal engineer on the fjord team."
+  },
+  {
+   "id": 23317,
+   "text": "Frank is the PM on the nexus team."
+  },
+  {
+   "id": 23318,
+   "text": "Kate is the senior engineer on the iris team."
+  },
+  {
+   "id": 23319,
+   "text": "Alice is the staff engineer on the orbit team."
+  },
+  {
+   "id": 23320,
+   "text": "Bob is the QA lead on the orbit team."
+  },
+  {
+   "id": 23321,
+   "text": "Noah is the QA lead on the fjord team."
+  },
+  {
+   "id": 23322,
+   "text": "Noah is the engineering manager on the lattice team."
+  },
+  {
+   "id": 23323,
+   "text": "Henry is the PM on the harbor team."
+  },
+  {
+   "id": 23324,
+   "text": "Sam is the QA lead on the monolith team."
+  },
+  {
+   "id": 23325,
+   "text": "Eve is the tech lead on the nexus team."
+  },
+  {
+   "id": 23326,
+   "text": "Kate is the QA lead on the tundra team."
+  },
+  {
+   "id": 23327,
+   "text": "Kate is the designer on the quartz team."
+  },
+  {
+   "id": 23328,
+   "text": "Olivia is the staff engineer on the ridge team."
+  },
+  {
+   "id": 23329,
+   "text": "Eve is the engineering manager on the monolith team."
+  },
+  {
+   "id": 23330,
+   "text": "Mia is the staff engineer on the harbor team."
+  },
+  {
+   "id": 23331,
+   "text": "Bob is the PM on the orbit team."
+  },
+  {
+   "id": 23332,
+   "text": "Olivia is the designer on the kestrel team."
+  },
+  {
+   "id": 23333,
+   "text": "Carol is the senior engineer on the prism team."
+  },
+  {
+   "id": 23334,
+   "text": "Mia is the tech lead on the atlas team."
+  },
+  {
+   "id": 23335,
+   "text": "Project harbor uses React for the frontend."
+  },
+  {
+   "id": 23336,
+   "text": "Henry is the senior engineer on the monolith team."
+  },
+  {
+   "id": 23337,
+   "text": "Grace is the tech lead on the delta team."
+  },
+  {
+   "id": 23338,
+   "text": "Kate is the designer on the harbor team."
+  },
+  {
+   "id": 23339,
+   "text": "Frank is on PTO from Wednesday to Tuesday."
+  },
+  {
+   "id": 23340,
+   "text": "Olivia is the QA lead on the compass team."
+  },
+  {
+   "id": 23341,
+   "text": "Ivy is the QA lead on the prism team."
+  },
+  {
+   "id": 23342,
+   "text": "Bob is the engineering manager on the echo team."
+  },
+  {
+   "id": 23343,
+   "text": "Olivia is the tech lead on the tundra team."
+  },
+  {
+   "id": 23344,
+   "text": "Olivia is the senior engineer on the fjord team."
+  },
+  {
+   "id": 23345,
+   "text": "Henry is the staff engineer on the glacier team."
+  },
+  {
+   "id": 23346,
+   "text": "Mia is the engineering manager on the compass team."
+  },
+  {
+   "id": 23347,
+   "text": "Henry is the senior engineer on the tundra team."
+  },
+  {
+   "id": 23348,
+   "text": "Liam is the tech lead on the delta team."
+  },
+  {
+   "id": 23349,
+   "text": "Dave is the designer on the atlas team."
+  },
+  {
+   "id": 23350,
+   "text": "Dave is the staff engineer on the prism team."
+  },
+  {
+   "id": 23351,
+   "text": "Mia is the tech lead on the glacier team."
+  },
+  {
+   "id": 23352,
+   "text": "Noah is the QA lead on the glacier team."
+  }
+ ],
+ "gate": "hermes-plugin/competing-distractors",
+ "note": "Distractors are drawn from the SAME generators as the answers, so most records share a sentence frame and differ by one entity token. This is a stress corpus, not a representative one: it exists to make bm25 degenerate and to destroy relation direction under cosine.",
+ "version": "1.0.0"
+}

--- a/tests/comparison/fixtures/direction_probes_v1_1.json
+++ b/tests/comparison/fixtures/direction_probes_v1_1.json
@@ -1,0 +1,120 @@
+{
+ "built_from": "corpus_4353_gate_v1.json",
+ "note": "Ground truth is role position, not record identity: this corpus gives each person many managers on purpose, so no single record is 'the' answer. Scoring by role share is what makes the subset valid on a corpus built to be degenerate.",
+ "probes": [
+  {
+   "entity": "Alice",
+   "n_object_records": 19,
+   "n_subject_records": 19,
+   "query_object": "Who reports to Alice?",
+   "query_plain": "What is Alice s manager?",
+   "query_possessive": "What is Alice's manager?",
+   "query_subject": "Who does Alice report to?"
+  },
+  {
+   "entity": "Bob",
+   "n_object_records": 18,
+   "n_subject_records": 19,
+   "query_object": "Who reports to Bob?",
+   "query_plain": "What is Bob s manager?",
+   "query_possessive": "What is Bob's manager?",
+   "query_subject": "Who does Bob report to?"
+  },
+  {
+   "entity": "Carol",
+   "n_object_records": 18,
+   "n_subject_records": 19,
+   "query_object": "Who reports to Carol?",
+   "query_plain": "What is Carol s manager?",
+   "query_possessive": "What is Carol's manager?",
+   "query_subject": "Who does Carol report to?"
+  },
+  {
+   "entity": "Dave",
+   "n_object_records": 19,
+   "n_subject_records": 19,
+   "query_object": "Who reports to Dave?",
+   "query_plain": "What is Dave s manager?",
+   "query_possessive": "What is Dave's manager?",
+   "query_subject": "Who does Dave report to?"
+  },
+  {
+   "entity": "Eve",
+   "n_object_records": 19,
+   "n_subject_records": 19,
+   "query_object": "Who reports to Eve?",
+   "query_plain": "What is Eve s manager?",
+   "query_possessive": "What is Eve's manager?",
+   "query_subject": "Who does Eve report to?"
+  },
+  {
+   "entity": "Frank",
+   "n_object_records": 19,
+   "n_subject_records": 19,
+   "query_object": "Who reports to Frank?",
+   "query_plain": "What is Frank s manager?",
+   "query_possessive": "What is Frank's manager?",
+   "query_subject": "Who does Frank report to?"
+  },
+  {
+   "entity": "Grace",
+   "n_object_records": 19,
+   "n_subject_records": 19,
+   "query_object": "Who reports to Grace?",
+   "query_plain": "What is Grace s manager?",
+   "query_possessive": "What is Grace's manager?",
+   "query_subject": "Who does Grace report to?"
+  },
+  {
+   "entity": "Henry",
+   "n_object_records": 19,
+   "n_subject_records": 18,
+   "query_object": "Who reports to Henry?",
+   "query_plain": "What is Henry s manager?",
+   "query_possessive": "What is Henry's manager?",
+   "query_subject": "Who does Henry report to?"
+  },
+  {
+   "entity": "Ivy",
+   "n_object_records": 19,
+   "n_subject_records": 17,
+   "query_object": "Who reports to Ivy?",
+   "query_plain": "What is Ivy s manager?",
+   "query_possessive": "What is Ivy's manager?",
+   "query_subject": "Who does Ivy report to?"
+  },
+  {
+   "entity": "Jack",
+   "n_object_records": 18,
+   "n_subject_records": 19,
+   "query_object": "Who reports to Jack?",
+   "query_plain": "What is Jack s manager?",
+   "query_possessive": "What is Jack's manager?",
+   "query_subject": "Who does Jack report to?"
+  },
+  {
+   "entity": "Kate",
+   "n_object_records": 19,
+   "n_subject_records": 19,
+   "query_object": "Who reports to Kate?",
+   "query_plain": "What is Kate s manager?",
+   "query_possessive": "What is Kate's manager?",
+   "query_subject": "Who does Kate report to?"
+  },
+  {
+   "entity": "Liam",
+   "n_object_records": 18,
+   "n_subject_records": 18,
+   "query_object": "Who reports to Liam?",
+   "query_plain": "What is Liam s manager?",
+   "query_possessive": "What is Liam's manager?",
+   "query_subject": "Who does Liam report to?"
+  }
+ ],
+ "scoring": {
+  "direction_separation": "mean over probes of (subject-role share in query_subject top-k) minus (subject-role share in query_object top-k). 0.0 = direction fully lost; 1.0 = perfectly separated. Reported SEPARATELY from overall precision so a candidate cannot look good by winning easy queries.",
+  "possessive_jaccard": "Jaccard overlap of top-k result sets for query_possessive vs query_plain. The two strings are IDENTICAL except that one apostrophe becomes a space, so 1.0 is correct and any lower value isolates the tokenize() apostrophe exemption. Deliberately a minimal pair: comparing differently-worded queries would conflate the defect with rewording."
+ },
+ "subset": "direction-sensitivity + possessive",
+ "version": "1.1.0"
+}

--- a/tests/comparison/gate_4k.py
+++ b/tests/comparison/gate_4k.py
@@ -1,0 +1,279 @@
+"""The competing-distractor gate — the one both sides run against a candidate wheel.
+
+This is a STRESS corpus, deliberately pathological, and that is the point. Its
+distractors come from the same generators as its answers, so ~3,000 records
+share five sentence frames and differ by a single entity token. Two properties
+follow, and they are what the gate exists to measure:
+
+  1. BM25 goes degenerate. 143 records match `taylor`; they carry 4 distinct
+     bm25 values. Every matcher gets lex = 1.0, so a boost that is monotone in
+     lex is constant across the matched set and cannot reorder within it.
+  2. Cosine loses relation DIRECTION. Under potion-2M, "Pat reports to Taylor"
+     scores 0.749 against the query `taylor` while "Taylor reports to Carol"
+     scores 0.439 — subject position ranks below object position.
+
+Real memory is less uniform than this (a 4,353-record production database
+scores 3/4 on the same probes), so treat a regression here as a signal about
+mechanism, not a forecast of field precision. Weight a production-clone gate
+above this one for any user-facing claim.
+
+Corpus and queries are hash-pinned so iterations across candidate wheels stay
+comparable. If a hash check fails, the gate refuses to run rather than quietly
+reporting numbers from a different corpus.
+
+Run:
+    python tests/comparison/gate_4k.py                 # precision + diagnostics
+    python tests/comparison/gate_4k.py --pool-sweep    # + cross-encoder sweep
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+FIXTURES = Path(__file__).parent / "fixtures"
+CORPUS = FIXTURES / "corpus_4353_gate_v1.json"
+QUERIES = FIXTURES / "queries_1k.json"
+
+# Pinned at gate v1.0.0. A candidate wheel that changes retrieval must be
+# measured against the same bytes the previous candidate was measured against.
+CORPUS_SHA256 = "2d2d039094644ce5b2a1d8de5047daa5b4a183e98919bdae3a57a67962df4fc9"
+QUERIES_SHA256 = "a4b866a5bdeccfb103b25d2cf1a66a1ca50af9096ccb55bf73579f676f4b407f"
+
+# Seeding is async; measuring before the write queue drains reports compaction
+# noise as retrieval quality. Learned the hard way — see benchmarks/.
+DRAIN_SECONDS = 30
+
+
+def _load() -> tuple[list[dict], list[dict]]:
+    cblob = CORPUS.read_text(encoding="utf-8")
+    qblob = QUERIES.read_text(encoding="utf-8")
+    for name, blob, want in (("corpus", cblob, CORPUS_SHA256),
+                             ("queries", qblob, QUERIES_SHA256)):
+        got = hashlib.sha256(blob.encode("utf-8")).hexdigest()
+        if got != want:
+            raise SystemExit(
+                f"{name} hash mismatch — this is not gate v1.0.0.\n"
+                f"  expected {want}\n  actual   {got}\n"
+                "Numbers from a drifted corpus are not comparable to prior runs."
+            )
+    return json.loads(cblob)["facts"], json.loads(qblob)["queries"]
+
+
+def _seed(facts: list[dict], db_path: str):
+    from yantrikdb._yantrikdb_rust import YantrikDB
+    db = YantrikDB.with_default(db_path)
+    for f in facts:
+        while True:
+            try:
+                db.record_text(f["text"], memory_type="semantic", namespace="g")
+                break
+            except Exception as e:  # noqa: BLE001 — backpressure is expected at this rate
+                if "queue full" in str(e) or "Backpressure" in type(e).__name__:
+                    time.sleep(0.02)
+                    continue
+                raise
+    time.sleep(DRAIN_SECONDS)
+    return db
+
+
+def _measure(fn, queries: list[dict], label: str) -> dict:
+    hits, lat = 0, []
+    for q in queries:
+        t0 = time.perf_counter()
+        got = fn(q["query"], q.get("top_k", 5))
+        lat.append((time.perf_counter() - t0) * 1000)
+        tgt = (q.get("target_text") or "").strip()
+        if tgt and any(tgt in g or g in tgt for g in got):
+            hits += 1
+    return {"config": label,
+            "precision_at_5": round(hits / len(queries), 3),
+            "p50_ms": round(statistics.median(lat), 1)}
+
+
+def _degeneracy(db_path: str, term: str = "taylor") -> dict:
+    """The measurement that distinguishes a set-level promoter from a ranker.
+
+    If distinct_bm25 / matched is near zero, the lexical lane has no remaining
+    signal to discriminate WITHIN the matched set, and any boost monotone in
+    lex leaves cosine to decide the order by itself.
+    """
+    con = sqlite3.connect(db_path)
+    rows = con.execute(
+        "SELECT memories_fts.rank, length(m.text) FROM memories m "
+        "JOIN memories_fts ON memories_fts.rowid = m.rowid "
+        "WHERE memories_fts MATCH ? AND m.consolidation_status='active' "
+        "ORDER BY rank", (term,)).fetchall()
+    if not rows:
+        return {"term": term, "matched": 0}
+    ranks = [r[0] for r in rows]
+    distinct = len({round(r, 6) for r in ranks})
+    best = min(ranks)  # fts5 rank is negative; best == most negative
+    tied_at_best = sum(1 for r in ranks if round(r, 6) == round(best, 6))
+    return {"term": term, "matched": len(rows), "distinct_bm25": distinct,
+            "degeneracy_ratio": round(distinct / len(rows), 4),
+            "bm25_spread": round(max(ranks) - min(ranks), 6),
+            # Everything tied at the best rank receives lex == 1.0 and is
+            # therefore ordered by cosine alone, whatever the boost does.
+            "matchers_tied_at_best_rank": tied_at_best,
+            "fraction_ordered_by_cosine_alone": round(tied_at_best / len(rows), 4)}
+
+
+def _claims_coverage(db_path: str, queries: list[dict], db) -> dict:
+    """Does the substrate already hold the answer that retrieval is missing?
+
+    Relation direction is extracted at write time into `claims` with src/dst
+    intact — precisely the signal cosine destroys. This counts the queries the
+    substrate can answer but retrieval does not surface.
+    """
+    con = sqlite3.connect(db_path)
+    txt2rid = {}
+    for rid, text in con.execute("SELECT rid, text FROM memories"):
+        txt2rid.setdefault((text or "").strip(), rid)
+    known_missed, answerable, gp_seen = [], 0, False
+    for q in queries:
+        tgt = (q.get("target_text") or "").strip()
+        if not tgt:
+            continue
+        rid = txt2rid.get(tgt)
+        claim = con.execute(
+            "SELECT src, dst, rel_type FROM claims "
+            "WHERE source_memory_rid=? AND tombstoned=0", (rid,)).fetchone() if rid else None
+        hits = db.recall(q["query"], top_k=5, namespace="g")
+        got = any(tgt in (h.get("text") or "") or (h.get("text") or "") in tgt for h in hits)
+        if any(h.get("scores", {}).get("graph_proximity", 0.0) for h in hits):
+            gp_seen = True
+        if claim:
+            answerable += 1
+            if not got:
+                known_missed.append({"query": q["query"], "claim": list(claim)})
+    return {
+        "claims_total": con.execute("SELECT COUNT(*) FROM claims").fetchone()[0],
+        "cognitive_edges_total": con.execute(
+            "SELECT COUNT(*) FROM cognitive_edges").fetchone()[0],
+        "answer_present_in_claims_with_direction": f"{answerable}/{len(queries)}",
+        "substrate_knows_but_retrieval_misses": len(known_missed),
+        "any_nonzero_graph_proximity": gp_seen,
+        "misses": known_missed,
+    }
+
+
+def _direction_and_possessive(db, top_k: int = 5) -> dict:
+    """Gate v1.1.0 subset — reported SEPARATELY from overall precision.
+
+    Two things overall precision cannot see:
+
+    DIRECTION. Each probe uses one entity in both roles. Ground truth is role
+    POSITION, not record identity, because this corpus gives every person many
+    managers on purpose. A retriever that has lost direction returns the same
+    records for "who does X report to" and "who reports to X", scoring ~0
+    separation; one that preserves it separates toward 1.0.
+
+    POSSESSIVE. Two queries one apostrophe apart, expressing the same need.
+    Jaccard of their result sets should be 1.0. Anything lower is the
+    `tokenize()` apostrophe exemption surfacing as retrieval instability.
+    """
+    probes = json.loads((FIXTURES / "direction_probes_v1_1.json")
+                        .read_text(encoding="utf-8"))["probes"]
+    seps, jaccards, rows = [], [], []
+
+    def _texts(q):
+        return [(h.get("text") or "").strip()
+                for h in db.recall_text(q, top_k=top_k, namespace="g")]
+
+    for p in probes:
+        e = p["entity"]
+        subj_pat = f"{e} reports to "          # e is SUBJECT
+        obj_pat = f" reports to {e}."          # e is OBJECT
+
+        def share(texts):
+            rel = [t for t in texts if subj_pat in t or obj_pat in t]
+            if not rel:
+                return None
+            return sum(1 for t in rel if t.startswith(subj_pat)) / len(rel)
+
+        s_q, o_q = share(_texts(p["query_subject"])), share(_texts(p["query_object"]))
+        sep = None if s_q is None or o_q is None else s_q - o_q
+        if sep is not None:
+            seps.append(sep)
+
+        a, b = set(_texts(p["query_possessive"])), set(_texts(p["query_plain"]))
+        jac = len(a & b) / len(a | b) if (a | b) else 1.0
+        jaccards.append(jac)
+        rows.append({"entity": e, "subject_role_share": s_q,
+                     "object_query_subject_share": o_q,
+                     "separation": None if sep is None else round(sep, 3),
+                     "possessive_jaccard": round(jac, 3)})
+
+    return {
+        "direction_separation": round(sum(seps) / len(seps), 3) if seps else None,
+        "direction_separation_note": "0.0 = direction fully lost, 1.0 = perfect",
+        "possessive_jaccard_mean": round(sum(jaccards) / len(jaccards), 3),
+        "possessive_jaccard_note": "1.0 = an apostrophe changes nothing, as it should",
+        "probes": rows,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--pool-sweep", action="store_true",
+                    help="also sweep cross-encoder pool_k (needs sentence-transformers)")
+    ap.add_argument("--direction", action="store_true",
+                    help="also run the v1.1.0 direction + possessive subset")
+    ap.add_argument("--db", default=None, help="reuse an already-seeded gate db")
+    args = ap.parse_args()
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarks"))
+    from _bootstrap import _pin_engine_import
+    _pin_engine_import()
+    from yantrikdb._yantrikdb_rust import YantrikDB
+
+    import yantrikdb
+
+    facts, queries = _load()
+    if args.db:
+        db_path, db = args.db, YantrikDB.with_default(args.db)
+    else:
+        db_path = os.path.join(tempfile.mkdtemp(), "gate.db")
+        print(f"seeding {len(facts)} records, then draining {DRAIN_SECONDS}s…",
+              file=sys.stderr)
+        db = _seed(facts, db_path)
+
+    out = {
+        "gate": "hermes-plugin/competing-distractors v1.0.0",
+        "engine": yantrikdb.__version__,
+        "corpus": len(facts), "queries": len(queries),
+        "results": [_measure(
+            lambda q, k: [h.get("text") or "" for h in
+                          db.recall_text(q, top_k=k, namespace="g")],
+            queries, "retrieval only")],
+        "lexical_degeneracy": _degeneracy(db_path),
+        "claims_lane": _claims_coverage(db_path, queries, db),
+    }
+    if args.direction:
+        out["direction_and_possessive"] = _direction_and_possessive(db)
+    if args.pool_sweep:
+        for pool in (30, 50, 100, 200):
+            try:
+                out["results"].append(_measure(
+                    lambda q, k, _p=pool: [
+                        h.get("text") or "" for h in yantrikdb.recall_reranked(
+                            db, q, top_k=k, pool_k=_p, namespace="g")],
+                    queries, f"+ cross-encoder, pool_k={pool}"))
+            except Exception as e:  # noqa: BLE001
+                out["results"].append({"config": f"+ cross-encoder, pool_k={pool}",
+                                       "error": f"{type(e).__name__}: {str(e)[:120]}"})
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/comparison/notes_baseline.py
+++ b/tests/comparison/notes_baseline.py
@@ -1,0 +1,195 @@
+"""Notes-as-memory baseline — the honest version of "why not just use Obsidian?"
+
+Obsidian is not a Hermes memory provider and this does not pretend it is. But
+it is what a large share of the community actually does: the agent writes
+durable facts into a markdown vault and searches it back. Ten community
+stories describe exactly that, and Hermes issue #2736 asks for it as a
+first-class memory layer. So "why do I need a memory substrate when I already
+have my notes?" is a fair question, and it deserves a measured answer rather
+than a rhetorical one.
+
+This runs a markdown vault over the SAME 1,000-fact corpus and the SAME 20
+queries the provider harness uses, scoring it the same way. Two retrieval
+modes, because arguing against only the weakest one would be a strawman:
+
+  keyword  — ranked term overlap, i.e. what vault search / ripgrep gives you
+  semantic — the same bundled embedder this plugin uses, over note bodies,
+             i.e. an Obsidian user who has wired up a semantic-search plugin
+
+The corpus carries 25 exact duplicates, 25 paraphrases and 25
+contradiction pairs precisely so the interesting columns are not recall@k —
+where a good vault does fine — but what happens to duplicates and
+contradictions, which a filesystem has no concept of.
+
+Run:
+    python tests/comparison/notes_baseline.py            # both modes
+    python tests/comparison/notes_baseline.py --mode keyword
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import statistics
+import sys
+import tempfile
+import time
+from collections import Counter
+from pathlib import Path
+
+FIXTURES = Path(__file__).parent / "fixtures"
+_WORD = re.compile(r"[a-z0-9]+")
+_STOP = {
+    "the", "a", "an", "is", "are", "was", "were", "to", "of", "in", "on", "for",
+    "and", "or", "with", "at", "by", "from", "as", "that", "this", "it", "its",
+    "what", "which", "who", "does", "do", "did", "user", "their", "they",
+}
+
+
+def _tokens(text: str) -> list[str]:
+    return [w for w in _WORD.findall(text.lower()) if w not in _STOP and len(w) > 2]
+
+
+# ---------------------------------------------------------------------------
+# The vault
+# ---------------------------------------------------------------------------
+
+class NotesVault:
+    """A markdown vault, written and searched the way an agent would.
+
+    One note per fact, because that is what "write it to Obsidian" produces.
+    No deduplication and no contradiction handling — not as a handicap, but
+    because a directory of files genuinely has no such notion. That absence
+    is the finding, not a flaw in the setup.
+    """
+
+    def __init__(self, root: Path, mode: str = "keyword"):
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.mode = mode
+        self._notes: list[tuple[Path, str]] = []
+        self._vectors: list = []
+        self._embedder = None
+        if mode == "semantic":
+            self._embedder = _load_embedder()
+
+    def write(self, idx: int, text: str) -> None:
+        slug = re.sub(r"[^a-z0-9]+", "-", text.lower())[:60].strip("-") or f"note-{idx}"
+        path = self.root / f"{idx:04d}-{slug}.md"
+        path.write_text(f"# {text}\n\ncaptured: fact {idx}\n", encoding="utf-8")
+        self._notes.append((path, text))
+        if self._embedder is not None:
+            self._vectors.append(self._embedder(text))
+
+    def search(self, query: str, top_k: int = 5) -> list[str]:
+        if self.mode == "semantic" and self._embedder is not None:
+            qv = self._embedder(query)
+            scored = [(_cosine(qv, v), t) for v, (_, t) in zip(self._vectors, self._notes)]
+        else:
+            q = Counter(_tokens(query))
+            if not q:
+                return []
+            scored = []
+            for _, text in self._notes:
+                t = Counter(_tokens(text))
+                overlap = sum(min(c, t[w]) for w, c in q.items())
+                if overlap:
+                    # length-normalised overlap: the same shape a vault's
+                    # ranked search gives, not raw hit counting
+                    scored.append((overlap / math.sqrt(len(t) + 1), text))
+        scored.sort(key=lambda x: -x[0])
+        return [t for _, t in scored[:top_k]]
+
+    # A vault cannot answer these. Recorded rather than skipped, because the
+    # absence is the substantive difference.
+    def duplicates_of(self, text: str) -> int:
+        return sum(1 for _, t in self._notes if t.strip() == text.strip())
+
+    def surfaces_contradictions(self) -> bool:
+        return False
+
+
+def _cosine(a, b) -> float:
+    num = sum(x * y for x, y in zip(a, b))
+    da = math.sqrt(sum(x * x for x in a)) or 1.0
+    db = math.sqrt(sum(y * y for y in b)) or 1.0
+    return num / (da * db)
+
+
+def _load_embedder():
+    """The same bundled embedder the plugin uses, so semantic mode is a fair
+    fight rather than a weaker model losing to a stronger one."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarks"))
+    from _bootstrap import _pin_engine_import
+    _pin_engine_import()
+    from model2vec import StaticModel  # noqa: PLC0415
+    model = StaticModel.from_pretrained("minishlab/potion-base-2M")
+    return lambda text: list(model.encode([text])[0])
+
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+def run(mode: str) -> dict:
+    corpus = json.loads((FIXTURES / "corpus_1k.json").read_text(encoding="utf-8"))
+    queries = json.loads((FIXTURES / "queries_1k.json").read_text(encoding="utf-8"))["queries"]
+    facts = corpus["facts"]
+
+    root = Path(tempfile.mkdtemp()) / "vault"
+    vault = NotesVault(root, mode=mode)
+
+    writes = []
+    for f in facts:
+        t0 = time.perf_counter()
+        vault.write(f["id"], f["text"])
+        writes.append((time.perf_counter() - t0) * 1000)
+
+    hits, reads = 0, []
+    for q in queries:
+        t0 = time.perf_counter()
+        got = vault.search(q["query"], top_k=q.get("top_k", 5))
+        reads.append((time.perf_counter() - t0) * 1000)
+        target = (q.get("target_text") or "").strip()
+        if target and any(target in g or g in target for g in got):
+            hits += 1
+
+    dup_examples = [f for f in facts if f.get("planted_kind") == "exact_dup"][:5]
+    dup_copies = [vault.duplicates_of(f["text"]) for f in dup_examples]
+
+    return {
+        "provider": f"notes-vault ({mode})",
+        "notes_written": len(vault._notes),
+        "vault_files": len(list(root.glob("*.md"))),
+        "write_p50_ms": round(statistics.median(writes), 3),
+        "recall_p50_ms": round(statistics.median(reads), 2),
+        "recall_p99_ms": round(sorted(reads)[int(len(reads) * 0.99) - 1], 2),
+        "precision_at_k": round(hits / len(queries), 3),
+        "queries": len(queries),
+        "duplicate_copies_kept": max(dup_copies) if dup_copies else None,
+        "canonicalises_duplicates": bool(dup_copies and max(dup_copies) <= 1),
+        "surfaces_contradictions": vault.surfaces_contradictions(),
+        "explains_why_retrieved": False,
+        "tracks_supersession": False,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--mode", choices=["keyword", "semantic", "both"], default="both")
+    args = ap.parse_args()
+    modes = ["keyword", "semantic"] if args.mode == "both" else [args.mode]
+    out = []
+    for m in modes:
+        try:
+            out.append(run(m))
+        except ImportError as e:
+            print(f"  skipping {m}: {e}", file=sys.stderr)
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_comparison_gate.py
+++ b/tests/test_comparison_gate.py
@@ -1,0 +1,101 @@
+"""The comparison gate is a cross-team contract, so CI defends its hashes.
+
+`tests/comparison/gate_4k.py` is the benchmark the engine team runs candidate
+builds against — they cannot reproduce it themselves, and both sides quote its
+numbers at each other. That only works if "gate v1.1.0" means the same bytes on
+both sides. A regenerated corpus that still *looked* right would silently make
+every historical number incomparable, and nobody would get an error.
+
+So the hashes are pinned here as well as inside the runner: the runner refuses
+to execute on a mismatch, and CI refuses to merge one.
+
+These tests deliberately do NOT run the gate — it needs a seeded engine and
+~30s of drain. They check that the contract is intact and the runner is honest
+about its own limits.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_FIX = _ROOT / "tests" / "comparison" / "fixtures"
+
+# Sent to yantrikdb-core on 2026-08-06 as gate v1.1.0. Changing a value here
+# without telling them makes their measurements silently incomparable to ours.
+PINNED = {
+    "corpus_4353_gate_v1.json":
+        "2d2d039094644ce5b2a1d8de5047daa5b4a183e98919bdae3a57a67962df4fc9",
+    "queries_1k.json":
+        "a4b866a5bdeccfb103b25d2cf1a66a1ca50af9096ccb55bf73579f676f4b407f",
+    "direction_probes_v1_1.json":
+        "dfe0242e72fa575c5d45bf7afc8e2e153dde279fc45be2b049da15f6e0383a3d",
+}
+
+
+@pytest.mark.parametrize("name", sorted(PINNED))
+def test_fixture_hash_is_unchanged(name):
+    path = _FIX / name
+    assert path.exists(), f"gate fixture missing: {name}"
+    got = hashlib.sha256(path.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
+    assert got == PINNED[name], (
+        f"{name} changed.\n  expected {PINNED[name]}\n  actual   {got}\n"
+        "If this is intentional, bump the gate version, re-pin here AND in "
+        "gate_4k.py, and send the new hashes to the engine team — otherwise "
+        "their numbers and ours stop meaning the same thing."
+    )
+
+
+def test_runner_pins_the_same_hashes():
+    """Two copies of a constant drift. This is the test that notices."""
+    src = (_ROOT / "tests" / "comparison" / "gate_4k.py").read_text(encoding="utf-8")
+    assert PINNED["corpus_4353_gate_v1.json"] in src
+    assert PINNED["queries_1k.json"] in src
+
+
+def test_runner_refuses_to_run_on_a_mismatch():
+    """Reporting numbers from a drifted corpus is worse than reporting none."""
+    src = (_ROOT / "tests" / "comparison" / "gate_4k.py").read_text(encoding="utf-8")
+    assert "hash mismatch" in src
+    assert "SystemExit" in src
+
+
+def test_direction_probes_are_minimal_pairs():
+    """The possessive axis measures ONE apostrophe. An earlier cut compared
+    differently-worded questions, which conflated the tokenizer defect with
+    rewording and produced a number that did not mean what its field name
+    claimed. This asserts the pair is byte-identical apart from that one
+    character, so the metric cannot quietly go back to measuring rewording."""
+    probes = json.loads(
+        (_FIX / "direction_probes_v1_1.json").read_text(encoding="utf-8"))["probes"]
+    assert probes
+    for p in probes:
+        assert p["query_possessive"].replace("'", " ") == p["query_plain"], (
+            f"not a minimal pair for {p['entity']}: "
+            f"{p['query_possessive']!r} vs {p['query_plain']!r}"
+        )
+
+
+def test_direction_probes_use_each_entity_in_both_roles():
+    """Role-share scoring is only meaningful if the entity actually appears as
+    both subject and object; otherwise 'direction separation' measures noise."""
+    probes = json.loads(
+        (_FIX / "direction_probes_v1_1.json").read_text(encoding="utf-8"))["probes"]
+    for p in probes:
+        assert p["n_subject_records"] >= 5
+        assert p["n_object_records"] >= 5
+
+
+def test_corpus_declares_that_it_is_a_stress_fixture():
+    """Whoever reads a number off this gate must be told it is pathological by
+    construction, or they will quote it as representative field precision."""
+    payload = json.loads(
+        (_FIX / "corpus_4353_gate_v1.json").read_text(encoding="utf-8"))
+    assert len(payload["facts"]) == 4353
+    note = payload["note"].lower()
+    assert "stress" in note
+    assert "not a representative" in note or "representative" in note

--- a/tests/test_v012_features.py
+++ b/tests/test_v012_features.py
@@ -136,9 +136,16 @@ class TestPeriodicMaintenance:
         self, provider_module, mock_client, monkeypatch,
     ):
         """The whole point: an always-on agent should get the SAME work a
-        short-lived one gets, including gap→task."""
+        short-lived one gets, including gap→task.
+
+        Gap detection is opt-in since v0.15.0 (the signal does not
+        discriminate — see YantrikDBConfig.gap_max_avg_top_score), so this
+        enables it explicitly. What is under test here is that periodic
+        maintenance runs the same path a session end does, not the default.
+        """
         mock_client.knowledge_gaps.return_value = {"gaps": [{"query": "x"}]}
         p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_GAP_DETECTION="true",
                       YANTRIKDB_MAINTENANCE_CADENCE_TURNS="1",
                       YANTRIKDB_MAINTENANCE_MIN_INTERVAL_SECONDS="0")
         p.on_turn_start(1, "hi")

--- a/tests/test_v015_engine_013.py
+++ b/tests/test_v015_engine_013.py
@@ -1,0 +1,165 @@
+"""v0.15.0 — admit engine 0.13.x, and stop shipping a signal that can't tell.
+
+Two changes, one theme: a number that doesn't disclose its own preconditions.
+
+RAISING THE CEILING. The engine's 0.13.0 brought BM25 lexical fusion. Our pin
+capped at <0.13.0, so nobody installing this plugin got it. The ceiling moves
+only after the suite runs green against the new minor — that rule is the whole
+reason `test_dependency_pins.py` exists, and this file records that it happened.
+
+RETIRING THE GAP SIGNAL. `gap_max_avg_top_score` thresholds the COMPOSITE
+recall score, which folds in importance, recency and decay — terms describing
+how to weight a result once you've decided to return it, not whether memory
+holds anything near the question. Measured on engine 0.13.0 over 4,353 records:
+0/20 queries flagged, and 3 of 4 deliberate-nonsense queries evaded the
+threshold ("zzqx wobble frangible" scored 0.4810). The detector isn't
+conservative, it's uninformative — and an operator reads its silence as
+"nothing missing".
+
+v0.12.2 already recalibrated this value once. Recalibrating again would move
+the same defect to a new constant and expire it at the next scoring change, so
+the default goes off until the signal itself discriminates. The knob stays:
+off-by-default is a default, not a removal.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    return _ROOT
+
+
+@pytest.fixture
+def mock_client(client_module) -> MagicMock:
+    c = MagicMock(spec=client_module.YantrikDBClient)
+    c.health.return_value = {"status": "ok"}
+    c.knowledge_gaps.return_value = {"gaps": [{"query": "unanswered thing"}]}
+    c.task_list.return_value = {"tasks": []}
+    return c
+
+
+def _provider(provider_module, mock_client, monkeypatch, **env):
+    monkeypatch.setenv("YANTRIKDB_MODE", "http")
+    monkeypatch.setenv("YANTRIKDB_TOKEN", "ydb_test")
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    p = provider_module.YantrikDBMemoryProvider()
+    with patch.object(provider_module, "make_backend", return_value=mock_client):
+        p.initialize("s1", agent_workspace="ws", agent_identity="coder",
+                     platform="cli")
+    return p
+
+
+class TestEngineCeiling:
+    def test_admits_0_13_x(self, repo_root):
+        """The whole point of the release: users get BM25 fusion."""
+        text = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+        assert "yantrikdb>=0.12.1,<0.14.0" in text
+
+    def test_still_bounded(self, repo_root):
+        """Raising a ceiling is not removing it. An unbounded pin is how
+        yantrikdb-mcp lost a published release when a dependency shipped a
+        new major; the bound moves, it never disappears."""
+        text = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+        assert "yantrikdb>=0.12.1," in text
+        assert "<0.14.0" in text
+        for line in text.splitlines():
+            s = line.strip()
+            if s.startswith('"yantrikdb>=') or s.startswith('"requests>='):
+                assert "<" in s, f"dependency lost its upper bound: {s}"
+
+
+class TestGapSignalIsOffByDefault:
+    def test_no_gap_call_at_session_end(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        """Not merely 'creates no tasks' — the engine is never asked. A
+        detector that cannot discriminate should not be consulted at all."""
+        p = _provider(provider_module, mock_client, monkeypatch)
+        p.on_session_end([])
+        mock_client.knowledge_gaps.assert_not_called()
+        mock_client.task_add.assert_not_called()
+
+    def test_agenda_block_does_not_consult_gaps(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_SURFACE_AGENDA="true")
+        p._format_agenda_block()
+        mock_client.knowledge_gaps.assert_not_called()
+
+    def test_agenda_still_shows_real_tasks(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        """Retiring the gap signal must not take the agenda with it — open
+        tasks are user-authored facts, not an inferred signal."""
+        mock_client.task_list.return_value = {"tasks": [
+            {"id": "t1", "title": "Ship the migration", "priority": "high"},
+        ]}
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_SURFACE_AGENDA="true")
+        block = p._format_agenda_block()
+        assert "Ship the migration" in block
+
+    def test_opt_in_restores_both_surfaces(
+        self, provider_module, mock_client, monkeypatch,
+    ):
+        p = _provider(provider_module, mock_client, monkeypatch,
+                      YANTRIKDB_GAP_DETECTION="true",
+                      YANTRIKDB_SURFACE_AGENDA="true")
+        p._format_agenda_block()
+        mock_client.knowledge_gaps.assert_called()
+        p.on_session_end([])
+        mock_client.task_add.assert_called()
+
+
+class TestTheOperatorIsToldWhy:
+    def test_setup_surfaces_the_switch(self, provider_module):
+        """A capability that silently stopped running is indistinguishable
+        from one that is broken. It appears in `hermes memory setup`."""
+        keys = {e["key"] for e in provider_module.YantrikDBMemoryProvider()
+                .get_config_schema()}
+        assert "gap_detection" in keys
+
+    def test_description_warns_rather_than_just_naming(self, provider_module):
+        """The description has to carry the risk, not the mechanism — an
+        operator flipping this on deserves to know it may fill their agenda
+        with work that isn't real."""
+        entry = next(e for e in provider_module.YantrikDBMemoryProvider()
+                     .get_config_schema() if e["key"] == "gap_detection")
+        d = entry["description"].lower()
+        assert entry["default"] == "false"
+        assert "off" in d
+        assert "gibberish" in d or "noise" in d
+
+    def test_the_measurement_is_recorded_next_to_the_constant(self, repo_root):
+        """The threshold that caused this must carry its own evidence. A bare
+        'deprecated' comment would leave the next maintainer free to just
+        retune it — which is precisely the mistake being corrected."""
+        src = (repo_root / "yantrikdb" / "client.py").read_text(encoding="utf-8")
+        i = src.index("gap_max_avg_top_score: float")
+        context = src[max(0, i - 3000):i]
+        assert "0 / 20" in context or "0/20" in context
+        assert "nonsense" in context.lower()
+        assert "gap_floor_check" in context
+
+
+class TestTheDiagnosticShips:
+    def test_gap_floor_check_is_present_and_runnable(self, repo_root):
+        """Anyone who calibrated a threshold against the composite has the
+        same latent bug. Shipping the check is how they find out."""
+        p = repo_root / "benchmarks" / "gap_floor_check.py"
+        assert p.exists()
+        src = p.read_text(encoding="utf-8")
+        compile(src, str(p), "exec")
+        # it must refuse to repeat the derivation that was retracted
+        assert "do NOT sum" in src or "does not sum" in src
+        assert "read_this_before_switching_to_similarity" in src

--- a/tests/test_v08_features.py
+++ b/tests/test_v08_features.py
@@ -41,7 +41,7 @@ class TestGapToTask:
         self, provider_module, mock_client, monkeypatch, tmp_path,
     ):
         p = _provider(provider_module, mock_client, monkeypatch, tmp_path,
-                      YANTRIKDB_AUTO_GAP_TASKS="true")
+                      YANTRIKDB_AUTO_GAP_TASKS="true", YANTRIKDB_GAP_DETECTION="true")
         mock_client.knowledge_gaps.return_value = {"gaps": [
             {"query": "kubernetes ingress config", "count": 6},
             {"query": "oncall escalation path", "count": 4},
@@ -55,7 +55,7 @@ class TestGapToTask:
         self, provider_module, mock_client, monkeypatch, tmp_path,
     ):
         p = _provider(provider_module, mock_client, monkeypatch, tmp_path,
-                      YANTRIKDB_AUTO_GAP_TASKS="true")
+                      YANTRIKDB_AUTO_GAP_TASKS="true", YANTRIKDB_GAP_DETECTION="true")
         mock_client.knowledge_gaps.return_value = {"gaps": [
             {"query": "kubernetes ingress config"},
             {"query": "oncall escalation path"},
@@ -71,24 +71,42 @@ class TestGapToTask:
         self, provider_module, mock_client, monkeypatch, tmp_path,
     ):
         p = _provider(provider_module, mock_client, monkeypatch, tmp_path,
-                      YANTRIKDB_AUTO_GAP_TASKS="true", YANTRIKDB_GAP_TASK_MAX="1")
+                      YANTRIKDB_AUTO_GAP_TASKS="true", YANTRIKDB_GAP_DETECTION="true", YANTRIKDB_GAP_TASK_MAX="1")
         mock_client.knowledge_gaps.return_value = {"gaps": [
             {"query": "a"}, {"query": "b"}, {"query": "c"},
         ]}
         p.on_session_end([])
         assert mock_client.task_add.call_count == 1
 
-    def test_on_by_default(
+    def test_off_by_default_because_the_signal_does_not_discriminate(
         self, provider_module, mock_client, monkeypatch, tmp_path,
     ):
-        """v0.10.0 — the self-directing loop ships ON.
+        """v0.15.0 reverses the v0.10.0 default, on measurement.
 
-        Through v0.9.x this was opt-in, which meant the capability the plugin
-        is *for* never ran for anyone who installed it and didn't read the
-        README. The gate is demand-aggregated and the output is capped, so
-        turning it on cannot mint junk tasks.
+        v0.10.0 shipped this ON reasoning that a demand-aggregated, capped
+        gate "cannot mint junk tasks". True, but it assumed the gate could
+        tell a real gap from noise. Measured on engine 0.13.0: deliberate
+        gibberish scores as high as real questions, so the gate is not
+        conservative — it is uninformative, and 3 of 4 nonsense queries
+        evade the threshold entirely.
+
+        Minting durable to-dos from that spends the operator's attention on
+        noise, and a silent gap surface is read as "nothing missing". Off
+        until the signal discriminates; the knob stays for anyone who has
+        calibrated their own threshold against their own corpus.
         """
         p = _provider(provider_module, mock_client, monkeypatch, tmp_path)
+        mock_client.knowledge_gaps.return_value = {"gaps": [{"query": "x"}]}
+        p.on_session_end([])
+        mock_client.task_add.assert_not_called()
+        mock_client.knowledge_gaps.assert_not_called()
+
+    def test_opt_in_restores_it(
+        self, provider_module, mock_client, monkeypatch, tmp_path,
+    ):
+        """Off by default is a default, not a removal."""
+        p = _provider(provider_module, mock_client, monkeypatch, tmp_path,
+                      YANTRIKDB_GAP_DETECTION="true")
         mock_client.knowledge_gaps.return_value = {"gaps": [{"query": "x"}]}
         p.on_session_end([])
         mock_client.task_add.assert_called_once()
@@ -106,7 +124,7 @@ class TestGapToTask:
         self, provider_module, mock_client, monkeypatch, tmp_path,
     ):
         p = _provider(provider_module, mock_client, monkeypatch, tmp_path,
-                      YANTRIKDB_AUTO_GAP_TASKS="true")
+                      YANTRIKDB_AUTO_GAP_TASKS="true", YANTRIKDB_GAP_DETECTION="true")
         mock_client.knowledge_gaps.side_effect = AttributeError("old engine")
         p.on_session_end([])  # must not raise
         mock_client.task_add.assert_not_called()
@@ -116,7 +134,7 @@ class TestGapToTask:
     ):
         # v0.8.1: engine 0.9.3+ scopes demand per namespace.
         p = _provider(provider_module, mock_client, monkeypatch, tmp_path,
-                      YANTRIKDB_AUTO_GAP_TASKS="true")
+                      YANTRIKDB_AUTO_GAP_TASKS="true", YANTRIKDB_GAP_DETECTION="true")
         mock_client.knowledge_gaps.return_value = {"gaps": [{"query": "x"}]}
         p.on_session_end([])
         assert mock_client.knowledge_gaps.call_args.kwargs.get("namespace")
@@ -133,7 +151,8 @@ class TestAgendaBlock:
         self, provider_module, mock_client, monkeypatch, tmp_path,
     ):
         p = _provider(provider_module, mock_client, monkeypatch, tmp_path,
-                      YANTRIKDB_SURFACE_AGENDA="true")
+                      YANTRIKDB_SURFACE_AGENDA="true",
+                      YANTRIKDB_GAP_DETECTION="true")
         mock_client.task_list.return_value = {"tasks": [
             {"id": "t1", "title": "Resolve knowledge gap: oncall path", "priority": "medium"},
         ]}
@@ -157,6 +176,7 @@ class TestAgendaBlock:
         self, provider_module, mock_client, monkeypatch, tmp_path,
     ):
         p = _provider(provider_module, mock_client, monkeypatch, tmp_path,
-                      YANTRIKDB_SURFACE_AGENDA="true")
+                      YANTRIKDB_SURFACE_AGENDA="true",
+                      YANTRIKDB_GAP_DETECTION="true")
         mock_client.knowledge_gaps.return_value = {"gaps": [{"query": "topic X"}]}
         assert "Your memory's agenda" in p.system_prompt_block()

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,52 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.15.0] — 2026-08-06 — Better retrieval, and one feature switched off on the evidence
+
+Two changes. One gives you a retrieval improvement that was sitting behind a version pin. The other **turns off a feature that has been quietly telling you nothing**, and explains why in enough detail that you can check the claim yourself.
+
+### Engine 0.13.x is now supported — you get BM25 lexical fusion
+
+The ceiling was `<0.13.0`, so nobody installing this plugin received the engine's new lexical fusion. It now admits `<0.14.0`, verified against the full suite on 0.13.0 before the bound moved — which is the rule `test_dependency_pins.py` exists to enforce. The bound moves; it never disappears.
+
+What fusion buys, measured on a deliberately hostile 4,353-record corpus: **precision@5 0.25 → 0.30 for +0.5 ms**, and two answers that previously never appeared in the top 100 at all became reachable. On corpora where records don't all share a sentence frame, the engine team measured considerably more.
+
+### Knowledge-gap detection is now OFF by default
+
+Since v0.10.0 this plugin has watched for questions your memory answers badly and turned recurring ones into agenda items and to-dos. **It doesn't work, and this release stops pretending it does.**
+
+`gap_max_avg_top_score` compares a *composite* recall score against a threshold. That composite folds in importance, recency and decay — terms that describe how to weight a result **once you've decided to return it**, not whether memory holds anything near the question. Measured on engine 0.13.0 over 4,353 records:
+
+```
+queries flagged as a gap ................ 0 / 20
+deliberate nonsense NOT flagged ......... 3 / 4
+  "zzqx wobble frangible" ....... avg 0.4810
+  "quantum tarpaulin metric" .... avg 0.3707
+  "grommet fitzwilliam parsnip" . avg 0.3023
+```
+
+Gibberish scores as high as a real question. So the detector is not being cautious, as v0.12.2 intended when it recalibrated the threshold — **it is uninformative, and its silence reads as "nothing is missing."** A signal that cannot be wrong cannot be right either.
+
+**The defect is the instrument, not the number.** v0.12.2 already retuned this constant once; retuning it again would move the same bug to a new value and expire it at the next scoring change. So the default goes off until the signal itself discriminates.
+
+Deliberately **not** replaced with a similarity threshold: on the same corpus nonsense reached `max_similarity` 0.653 against 0.624 for real queries, so that swap is unproven and might only relocate the defect. The engine team is gating a `min_similarity` candidate on evidence; this plugin adopts it if and when it separates.
+
+Nothing was removed. `YANTRIKDB_GAP_DETECTION=true` restores the previous behaviour, and it appears in `hermes memory setup` with the risk stated rather than the mechanism. **Open tasks are unaffected** — those are facts you wrote, not a signal we inferred.
+
+### Check it against your own memory
+
+```bash
+python benchmarks/gap_floor_check.py <your.db> [--threshold 0.30]
+```
+
+Reports the observed score distribution, probes it with nonsense, and exits non-zero if gibberish clears your threshold. If you calibrated a threshold against a composite score anywhere, this tells you in one command. It deliberately does **not** compute a "floor" from the per-component contributions — those don't sum to the composite, and an earlier version of this analysis drew a wrong conclusion from assuming they did. The script says so, so nobody repeats it.
+
+### The benchmark gate is now in the repo
+
+`tests/comparison/gate_4k.py` plus hash-pinned fixtures — the competing-distractor gate used to evaluate engine candidates, including a direction-sensitivity subset and a possessive minimal pair. It refuses to run on a corpus whose hash has drifted, and CI asserts the hashes so a regenerated fixture can't silently make old numbers incomparable. It is a **stress** corpus, pathological by construction; weight a production-clone benchmark above it for any user-facing claim.
+
+19 new tests; 456 pass / 3 skip.
+
 ## [0.14.0] — 2026-08-05 — Standing rules that belong to the operator
 
 Until now exactly one channel in this plugin carried always-injected **rules** rather than facts: a knowledge pack's constitution. Which meant **a third party could install standing rules into someone's agent and the person who owns it could not.** That asymmetry was the wrong way round.

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -1599,6 +1599,21 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 "env_var": "YANTRIKDB_CONSTITUTION_PATH",
             },
             {
+                "key": "gap_detection",
+                "description": (
+                    "Turn unanswered questions into agenda items and to-dos. "
+                    "OFF since v0.15.0 because the underlying score does not "
+                    "reliably tell a real gap from noise — measured on engine "
+                    "0.13.0, deliberate gibberish scored as high as genuine "
+                    "questions. Turning this on may fill your agenda with "
+                    "work that isn't real; leave it off unless you have "
+                    "checked the threshold against your own memory with "
+                    "benchmarks/gap_floor_check.py."
+                ),
+                "default": "false",
+                "env_var": "YANTRIKDB_GAP_DETECTION",
+            },
+            {
                 "key": "shared_brain_namespace",
                 "description": (
                     "Running SEVERAL AGENTS? Set this to a shared namespace "
@@ -3994,14 +4009,18 @@ class YantrikDBMemoryProvider(MemoryProvider):
             tasks = (listed.get("tasks") if isinstance(listed, dict) else listed) or []
         except (AttributeError, YantrikDBServerError, YantrikDBError):
             tasks = []
-        try:
-            resp = self._client.knowledge_gaps(
-                max_avg_top_score=self._config.gap_max_avg_top_score, limit=cap,
-                namespace=self._namespace,
-            )
-            gaps = (resp.get("gaps") if isinstance(resp, dict) else resp) or []
-        except (AttributeError, YantrikDBServerError, YantrikDBError):
-            gaps = []
+        # v0.15.0: the gap signal is off by default because it does not
+        # discriminate — see YantrikDBConfig.gap_max_avg_top_score. Showing an
+        # empty "unanswered questions" list would read as "nothing missing".
+        if self._config.gap_detection:
+            try:
+                resp = self._client.knowledge_gaps(
+                    max_avg_top_score=self._config.gap_max_avg_top_score, limit=cap,
+                    namespace=self._namespace,
+                )
+                gaps = (resp.get("gaps") if isinstance(resp, dict) else resp) or []
+            except (AttributeError, YantrikDBServerError, YantrikDBError):
+                gaps = []
         if not tasks and not gaps:
             return ""
         lines = ["", "## Your memory's agenda"]
@@ -4105,6 +4124,11 @@ class YantrikDBMemoryProvider(MemoryProvider):
         if self._client is None or self._config is None:
             return
         cfg = self._config
+        # v0.15.0: minting durable to-dos from a signal that cannot tell
+        # gibberish from a real question spends the operator's attention on
+        # noise. Off until the engine ships a gap signal that discriminates.
+        if not cfg.gap_detection:
+            return
         try:
             resp = self._client.knowledge_gaps(
                 min_count=cfg.gap_task_min_count,

--- a/yantrikdb/client.py
+++ b/yantrikdb/client.py
@@ -400,6 +400,16 @@ class YantrikDBConfig:
     # for each recurring gap that doesn't already have one — so the agent's
     # unanswered questions become durable, actionable to-dos.
     auto_gap_tasks: bool = True
+    # gap_detection (v0.15.0): master switch for everything derived from
+    # knowledge_gaps(). DEFAULT OFF, and that is a correction rather than a
+    # preference — see gap_max_avg_top_score below for the measurement.
+    #
+    # Re-enable once the engine ships a gap signal that discriminates; until
+    # then the surfaces below are silent whether this is on or off, and an
+    # honest off beats a silent on. Set YANTRIKDB_GAP_DETECTION=true to
+    # restore the previous behaviour if you have calibrated your own
+    # threshold against your own corpus.
+    gap_detection: bool = False
     gap_task_max: int = 3            # cap new gap-tasks created per session
     gap_task_min_count: int = 3      # a gap must recur >= this to become a task
     # Max average top recall score for a query to count as a "gap".
@@ -424,6 +434,35 @@ class YantrikDBConfig:
     # tests/test_gap_calibration.py re-measures this against the benchmark
     # corpus, so the next scoring change fails loudly instead of silently
     # filling somebody's agenda.
+    #
+    # v0.15.0 — WHY gap_detection NOW DEFAULTS OFF. The overlap noted above
+    # ("no threshold separates them cleanly") turned out to understate it.
+    # Measured on engine 0.13.0 against a 4,353-record corpus:
+    #
+    #   queries flagged as a gap at 0.30 ............ 0 / 20
+    #   deliberate nonsense NOT flagged ............. 3 / 4
+    #     "zzqx wobble frangible" ......... avg 0.4810
+    #     "quantum tarpaulin metric" ...... avg 0.3707
+    #     "grommet fitzwilliam parsnip" ... avg 0.3023
+    #
+    # Gibberish scores as high as real questions, so the detector is not
+    # erring toward silence as v0.12.2 intended — it is silent, and its
+    # silence carries no information. An operator reads that as "no gaps".
+    #
+    # The defect is the INSTRUMENT, not the number. A threshold compared
+    # against the COMPOSITE score inherits terms — importance, recency,
+    # decay — that describe how to weight a result once you have decided to
+    # return it, not whether memory holds anything near the question. v0.12.2
+    # recalibrated the value and left the instrument; recalibrating again
+    # would just move the same bug to a new constant and expire it on the
+    # next scoring change.
+    #
+    # Deliberately NOT replaced with a similarity threshold here: on the same
+    # corpus, nonsense reached max_similarity 0.653 against 0.624 for real
+    # queries, so that swap is unproven and might only relocate the defect.
+    # The engine is gating a `min_similarity` candidate on evidence; this
+    # plugin adopts it if and when it separates. benchmarks/gap_floor_check.py
+    # reproduces all of the above against any database in one command.
     gap_max_avg_top_score: float = 0.30
     # surface_agenda: prepend a compact "## Your memory's agenda" block to
     # system_prompt_block — top open tasks + unresolved knowledge gaps — so
@@ -569,6 +608,9 @@ class YantrikDBConfig:
             ),
             conversation_buffer_surface_limit=_parse_int(
                 os.environ.get("YANTRIKDB_CONVERSATION_BUFFER_SURFACE_LIMIT"), 6,
+            ),
+            gap_detection=_parse_bool(
+                os.environ.get("YANTRIKDB_GAP_DETECTION"), default=False,
             ),
             auto_gap_tasks=_parse_bool(
                 os.environ.get("YANTRIKDB_AUTO_GAP_TASKS"), default=True,

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,8 +1,8 @@
 name: yantrikdb
-version: 0.14.0
+version: 0.15.0
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.12.1,<0.13.0
+  - yantrikdb>=0.12.1,<0.14.0
   - requests>=2.31,<3.0.0
 hooks:
   - on_session_end


### PR DESCRIPTION
Two changes, one theme: **a number that doesn't disclose its own preconditions.**

## Raise the engine ceiling to `<0.14.0`

The pin capped at `<0.13.0`, so nobody installing this plugin received the engine's BM25 lexical fusion. Full suite run green against 0.13.0 **before** the bound moved — the rule `test_dependency_pins.py` exists to enforce. The bound moves; it never disappears.

Measured on the 4,353-record gate: **precision@5 0.25 → 0.30 for +0.5 ms**, and two answers previously absent from the top 100 became reachable.

## Turn gap detection OFF by default

`gap_max_avg_top_score` thresholds the **composite** recall score, which folds in importance, recency and decay — terms describing how to weight a result *once you've decided to return it*, not whether memory holds anything near the question.

```
queries flagged as a gap ................ 0 / 20
deliberate nonsense NOT flagged ......... 3 / 4
  "zzqx wobble frangible" ....... avg 0.4810
  "quantum tarpaulin metric" .... avg 0.3707
  "grommet fitzwilliam parsnip" . avg 0.3023
```

Gibberish scores as high as a real question. The detector is not being cautious as v0.12.2 intended when it recalibrated this constant — **it is uninformative, and its silence reads as "nothing is missing."**

**The defect is the instrument, not the number.** Recalibrating again would move the same bug to a new value and expire it at the next scoring change.

Deliberately **not** swapped for a similarity threshold: nonsense reached `max_similarity` 0.653 vs 0.624 for real queries on the same corpus, so that swap is unproven and may only relocate the defect. The engine is gating a `min_similarity` candidate on evidence; this plugin adopts it if it separates.

Nothing removed — `YANTRIKDB_GAP_DETECTION=true` restores it, surfaced in `hermes memory setup` with the **risk** stated rather than the mechanism. Open tasks are untouched: those are facts the user wrote, not a signal we inferred.

## Also

- **`benchmarks/gap_floor_check.py`** — anyone who calibrated against a composite score can convict their own copy in one command. Reports observed distributions only, and documents why a derived "floor" is unavailable: the per-component contributions do **not** sum to the composite (verified — they differ by ~0.2, and a composite can fall below the sum of its own non-similarity parts). An earlier version of this analysis drew a wrong conclusion from assuming they did; the script says so, so nobody repeats it.
- **`tests/comparison/gate_4k.py`** + hash-pinned fixtures — the competing-distractor gate, with a direction-sensitivity subset and a possessive minimal pair. The runner refuses to execute on a drifted corpus and CI asserts the hashes, because these numbers are quoted across teams and must mean the same bytes on both sides. It is a **stress** corpus, pathological by construction — weight a production-clone benchmark above it for any user-facing claim.

19 new tests; **456 pass / 3 skip**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)