### PR TITLE
release: v0.16.0 — admit engine 0.14.0

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.15.0
+version: 0.16.0
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the
@@ -7,7 +7,7 @@ version: 0.15.0
 # `yantrikdb-hermes install <hermes>`. Both should declare the same version.
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.12.1,<0.14.0
+  - yantrikdb>=0.12.1,<0.15.0
   - requests>=2.31,<3.0.0
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.15.0"
+version = "0.16.0"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -42,7 +42,7 @@ classifiers = [
 # shipped 2.0.0 against an unbounded pin. tests/test_dependency_pins.py enforces
 # this; raise a ceiling only after testing against the new major.
 dependencies = [
-  "yantrikdb>=0.12.1,<0.14.0",
+  "yantrikdb>=0.12.1,<0.15.0",
   "requests>=2.31,<3.0.0",
 ]
 
@@ -156,7 +156,7 @@ exclude = ["reference/", "tests/", "^__init__\\.py$"]
 # matching `## [X.Y.Z] — YYYY-MM-DD — Summary` header. The CI `version-sync`
 # job blocks merge if the three sources drift.
 [tool.bumpversion]
-current_version = "0.15.0"
+current_version = "0.16.0"
 commit = false       # let the human author the commit message + body
 tag = false          # tag via `gh release create`, not on bump
 allow_dirty = true

--- a/tests/test_v015_engine_013.py
+++ b/tests/test_v015_engine_013.py
@@ -24,6 +24,7 @@ off-by-default is a default, not a removal.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -58,19 +59,37 @@ def _provider(provider_module, mock_client, monkeypatch, **env):
     return p
 
 
+def _engine_bounds(repo_root):
+    """(floor, ceiling) of the engine pin as (major, minor, patch) tuples.
+
+    Parsed rather than string-matched: this file asserts that 0.13.x stays
+    admitted, which is a claim about the *range*. Pinning the literal ceiling
+    made a later release fail a test whose own docstring says the bound moves.
+    """
+    text = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+    m = re.search(r'"yantrikdb>=([\d.]+),<([\d.]+)"', text)
+    assert m, "engine pin is missing, unbounded, or no longer parseable"
+
+    def parts(v):
+        return tuple(int(x) for x in v.split("."))
+
+    return parts(m.group(1)), parts(m.group(2))
+
+
 class TestEngineCeiling:
     def test_admits_0_13_x(self, repo_root):
         """The whole point of the release: users get BM25 fusion."""
-        text = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
-        assert "yantrikdb>=0.12.1,<0.14.0" in text
+        floor, ceiling = _engine_bounds(repo_root)
+        assert floor <= (0, 13, 0), f"floor {floor} excludes 0.13.x"
+        assert ceiling > (0, 13, 0), f"ceiling {ceiling} excludes 0.13.x"
 
     def test_still_bounded(self, repo_root):
         """Raising a ceiling is not removing it. An unbounded pin is how
         yantrikdb-mcp lost a published release when a dependency shipped a
         new major; the bound moves, it never disappears."""
+        floor, ceiling = _engine_bounds(repo_root)
+        assert floor == (0, 12, 1), f"engine floor moved to {floor} unremarked"
         text = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
-        assert "yantrikdb>=0.12.1," in text
-        assert "<0.14.0" in text
         for line in text.splitlines():
             s = line.strip()
             if s.startswith('"yantrikdb>=') or s.startswith('"requests>='):

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.16.0] — 2026-08-12 — Engine 0.14.0 admitted, and one axis this release could not verify
+
+The ceiling moves from `<0.14.0` to `<0.15.0`. No plugin behaviour changes: this release is the compatibility claim and the evidence behind it.
+
+### What engine 0.14.0 gives you
+
+Caller-supplied `created_at` on record input, so an imported memory can carry the time it actually started rather than the time it was ingested. A caller-supplied `consolidate_cluster`. A `get_memory(rid)` point-read. Packs now expose their namespace. And the bundled embedder initialises **once per process** instead of once per instance, with bounded-backoff retry on download.
+
+### The one compile break cannot reach this plugin
+
+Engine 0.14.0 breaks Rust callers that construct `RecordInput` by struct literal. This plugin has no `Cargo.toml`, no `.rs` files, and zero `RecordInput` constructions — checked, not assumed. Pure-Python and MCP consumers are unaffected.
+
+### What the gate measured
+
+`tests/comparison/gate_4k.py` v1.3.0 on the hash-pinned 4,353-record corpus, 7 instances, both engines seeded by their own interpreter:
+
+| metric | 0.13.4 | 0.14.0 |
+|---|---|---|
+| precision@5 | 0.3929 (spread 0.0625) | 0.3750 (spread 0.0000) |
+| role_share | 0.8464 (spread 0.0500) | 0.8750 (spread 0.0000) |
+| possessive_top1 | 0.9167 | 0.9167 |
+| distinct_orderings | 2 | 2 |
+| lexical_degeneracy | 143 / 4 / 0.2797 | identical |
+
+**No primary metric moved outside 0.13.4's own measured spread.** Full suite 462 pass / 3 skip, identical on both. The plain encryption canary is clean with its control firing.
+
+The spread going to zero is the interesting number, and it is **not** a finding. The gate opens 7 instances and per-instance embedder init was the racy path, so 0.14.0's process-global init is a plausible mechanism — but nothing here tested that link, and one gate run is not a variance measurement.
+
+### What this release did **not** verify
+
+`benchmarks/encryption_migration_canary.py` returns `INCONCLUSIVE` on the 0.13.3 → 0.14.0 path at both 300 and 3,000 rows: the pre-fix writer left no plaintext, so the scan cannot demonstrate it would detect the freed-page case. **An INCONCLUSIVE is not a pass.** Whether 0.14.0 retains the VACUUM-then-checkpoint fix is untested by this release, and the ceiling moved anyway as an operator decision. If you enable encryption, that gap is yours to weigh — the plain canary covers fresh writes, not migrated pages.
+
+### A correction to how these numbers were produced
+
+The first comparison run for this release was invalid: the system interpreter had already been upgraded to 0.14.0, so a "0.13.4 baseline" measured 0.14.0 against itself, and reported a `distinct_orderings 1 → 2` regression that does not exist. The gate has always stamped `"engine"` in its output; the stamp was simply not read before the arm was trusted. Every number above comes from version-pinned virtualenvs with both stamps asserted first. **If you compare engine builds, assert the stamp before you compare the metrics** — the instrument recorded provenance correctly and the reading is where it failed.
+
 ## [0.15.0] — 2026-08-06 — Better retrieval, and one feature switched off on the evidence
 
 Two changes. One gives you a retrieval improvement that was sitting behind a version pin. The other **turns off a feature that has been quietly telling you nothing**, and explains why in enough detail that you can check the claim yourself.

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,8 +1,8 @@
 name: yantrikdb
-version: 0.15.0
+version: 0.16.0
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.12.1,<0.14.0
+  - yantrikdb>=0.12.1,<0.15.0
   - requests>=2.31,<3.0.0
 hooks:
   - on_session_end


### PR DESCRIPTION
Raises the engine ceiling from `<0.14.0` to `<0.15.0`. No plugin behaviour changes — this PR is the compatibility claim plus the evidence for it.

## What the gate measured

`tests/comparison/gate_4k.py` v1.3.0, hash-pinned 4,353-record corpus, 7 instances, each engine seeding its own copy from a version-pinned venv:

| metric | 0.13.4 | 0.14.0 |
|---|---|---|
| precision@5 | 0.3929 (spread 0.0625) | 0.3750 (spread 0.0000) |
| role_share | 0.8464 (spread 0.0500) | 0.8750 (spread 0.0000) |
| possessive_top1 | 0.9167 | 0.9167 |
| distinct_orderings | 2 | 2 |
| lexical_degeneracy | 143 / 4 / 0.2797 | identical |

No primary metric moved outside 0.13.4's own measured spread. Suite 462 pass / 3 skip on both engines. Plain encryption canary clean **with its control firing**.

0.14.0's only compile break is Rust struct-literal `RecordInput` callers — unreachable here (no `Cargo.toml`, no `.rs`, zero `RecordInput` constructions; checked).

## Two things this PR does not claim

**The zero spread is a hypothesis, not a finding.** The gate opens 7 instances and per-instance embedder init was the racy path, so 0.14.0's process-global init is a plausible mechanism — but nothing here tested that link, and one run is not a variance measurement.

**`encryption_migration_canary` returns INCONCLUSIVE** on 0.13.3 → 0.14.0 at both 300 and 3,000 rows: the pre-fix writer left no plaintext, so the scan cannot demonstrate it would detect the freed-page case. An INCONCLUSIVE is not a pass. Whether 0.14.0 retains the VACUUM-then-checkpoint fix is untested by this release. The ceiling moves anyway as an operator decision, and the CHANGELOG states the gap where an encryption user will see it.

## Correction

The first comparison run was invalid — the system interpreter had already moved to 0.14.0, so the "0.13.4 baseline" measured 0.14.0 against itself and reported a `distinct_orderings 1 → 2` regression that does not exist. The gate stamps `"engine"` in its output; the stamp was not read before the arm was trusted. Every number above comes from pinned venvs with both stamps asserted first.

## Test change

`test_v015_engine_013.py` now parses the pin rather than matching the literal ceiling — asserting 0.13.x stays admitted and the floor has not moved unremarked, which is the claim its docstring always made. The previous form failed on any ceiling raise, i.e. on exactly the event its own comment describes as normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)