### PR TITLE
deps: admit engine 0.15.3, exclude 0.15.0–0.15.2 (v0.18.0)

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.17.0
+version: 0.18.0
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the
@@ -7,7 +7,7 @@ version: 0.17.0
 # `yantrikdb-hermes install <hermes>`. Both should declare the same version.
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.12.1,<0.15.0
+  - yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.16.0
   - requests>=2.31,<3.0.0
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.17.0"
+version = "0.18.0"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -42,7 +42,7 @@ classifiers = [
 # shipped 2.0.0 against an unbounded pin. tests/test_dependency_pins.py enforces
 # this; raise a ceiling only after testing against the new major.
 dependencies = [
-  "yantrikdb>=0.12.1,<0.15.0",
+  "yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.16.0",
   "requests>=2.31,<3.0.0",
 ]
 

--- a/tests/test_gap_calibration.py
+++ b/tests/test_gap_calibration.py
@@ -78,6 +78,7 @@ def _default_threshold(client_module) -> float:
 
 
 class TestGapThresholdCalibration:
+    @pytest.mark.xfail(reason="engine >=0.15.0 folded the priors into one bounded budget, so composite scores rescaled (comp/similarity 1.0644 -> 0.7788, embedder held fixed). At 5,218-record scale the nonsense band 0.2346-0.3050 OVERLAPS the real band 0.2346-0.3946, so NO constant separates them and there is nothing to recalibrate to. This is the instrument defect YantrikDBConfig documents, not a stale number. gap_detection stays False; TestGapSignalIsOffByDefault is the guard that still binds.", strict=False)
     def test_answerable_questions_are_not_called_gaps(
         self, answered_scores, client_module,
     ):
@@ -97,6 +98,7 @@ class TestGapThresholdCalibration:
             "that mints tasks for questions the memory answers correctly."
         )
 
+    @pytest.mark.xfail(reason="engine >=0.15.0 folded the priors into one bounded budget, so composite scores rescaled (comp/similarity 1.0644 -> 0.7788, embedder held fixed). At 5,218-record scale the nonsense band 0.2346-0.3050 OVERLAPS the real band 0.2346-0.3946, so NO constant separates them and there is nothing to recalibrate to. This is the instrument defect YantrikDBConfig documents, not a stale number. gap_detection stays False; TestGapSignalIsOffByDefault is the guard that still binds.", strict=False)
     def test_threshold_still_has_headroom_below_answered_scores(
         self, answered_scores, client_module,
     ):

--- a/tests/test_v015_engine_013.py
+++ b/tests/test_v015_engine_013.py
@@ -59,21 +59,43 @@ def _provider(provider_module, mock_client, monkeypatch, **env):
     return p
 
 
+def _engine_spec(repo_root):
+    """The raw engine specifier string from pyproject."""
+    text = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+    m = re.search(r'"(yantrikdb>=[^"]+)"', text)
+    assert m, "engine pin is missing or no longer parseable"
+    return m.group(1)
+
+
 def _engine_bounds(repo_root):
     """(floor, ceiling) of the engine pin as (major, minor, patch) tuples.
 
     Parsed rather than string-matched: this file asserts that 0.13.x stays
     admitted, which is a claim about the *range*. Pinning the literal ceiling
     made a later release fail a test whose own docstring says the bound moves.
+
+    Tolerates `!=` exclusions between the bounds. A pin may need to admit a
+    range while excluding named releases inside it — excluding a known-bad
+    version is not the same as being unbounded, and the parser must not
+    conflate them. See `_engine_exclusions` for the other half of the claim.
     """
-    text = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
-    m = re.search(r'"yantrikdb>=([\d.]+),<([\d.]+)"', text)
-    assert m, "engine pin is missing, unbounded, or no longer parseable"
+    spec = _engine_spec(repo_root)
+    floor = re.search(r">=([\d.]+)", spec)
+    ceiling = re.search(r"<([\d.]+)", spec)
+    assert floor and ceiling, f"engine pin is missing a bound: {spec}"
 
     def parts(v):
         return tuple(int(x) for x in v.split("."))
 
-    return parts(m.group(1)), parts(m.group(2))
+    return parts(floor.group(1)), parts(ceiling.group(1))
+
+
+def _engine_exclusions(repo_root):
+    """Versions the pin explicitly refuses, as (major, minor, patch) tuples."""
+    return {
+        tuple(int(x) for x in v.split("."))
+        for v in re.findall(r"!=([\d.]+)", _engine_spec(repo_root))
+    }
 
 
 class TestEngineCeiling:
@@ -82,6 +104,26 @@ class TestEngineCeiling:
         floor, ceiling = _engine_bounds(repo_root)
         assert floor <= (0, 13, 0), f"floor {floor} excludes 0.13.x"
         assert ceiling > (0, 13, 0), f"ceiling {ceiling} excludes 0.13.x"
+
+    def test_known_bad_releases_stay_excluded(self, repo_root):
+        """Engine 0.15.0-0.15.2 changed the score SCALE (priors moved into one
+        bounded budget) without changing ranking, and shipped three ranking
+        defects the engine fixed in 0.15.3. They sit inside the admitted range,
+        so they are excluded by name. Measured, embedder held fixed at 64 dims:
+        composite/similarity fell 1.0644 -> 0.7788 across that boundary while
+        similarity itself was byte-identical.
+
+        If a later release widens the range, these exclusions must survive or
+        be replaced by a floor above them — dropping them silently re-admits
+        the defects."""
+        floor, ceiling = _engine_bounds(repo_root)
+        excluded = _engine_exclusions(repo_root)
+        for bad in [(0, 15, 0), (0, 15, 1), (0, 15, 2)]:
+            if floor <= bad < ceiling:
+                assert bad in excluded, (
+                    f"{bad} is inside the admitted range {floor}..{ceiling} "
+                    f"and is not excluded; it carries known ranking defects"
+                )
 
     def test_still_bounded(self, repo_root):
         """Raising a ceiling is not removing it. An unbounded pin is how

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,101 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.18.0] — 2026-08-18
+
+### The 0.15 line is admitted — except the three releases that should not be
+
+Pin: `yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.16.0`.
+
+v0.17.0 shipped `<0.15.0` and said the 0.15 admission "rides the next release,
+after the gate runs on this plugin's own harness." The gate has run, on the
+homelab container, and it found more than a yes/no.
+
+**The recall gate holds.** `benchmarks/run_recall_bench.py`, three runs per arm:
+recall@1 0.973, @3/@5/@10 1.000, answer-containment identical, MRR 0.987 — byte
+identical on 0.14.1 and 0.15.3, zero variance. No regression in ranking.
+
+**0.15.0 rescaled composite scores, and ranking-only metrics cannot see it.**
+With the embedder held fixed at 64 dims (see the harness note below), similarity
+is byte-identical across engines — median 0.6044, min 0.3368, max 0.9206 — while
+the multiplier applied on top of it moves:
+
+| | 0.14.1 | 0.15.0 | 0.15.3 |
+|---|---|---|---|
+| composite ÷ similarity, median | 1.0644 | 0.7788 | 0.7788 |
+| composite ÷ similarity, **max** | **1.4317** | **1.1917** | 1.1917 |
+| avg-top3, median | 0.4721 | 0.3357 | 0.3357 |
+
+The max crossing 1.30 is the mechanism: engine commit `8ad509b` replaced an
+unbounded multiplicative freshness factor with `score = relevance ×
+exp(POLICY_BUDGET_LN × Σwᵢzᵢ)`, capped at 1.30. MRR did not move because a
+near-uniform scale factor preserves order. **A benchmark that measures only
+ranking is structurally blind to a rescaling — and every consumer that
+thresholds a raw score is invisible to it.** That is the finding worth carrying.
+
+0.15.1, 0.15.2 and 0.15.3 are identical to 0.15.0 on every figure above.
+
+### `gap_max_avg_top_score` is not recalibrated, and cannot be
+
+The rescaling puts the 0.30 default above the answered distribution, so
+`test_gap_calibration` fails on the 0.15 line. The obvious response is to pick a
+new constant. It does not exist. Measured with `benchmarks/gap_floor_check.py`
+on engine 0.15.3 against a **5,218-record** corpus — the scale this project's own
+0.13.0 measurement used:
+
+```
+nonsense  0.2346  0.2674  0.2709  0.3050
+real      0.2346 ........................ 0.3946
+```
+
+The bands overlap. 0.22 flags every real query; 0.31 reports "quantum tarpaulin
+metric" as answered. This reproduces the instrument defect `YantrikDBConfig`
+already documents, on a newer engine and a different corpus, and confirms the
+call made there: *the defect is the instrument, not the number.*
+
+A 40-record corpus does **not** reproduce it — nonsense separates cleanly at that
+size, because a random string has too few neighbours to look plausible. Anyone
+re-testing this must do it at realistic scale or they will measure the corpus
+rather than the detector.
+
+The two calibration tests are therefore `xfail` with that measurement recorded,
+not deleted and not "fixed" by moving the constant. `gap_detection` stays
+`False`, and the eight tests that enforce that — including
+`test_off_by_default_because_the_signal_does_not_discriminate` — still bind.
+
+### Two harness defects found while running the gate
+
+- **`run_recall_bench.py` reports an embedder it does not control.** Line 123
+  prints `Embedder: bundled potion-2M` as a hardcoded literal, and `_bootstrap`
+  pins nothing. Engine 0.15.0 introduced a 256-dim `potion-base-8M` default for
+  new stores, so on any engine ≥0.15.0 the bench silently used a different model
+  than it claimed. Every comparison spanning that boundary is embedder-confounded
+  and the output conceals it. The numbers above were re-taken with the dimension
+  pinned explicitly; an earlier confounded run overstated the effect by ~50%.
+- **`_engine_bounds` could not parse a pin containing `!=`.** It reported a
+  bounded pin as "missing, unbounded, or no longer parseable". Widened, and
+  `test_known_bad_releases_stay_excluded` now asserts the exclusions survive so
+  a later widening cannot silently re-admit 0.15.0–0.15.2.
+
+### Why those three releases are excluded rather than admitted
+
+Engine 0.15.0–0.15.2 carry ranking defects fixed in 0.15.3: freshness computed
+from `last_access` (which `reinforce()` mutates on every recall that *returns* a
+record, so ranking depended on who had read a memory), valence applied outside
+the policy budget with no range check (valence=100 → 31× multiplier), and a
+rescue lane that self-disabled with use. Admitting them because they sit inside a
+widened range would be the same mistake as an unbounded `>=`.
+
+The floor is unchanged, so no currently-supported engine is dropped.
+
+### Verified in the homelab container
+
+Plugin source + engine 0.15.3: every provider surface exercised (health,
+record_turn, recall, list_records, recent_turns, conflicts, knowledge_gaps,
+pending_triggers) with results identical to the 0.14.1 baseline; the agent's own
+memory migrated schema 40 → 41 with rows and integrity intact; `hermes memory
+status` reports the provider available. Suite: 461 passed, 3 skipped, 2 xfailed.
+
 ## [0.17.0] — 2026-08-16
 
 ### Fixed — five silent config/wire defects (2026-08-15 downstream audit)

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,8 +1,8 @@
 name: yantrikdb
-version: 0.17.0
+version: 0.18.0
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.12.1,<0.15.0
+  - yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.16.0
   - requests>=2.31,<3.0.0
 hooks:
   - on_session_end


### PR DESCRIPTION
v0.17.0 deferred the 0.15 admission until the gate ran on this plugin's own harness. It has run — in the homelab container, never locally — and it found more than a yes/no.

Pin: `yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.16.0`

## The recall gate holds

`run_recall_bench.py`, three runs per arm, 0.14.1 vs 0.15.3: recall@1 0.973, @3/@5/@10 1.000, answer-containment identical, **MRR 0.987** — byte-identical, zero variance.

## But 0.15.0 rescaled composite scores, and ranking metrics cannot see it

With the embedder pinned at 64 dims, similarity is byte-identical across engines (median 0.6044 / min 0.3368 / max 0.9206) while the multiplier on top of it moves:

| | 0.14.1 | 0.15.0 | 0.15.3 |
|---|---|---|---|
| composite ÷ similarity (median) | 1.0644 | 0.7788 | 0.7788 |
| composite ÷ similarity (**max**) | **1.4317** | **1.1917** | 1.1917 |
| avg-top3 (median) | 0.4721 | 0.3357 | 0.3357 |

The max crossing **1.30** is the mechanism — engine `8ad509b` replaced an unbounded multiplicative freshness factor with `score = relevance × exp(POLICY_BUDGET_LN × Σwᵢzᵢ)`, capped at 1.30. MRR didn't move because a near-uniform scale factor **preserves order**.

> A benchmark that measures only ranking is structurally blind to a rescaling — and every consumer that thresholds a raw score is invisible to it.

0.15.1/.2/.3 are identical to 0.15.0 on every figure.

## `gap_max_avg_top_score` is not recalibrated, because it cannot be

Measured with `gap_floor_check.py` on a **5,218-record** corpus — the scale the 0.13.0 measurement used:

```
nonsense  0.2346  0.2674  0.2709  0.3050
real      0.2346 ........................ 0.3946
```

The bands overlap. 0.22 flags every real query; 0.31 reports "quantum tarpaulin metric" as answered. This reproduces the instrument defect `YantrikDBConfig` documents and **confirms its call** — the defect is the instrument, not the number.

A 40-record corpus does *not* reproduce this: nonsense separates cleanly at that size because a random string has too few neighbours to look plausible. That is how I first got this wrong, and anyone re-testing must use realistic scale or they'll measure the corpus instead of the detector.

The two calibration tests are `xfail` with the measurement recorded — not deleted, not "fixed" by moving the constant. `gap_detection` stays `False`, and the **eight** tests enforcing that still bind, including `test_off_by_default_because_the_signal_does_not_discriminate`.

## Two harness defects found while running the gate

- **`run_recall_bench.py:123` reports an embedder it does not control** — it prints `Embedder: bundled potion-2M` as a hardcoded literal while `_bootstrap` pins nothing. Engine 0.15.0 introduced a 256-dim `potion-base-8M` default for new stores, so on any engine ≥0.15.0 the bench used a different model than it claimed. Every comparison spanning that boundary is embedder-confounded and the output conceals it — an earlier confounded run of mine overstated the effect by ~50%.
- **`_engine_bounds` could not parse a pin containing `!=`**, reporting a bounded pin as "missing, unbounded, or no longer parseable". Widened, and `test_known_bad_releases_stay_excluded` now asserts the exclusions survive so a later widening cannot silently re-admit 0.15.0–0.15.2.

## Why those three are excluded rather than admitted

They carry the ranking defects fixed in 0.15.3: freshness computed from `last_access` (which `reinforce()` mutates on every recall that *returns* a record), valence applied outside the policy budget with no range check (`valence=100` → 31×), and a rescue lane that self-disabled with use. Admitting them because they sit inside a widened range would be the same mistake as an unbounded `>=`.

Floor unchanged — no currently-supported engine is dropped.

## Gates

**461 passed, 3 skipped, 2 xfailed** on engine 0.15.3. Verified end-to-end in the container: all provider surfaces identical to the 0.14.1 baseline, agent memory migrated schema 40 → 41 with rows and integrity intact, `hermes memory status` reports available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)