### PR TITLE
release: v0.18.2 — the release notes re-introduced the CRITICAL the release removed

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.18.1
+version: 0.18.2
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.18.1"
+version = "0.18.2"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -156,7 +156,7 @@ exclude = ["reference/", "tests/", "^__init__\\.py$"]
 # matching `## [X.Y.Z] — YYYY-MM-DD — Summary` header. The CI `version-sync`
 # job blocks merge if the three sources drift.
 [tool.bumpversion]
-current_version = "0.18.1"
+current_version = "0.18.2"
 commit = false       # let the human author the commit message + body
 tag = false          # tag via `gh release create`, not on bump
 allow_dirty = true

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
-## [0.18.1] — 2026-08-18 — Installable again
+## [0.18.2] — 2026-08-18 — Installable again, this time verified on a fresh clone
 
 Hermes v0.20.x scans plugin repositories on `hermes plugins install` and blocks a community plugin on **any single critical finding** — `--force` does not override it. This plugin tripped three, and all three were false positives. Reported by @luismanson in #67.
 
@@ -17,11 +17,15 @@ Hermes v0.20.x scans plugin repositories on `hermes plugins install` and blocks 
 
 ### What was flagged, and why it was wrong
 
-The init-failure prompt said *"Do NOT tell the user their memories were saved — they were not."* That matches `deception_hide`, whose description is "instructs agent to hide information from user" — **the exact opposite of what the sentence does.** It is an anti-deception guard: when the plugin fails to initialise, the agent must not claim a save that never happened. It now reads as a positive directive, which is better prompting regardless of any scanner. The test asserting it checks the behaviour (`"nothing was saved"`) rather than the sentence, so rewording it again won't break it twice.
+The init-failure prompt used a negative imperative — an instruction *not* to inform the user that their memories had been saved, because they had not been. That matches `deception_hide`, whose description is "instructs agent to hide information from user" — **the exact opposite of what the sentence does.** It is an anti-deception guard: when the plugin fails to initialise, the agent must not claim a save that never happened. It now reads as a positive directive, which is better prompting regardless of any scanner. The test asserting it checks the behaviour (`"nothing was saved"`) rather than the sentence, so rewording it again won't break it twice.
 
-`extractor.py` described its stopword list as "words that pretend to be names", tripping `role_pretend`. They don't pretend anything; they look like names. The new wording is simply more accurate.
+`extractor.py` described its stopword list with a verb implying those words impersonate names, tripping `role_pretend`. They don't impersonate anything; they look like names. The new wording is simply more accurate.
 
 The third was `tests/test_semantic_contract.py`, which stores prompt-injection text and asserts it round-trips **verbatim** — a test that the trust boundary holds, read by the scanner as the attack it tests for. The payload is now an equally hostile string that isn't the scanner's signature. That case asserts byte-fidelity of adversarial text, so the exact wording carries no load; **obfuscating** it would have weakened the test, but **substituting** it does not. A comment says so, because restoring the canonical phrase would silently re-block every install.
+
+### Why this entry paraphrases instead of quoting
+
+v0.18.1 quoted the two offending strings verbatim to explain the fix — and this file ships inside the repository the scanner walks, so **the release notes re-introduced the CRITICAL the release removed.** A fresh clone of v0.18.1 still scanned `DANGEROUS`. The strings above are described rather than reproduced for that reason. If you document a scanner finding, do not paste its trigger into a tracked file.
 
 ### The other 108 findings are deliberate
 

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.18.1
+version: 0.18.2
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
   - yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.16.0


### PR DESCRIPTION
v0.18.1 quoted both offending strings verbatim in order to explain the fix. `CHANGELOG.md` ships inside the repository the scanner walks, so **a fresh clone of v0.18.1 still scanned `DANGEROUS`** — same `deception_hide` pattern, now at `yantrikdb/CHANGELOG.md:20`, inside the notes announcing its removal. The `role_pretend` string returned the same way on line 22.

The release did not achieve the thing it claimed.

| | verdict | findings | criticals |
|---|---|---|---|
| fresh clone of v0.18.1 | dangerous | 110 | 1 |
| this PR | **caution** | 108 | **0** |

## The fix

Both strings are now *described* rather than reproduced, plus a section explaining why — so the next person documenting a scanner finding doesn't paste the trigger into a tracked file.

## Process error worth recording

I scanned at `d2a87db`, got `CAUTION` / 0 criticals, and treated that as the release verdict. The changelog landed afterwards in `4c8f342` and I shipped without re-scanning. **I verified an intermediate state and reported it as the shipped state.**

That's the same shape as two earlier failures in this arc: reading a gate metric without checking the engine stamp, and running a canary whose fixture couldn't produce the condition it scanned for. Verify the artifact you are actually shipping, at the commit you are actually shipping. This PR was scanned on the assembled tree before tagging.

## Scope

v0.18.1 stays on PyPI and is functionally identical — the Python package is unaffected, since `CHANGELOG.md` is documentation and isn't part of the importable module surface. Only `hermes plugins install`, which clones and scans the repo, saw the regression.

Suite 461 pass / 3 skip / 2 xfail; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)