### PR TITLE
fix(bench): the canary was measuring its own fixture, and more rows made it lie

### DIFF
--- a/benchmarks/encryption_migration_canary.py
+++ b/benchmarks/encryption_migration_canary.py
@@ -33,6 +33,28 @@ in the same run, on the same fixture.
 Verify the pair by also running it with a KNOWN-BAD candidate (0.13.2/0.13.3):
 it must report RESIDUAL. A run that only ever shows green has not been shown to
 go red.
+
+TWO WAYS TO GET A MEANINGLESS RESULT FROM THIS SCRIPT. Both were hit for real
+while gating engine 0.14.0, and both look like a pass if you do not read closely.
+
+1. THE PREFIX MUST PREDATE 0.13.2. There are two different "pre-fix" versions
+   here and conflating them wastes a day: the WRITE path was fixed in 0.13.2,
+   the FREED-PAGE erasure only in 0.13.4. Hand this script a 0.13.2 or 0.13.3
+   prefix and it seals on write, no plaintext is ever created, nothing can be
+   stranded, and you get INCONCLUSIVE — a true statement about the fixture and
+   no statement at all about the candidate. Use 0.13.1.
+
+2. ROW COUNT IS LOAD-BEARING, AND MORE IS WORSE. Measured 0.13.1 -> 0.13.3:
+
+       200 rows    before 203    after 4     RESIDUAL
+       500 rows    before 503    after 3     RESIDUAL
+      3000 rows    before 3000   after 0     "clean"  <-- FALSE GREEN
+
+   At 3000 rows the migration's own subsequent writes reuse the freed pages and
+   overwrite the plaintext incidentally, so a KNOWN-BAD engine reports clean.
+   The control still fires, which is what makes this dangerous: the run looks
+   fully qualified. Scaling rows up to "be thorough" inverts the result. Stay at
+   200-500 unless you have re-demonstrated a red at the larger count.
 """
 
 from __future__ import annotations
@@ -94,13 +116,28 @@ print(yantrikdb.__version__)
 
     before = _scan(work)
     if not before:
+        try:
+            sealed_on_write = tuple(
+                int(p) for p in pre_ver.split(".")[:3]
+            ) >= (0, 13, 2)
+        except ValueError:
+            sealed_on_write = False
+        detail = ("the pre-fix engine left no plaintext, so this scan cannot "
+                  "detect the freed-page case. A clean result below would "
+                  "mean nothing.")
+        if sealed_on_write:
+            detail += (f" NAMED CAUSE: the prefix arm is {pre_ver}, and the "
+                       "write path was fixed in 0.13.2 — it seals on write, so "
+                       "there is never plaintext to strand. This is a fixture "
+                       "error, not a finding about the candidate. Use a prefix "
+                       "older than 0.13.2 (0.13.1).")
+        else:
+            detail += (" Either the writer is already fixed, or the fixture "
+                       "is wrong.")
         print(json.dumps({
             "written_by": pre_ver,
             "verdict": "INCONCLUSIVE — the control failed",
-            "detail": ("the pre-fix engine left no plaintext, so this scan "
-                       "cannot detect the freed-page case. Either the writer "
-                       "is already fixed, or the fixture is wrong. A clean "
-                       "result below would mean nothing."),
+            "detail": detail,
         }, indent=2))
         return 2
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.16.0
+version: 0.17.0
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.16.0"
+version = "0.17.0"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,7 +3,34 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
-## [Unreleased]
+## [0.17.0] — 2026-08-16
+
+### Fixed — five silent config/wire defects (2026-08-15 downstream audit)
+
+All the same shape: accepted input, reported success, did something else.
+
+- **Config overlay coerces by the default's runtime type.** The hand-frozen
+  name sets stopped at v0.5, so `"gap_detection": "false"` in yantrikdb.json
+  set the truthy *string* and enabled the feature the operator disabled; a
+  string cadence raised TypeError inside `on_turn_start` every turn.
+- **HTTP retries no longer replay POSTs.** A server that committed and died
+  mid-response got `/v1/remember` silently duplicated; hook writes carry no
+  idempotency key, so POST retry-on-5xx is unsafe by construction.
+  Connect-level errors still retry (the request never reached the server).
+- **`until:"now"` is a point in time, not midnight** — the old mapping
+  excluded up to 24h of the freshest memories from a correct-looking recall.
+- **Setup writes `fleet_view_enabled`**, the key the overlay loop actually
+  reads; `"fleet_view"` was dropped by hasattr and silently ignored.
+- **fleet/packs tool schemas use `parameters`** like every other tool schema
+  in the file, so the host stops seeing two malformed tools.
+
+### Not verified in this release, on purpose
+
+The engine pin stays `>=0.12.1,<0.15.0`. Engine 0.15.0 changes retrieval
+(lexical-novelty selection, lane quotas, per-lane filter integrity, and
+formerly-inert tuning knobs now live); admitting it is a gated decision —
+the 0.15 admission rides the next release, after the gate runs on this
+plugin's own harness.
 
 ### The axis v0.16.0 shipped as unverified is now verified
 

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [Unreleased]
+
+### The axis v0.16.0 shipped as unverified is now verified
+
+v0.16.0 said the freed-page erasure could not be certified because `encryption_migration_canary.py` returned `INCONCLUSIVE`. **That was a defect in the fixture, not an open question about the engine.** It is closed:
+
+```
+0.13.1 -> 0.13.3   before 203 / 503   after 4 / 3   RESIDUAL   <- the red proof
+0.13.1 -> 0.13.4   before 203 / 503   after 0       clean
+0.13.1 -> 0.14.0   before 203 / 503   after 0       clean
+0.13.1 -> 0.14.1   before 203 / 503   after 0       clean
+```
+
+Two mistakes were in the way, and the script now documents and detects both. The prefix arm must predate **0.13.2** — the write path was fixed there, so a 0.13.2/0.13.3 prefix seals on write and never creates plaintext to strand; the run now names that cause instead of leaving the operator to guess between two possibilities. And **row count is load-bearing in the direction nobody expects**: the residue shows at 200 and 500 rows and vanishes at 3,000, because the migration's own later writes reuse the freed pages and erase the evidence. A 3,000-row run reports *clean on a known-bad engine* with its control still firing — a false green that looks fully qualified. Raising the row count "to be thorough" inverts the result.
+
+### Engine 0.14.1 measured, and one earlier hypothesis retracted
+
+0.14.1 lands inside the shipped `<0.15.0` ceiling and changes recall ranking, so it was measured rather than assumed. Three runs per arm, engine stamps asserted first, compared as **across-run ranges**:
+
+| metric | 0.13.4 (3 runs) | 0.14.1 (3 runs) | |
+|---|---|---|---|
+| precision@5 | 0.3750–0.3929 | 0.3839 | overlap — not a result |
+| role_share | 0.8250–0.8750 | 0.8333 | overlap — not a result |
+| possessive_top1 | 0.9167 | **1.0000** | real |
+| possessive_jaccard | 0.8690–0.8889 | **0.9722** | real |
+| direction_separation | 0.0690–0.0952 | **0.1310–0.1429** | real, no overlap |
+| distinct_orderings | 2, 2, 1 | 1, 1, 1 | |
+
+**v0.16.0's zero-spread hypothesis is retracted.** It suggested engine 0.14.0's process-global embedder init explained the gate's cross-instance spread collapsing to zero. Re-running the identical gate on 0.13.4 gave spreads of 0.0625/0.0500, then 0.0000/0.0000, then 0.0000/0.0000 — **0.13.4 produces zero spread too.** The single observation was noise.
+
+That retraction exposed a **defect in how this gate is read**. Its `spread` is *within-run* variation across the 7 instances, and its own `reading` text says a change larger than it is real. That yardstick generates false positives: `role_share` moved 0.8750 → 0.8333 with spread 0.0000 on both arms, which clears the stated bar — yet 0.13.4 alone ranges 0.8250–0.8750 across runs and contains both values. **Compare across-run ranges from repeated runs; a single run's spread is not a variance measurement.**
+
 ## [0.16.0] — 2026-08-12 — Engine 0.14.0 admitted, and one axis this release could not verify
 
 The ceiling moves from `<0.14.0` to `<0.15.0`. No plugin behaviour changes: this release is the compatibility claim and the evidence behind it.

--- a/yantrikdb/__init__.py
+++ b/yantrikdb/__init__.py
@@ -855,7 +855,7 @@ FLEET_SCHEMA = {
         "or 'which of my agents is stuck?' before duplicating effort. Read-"
         "only, and never available when per-user scoping is on."
     ),
-    "input_schema": {"type": "object", "properties": {}, "required": []},
+    "parameters": {"type": "object", "properties": {}, "required": []},
 }
 
 PACKS_SCHEMA = {
@@ -877,7 +877,7 @@ PACKS_SCHEMA = {
         "refusal prevents confidently wrong answers, so report it rather "
         "than retrying with allow_unverified_embedder."
     ),
-    "input_schema": {
+    "parameters": {
         "type": "object",
         "properties": {
             "action": {
@@ -1318,7 +1318,13 @@ def _parse_time_filter(value: Any) -> float | None:
     today_midnight = _dt.datetime.now().replace(
         hour=0, minute=0, second=0, microsecond=0,
     ).timestamp()
-    if s in ("now", "today"):
+    if s == "now":
+        # "now" is a point in time, not a day. Mapping it to midnight made
+        # `until: "now"` exclude everything stored since midnight — up to
+        # 24h of the freshest memories vanished from a recall that looked
+        # correct (2026-08-15 downstream audit).
+        return now
+    if s == "today":
         return today_midnight
     if s == "yesterday":
         return today_midnight - 86400
@@ -1629,7 +1635,11 @@ class YantrikDBMemoryProvider(MemoryProvider):
                 "env_var": "YANTRIKDB_SHARED_BRAIN_NAMESPACE",
             },
             {
-                "key": "fleet_view",
+                # Was "fleet_view" — the config attribute is
+                # fleet_view_enabled, and the overlay loop drops unknown
+                # keys via hasattr: setup wrote the value and it was
+                # silently ignored (2026-08-15 downstream audit).
+                "key": "fleet_view_enabled",
                 "description": (
                     "Running several agents and want to SEE across them? Adds "
                     "a read-only `yantrikdb_fleet` tool reporting each sibling "
@@ -1728,7 +1738,15 @@ class YantrikDBMemoryProvider(MemoryProvider):
         # requires a token. is_available() short-circuits at the provider
         # level, but be defensive here too.
         if self._config.mode == "http" and not self._config.token:
-            logger.debug("YantrikDB http mode but no token — plugin inactive")
+            # Surfaced, not debug-logged: without _init_error the prompt
+            # block rendered as if memory simply didn't exist and tools
+            # failed with a generic "not active" — the silently-absent
+            # state v0.4.4 fixed for every OTHER init failure.
+            self._init_error = (
+                "http mode configured but YANTRIKDB_TOKEN is empty — "
+                "set the token or switch mode to embedded"
+            )
+            logger.error("YantrikDB %s", self._init_error)
             return
 
         self._base_namespace = _derive_namespace(self._config.namespace, kwargs)
@@ -4418,11 +4436,12 @@ class YantrikDBMemoryProvider(MemoryProvider):
 
         def _run() -> None:
             try:
+                # _run_maintenance already runs auto-ack + gap-tasks when
+                # configured; calling them again here drained triggers and
+                # scanned gaps twice per cadence — wasted round-trips today,
+                # a double-write the moment either helper gains a
+                # non-idempotent step (2026-08-15 downstream audit).
                 self._run_maintenance(reason="periodic")
-                if cfg.auto_acknowledge_triggers:
-                    self._auto_acknowledge_pending_triggers()
-                if cfg.auto_gap_tasks:
-                    self._auto_gap_tasks()
             except YantrikDBError as e:
                 logger.debug("YantrikDB periodic maintenance failed: %s", e)
 

--- a/yantrikdb/client.py
+++ b/yantrikdb/client.py
@@ -719,7 +719,22 @@ class YantrikDBConfig:
             elif key in bool_fields:
                 setattr(cfg, key, _parse_bool(val, default=getattr(cfg, key)))
             else:
-                setattr(cfg, key, val)
+                # Coerce by the DEFAULT's runtime type. The hand-maintained
+                # name sets above were frozen at v0.5; every knob added
+                # since fell through to raw setattr — so a yantrikdb.json
+                # carrying "gap_detection": "false" set the truthy STRING
+                # "false" and silently ENABLED the feature the operator
+                # disabled, and a string cadence raised TypeError inside
+                # on_turn_start every turn (2026-08-15 downstream audit).
+                current = getattr(cfg, key)
+                if isinstance(current, bool):
+                    setattr(cfg, key, _parse_bool(val, default=current))
+                elif isinstance(current, int) and not isinstance(current, bool):
+                    setattr(cfg, key, _parse_int(val, current))
+                elif isinstance(current, float):
+                    setattr(cfg, key, _parse_float(val, current))
+                else:
+                    setattr(cfg, key, val)
         return cfg
 
 
@@ -849,7 +864,13 @@ class YantrikDBClient:
             read=min(config.retry_total, 2),
             backoff_factor=0.5,
             status_forcelist=(500, 502, 504),
-            allowed_methods=frozenset(("GET", "POST", "DELETE")),
+            # POST removed 2026-08-15: retrying non-idempotent /v1/remember
+            # (and relate/task/skill writes) on a 5xx transparently REPLAYS
+            # the write — a server that committed and died mid-response got
+            # the memory silently duplicated, and the plugin's hook writes
+            # carry no idempotency key. Connect-level errors still retry
+            # safely (the request never reached the server).
+            allowed_methods=frozenset(("GET", "DELETE")),
             respect_retry_after_header=True,
             raise_on_status=False,
         )

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.16.0
+version: 0.17.0
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.12.1,<0.15.0


### PR DESCRIPTION
Closes the axis [v0.16.0](https://github.com/yantrikos/yantrikdb-hermes-plugin/releases/tag/v0.16.0) shipped as unverified. It was a defect in the fixture, not an open question about the engine.

```
0.13.1 -> 0.13.3   before 203 / 503   after 4 / 3   RESIDUAL   <- the red proof
0.13.1 -> 0.13.4   before 203 / 503   after 0       clean
0.13.1 -> 0.14.0   before 203 / 503   after 0       clean
0.13.1 -> 0.14.1   before 203 / 503   after 0       clean
```

## Two mistakes were in the way

**The prefix arm must predate 0.13.2.** Two different "pre-fix" versions were conflated: the *write* path was fixed in 0.13.2, the *freed-page* erasure only in 0.13.4. A 0.13.2/0.13.3 prefix seals on write, so no plaintext is ever created and nothing can be stranded. The `INCONCLUSIVE` was a true statement about the fixture and no statement at all about the candidate. The script now **detects and names** that case rather than offering the operator two possibilities with no way to tell them apart.

**Row count is load-bearing in the direction nobody expects.** Residue shows at 200 and 500 rows and *vanishes* at 3,000 — the migration's own later writes reuse the freed pages and overwrite the plaintext incidentally. A 3,000-row run reports **clean on a known-bad engine, with its control still firing**: a false green that looks fully qualified. Raising the row count "to be thorough" inverts the result.

## Also recorded

Engine **0.14.1** lands inside the shipped `<0.15.0` ceiling and changes recall ranking, so it was measured, not assumed. Three runs per arm, stamps asserted, compared as across-run ranges:

| metric | 0.13.4 (3 runs) | 0.14.1 (3 runs) | |
|---|---|---|---|
| precision@5 | 0.3750–0.3929 | 0.3839 | overlap — not a result |
| role_share | 0.8250–0.8750 | 0.8333 | overlap — not a result |
| possessive_top1 | 0.9167 | **1.0000** | real |
| possessive_jaccard | 0.8690–0.8889 | **0.9722** | real |
| direction_separation | 0.0690–0.0952 | **0.1310–0.1429** | real, no overlap |
| distinct_orderings | 2, 2, 1 | 1, 1, 1 | |

**v0.16.0's zero-spread hypothesis is retracted.** Re-running the identical gate on 0.13.4 gave 0.0625/0.0500, then 0.0000/0.0000, then 0.0000/0.0000 — 0.13.4 produces zero spread too. The single observation was noise.

That retraction exposed a **defect in how this gate is read**. Its `spread` is *within-run* variation across the 7 instances, and its own `reading` text says a change larger than it is real. That yardstick generates false positives: `role_share` moved 0.8750 → 0.8333 with spread 0.0000 on both arms — clearing the stated bar — while 0.13.4 alone ranges 0.8250–0.8750 across runs and contains both values.

Suite 462 pass / 3 skip; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)