### PR TITLE
test: make the 4k comparison gate reproducible

### DIFF
--- a/tests/comparison/compare_gate_4k.py
+++ b/tests/comparison/compare_gate_4k.py
@@ -1,0 +1,429 @@
+"""Compare canonical gate v1.4 reports from two isolated Python environments."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import statistics
+import subprocess
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+GATE_NAME = "hermes-plugin/competing-distractors"
+GATE_VERSION = "1.4.0"
+COMPARATOR_VERSION = "1.4.0"
+DEFAULT_TOP_K = 5
+DEFAULT_STABILITY_QUERY = "What is Taylor's role?"
+
+_ENGINE_KEYS = {"distribution_version", "module_file", "import_source", "wheel_sha256"}
+_HOST_KEYS = {"platform", "python"}
+_FIXTURE_KEYS = {"corpus_sha256", "queries_sha256", "probes_sha256"}
+_SEED_KEYS = {"path", "sha256", "bytes", "mtime_unix", "created_at_min",
+              "created_at_max", "record_count"}
+_CONFIG_KEYS = {"metric_repeats", "stability_runs", "drift_probe_seconds",
+                "top_k", "stability_query"}
+
+
+class ComparisonRefusal(ValueError):
+    """Raised when reports are not demonstrably comparable."""
+
+
+@dataclass(frozen=True)
+class GateConfig:
+    metric_repeats: int
+    stability_runs: int
+    drift_probe_seconds: int
+    top_k: int = DEFAULT_TOP_K
+    stability_query: str = DEFAULT_STABILITY_QUERY
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "metric_repeats": self.metric_repeats,
+            "stability_runs": self.stability_runs,
+            "drift_probe_seconds": self.drift_probe_seconds,
+            "top_k": self.top_k,
+            "stability_query": self.stability_query,
+        }
+
+
+@dataclass(frozen=True)
+class ArmRun:
+    arm: str
+    round_number: int
+    report: Mapping[str, Any]
+
+
+Runner = Callable[[str, Path, Path, GateConfig], Mapping[str, Any]]
+Hasher = Callable[[Path], str]
+
+
+def _refuse(message: str) -> None:
+    raise ComparisonRefusal(message)
+
+
+def _mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        _refuse(f"{field} must be a JSON object")
+    return value
+
+
+def _list(value: Any, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        _refuse(f"{field} must be a JSON array")
+    return value
+
+
+def _require_keys(value: Mapping[str, Any], keys: set[str], field: str) -> None:
+    missing = sorted(keys - set(value))
+    if missing:
+        _refuse(f"{field} is missing canonical fields: {', '.join(missing)}")
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=True).encode("ascii")
+
+
+def _seed_fingerprint(db_path: Path) -> str:
+    """Use the runner's exact name+NUL+bytes digest over the whole seed bundle."""
+    files = sorted(
+        (path for path in db_path.parent.glob(db_path.name + "*") if path.is_file()),
+        key=lambda path: path.name,
+    )
+    digest = hashlib.sha256()
+    for path in files:
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\0")
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        _refuse(f"{field} must be numeric")
+    return float(value)
+
+
+def _validate_signature(item: Any, field: str) -> Mapping[str, Any]:
+    signature = _mapping(item, field)
+    _require_keys(signature, {"ordering_rids", "ordering_texts", "count",
+                              "observed_at_unix"}, field)
+    rids = _list(signature["ordering_rids"], f"{field}.ordering_rids")
+    texts = _list(signature["ordering_texts"], f"{field}.ordering_texts")
+    if len(rids) != len(texts):
+        _refuse(f"{field} RID/text ordering lengths differ")
+    count = signature["count"]
+    if isinstance(count, bool) or not isinstance(count, int) or count < 1:
+        _refuse(f"{field}.count must be a positive integer")
+    timestamps = _list(signature["observed_at_unix"], f"{field}.observed_at_unix")
+    if len(timestamps) != count:
+        _refuse(f"{field}.count does not match observed_at_unix length")
+    for index, timestamp in enumerate(timestamps):
+        _number(timestamp, f"{field}.observed_at_unix[{index}]")
+    return signature
+
+
+def _validate_report(report: Mapping[str, Any], label: str, expected: GateConfig) -> None:
+    if report.get("gate") != GATE_NAME:
+        _refuse(f"{label} gate mismatch: {report.get('gate')!r}")
+    if report.get("gate_version") != GATE_VERSION:
+        _refuse(f"{label} gate version mismatch: expected {GATE_VERSION!r}, "
+                f"got {report.get('gate_version')!r}")
+
+    engine = _mapping(report.get("engine"), f"{label}.engine")
+    host = _mapping(report.get("host"), f"{label}.host")
+    fixtures = _mapping(report.get("fixtures"), f"{label}.fixtures")
+    seed = _mapping(report.get("seed"), f"{label}.seed")
+    config = _mapping(report.get("config"), f"{label}.config")
+    observed = _mapping(report.get("observed"), f"{label}.observed")
+    _require_keys(engine, _ENGINE_KEYS, f"{label}.engine")
+    _require_keys(host, _HOST_KEYS, f"{label}.host")
+    _require_keys(fixtures, _FIXTURE_KEYS, f"{label}.fixtures")
+    _require_keys(seed, _SEED_KEYS, f"{label}.seed")
+    _require_keys(config, _CONFIG_KEYS, f"{label}.config")
+    _require_keys(observed, {"started_unix", "finished_unix", "seed_age_s_at_start"},
+                  f"{label}.observed")
+    if _canonical_bytes(config) != _canonical_bytes(expected.as_dict()):
+        _refuse(f"{label} config mismatch: expected {expected.as_dict()!r}, "
+                f"got {dict(config)!r}")
+    started = _number(observed["started_unix"], f"{label}.observed.started_unix")
+    finished = _number(observed["finished_unix"], f"{label}.observed.finished_unix")
+    if finished < started:
+        _refuse(f"{label} observed window ends before it starts")
+
+    metrics = _mapping(report.get("metrics"), f"{label}.metrics")
+    if not metrics:
+        _refuse(f"{label}.metrics must not be empty")
+    for name, raw_metric in metrics.items():
+        metric = _mapping(raw_metric, f"{label}.metrics.{name}")
+        _require_keys(metric, {"values", "mean", "stdev", "spread", "window",
+                               "burst_span_s", "drift_probe"},
+                      f"{label}.metrics.{name}")
+        values = _list(metric["values"], f"{label}.metrics.{name}.values")
+        if len(values) != expected.metric_repeats:
+            _refuse(f"{label}.metrics.{name}.values count mismatch: "
+                    f"expected {expected.metric_repeats}, got {len(values)}")
+        for index, value in enumerate(values):
+            _number(value, f"{label}.metrics.{name}.values[{index}]")
+        window = _mapping(metric["window"], f"{label}.metrics.{name}.window")
+        _require_keys(window, {"t_start_unix", "t_end_unix", "seed_age_s"},
+                      f"{label}.metrics.{name}.window")
+        drift = _mapping(metric["drift_probe"], f"{label}.metrics.{name}.drift_probe")
+        _require_keys(drift, {"before", "after", "moved", "seconds"},
+                      f"{label}.metrics.{name}.drift_probe")
+
+    stability = _mapping(report.get("stability"), f"{label}.stability")
+    _require_keys(stability, {"query", "runs", "distinct", "signatures"},
+                  f"{label}.stability")
+    if stability["query"] != expected.stability_query:
+        _refuse(f"{label} stability query does not match config")
+    if stability["runs"] != expected.stability_runs:
+        _refuse(f"{label} stability run count does not match config")
+    signatures = _list(stability["signatures"], f"{label}.stability.signatures")
+    if stability["distinct"] != len(signatures):
+        _refuse(f"{label} stability distinct count does not match signatures")
+    total = 0
+    for index, item in enumerate(signatures):
+        signature = _validate_signature(item, f"{label}.stability.signatures[{index}]")
+        total += signature["count"]
+    if total != expected.stability_runs:
+        _refuse(f"{label} stability signature counts total {total}, "
+                f"expected {expected.stability_runs}")
+    _mapping(report.get("lexical_degeneracy"), f"{label}.lexical_degeneracy")
+
+
+def _signature_key(signature: Mapping[str, Any]) -> bytes:
+    return _canonical_bytes({"ordering_rids": signature["ordering_rids"],
+                             "ordering_texts": signature["ordering_texts"]})
+
+
+def _collect_signatures(reports: Sequence[Mapping[str, Any]]) -> dict[bytes, dict[str, Any]]:
+    collected: dict[bytes, dict[str, Any]] = {}
+    for report in reports:
+        stability = _mapping(report["stability"], "stability")
+        for item in _list(stability["signatures"], "stability.signatures"):
+            signature = _mapping(item, "stability.signature")
+            key = _signature_key(signature)
+            current = collected.setdefault(key, {
+                "ordering_rids": signature["ordering_rids"],
+                "ordering_texts": signature["ordering_texts"], "count": 0})
+            current["count"] += signature["count"]
+    return collected
+
+
+def _stability_timestamps(report: Mapping[str, Any]) -> list[float]:
+    timestamps = []
+    stability = _mapping(report["stability"], "stability")
+    for item in _list(stability["signatures"], "stability.signatures"):
+        signature = _mapping(item, "stability.signature")
+        timestamps.extend(float(value) for value in signature["observed_at_unix"])
+    return sorted(timestamps)
+
+
+def _range(values: Sequence[float]) -> dict[str, float | int]:
+    return {"count": len(values), "min": min(values), "max": max(values),
+            "range": max(values) - min(values)}
+
+
+def compare_reports(runs: Sequence[ArmRun], *, expected_config: GateConfig,
+                    process_orders: Sequence[Sequence[str]]) -> dict[str, Any]:
+    if not runs:
+        _refuse("no gate reports were supplied")
+    by_round: dict[int, dict[str, Mapping[str, Any]]] = {}
+    by_arm: dict[str, list[Mapping[str, Any]]] = {"baseline": [], "candidate": []}
+    for run in runs:
+        if run.arm not in by_arm:
+            _refuse(f"unknown arm {run.arm!r}")
+        _validate_report(run.report, f"{run.arm} round {run.round_number}", expected_config)
+        pair = by_round.setdefault(run.round_number, {})
+        if run.arm in pair:
+            _refuse(f"duplicate {run.arm} report for round {run.round_number}")
+        pair[run.arm] = run.report
+        by_arm[run.arm].append(run.report)
+
+    if len(by_round) < 2:
+        _refuse("at least 2 paired rounds are required")
+    if len(process_orders) != len(by_round):
+        _refuse("process order count does not match paired round count")
+    for round_number, pair in by_round.items():
+        if set(pair) != {"baseline", "candidate"}:
+            _refuse(f"round {round_number} does not contain both arms")
+
+    first = runs[0].report
+    comparable = {"gate_version": first["gate_version"], "fixtures": first["fixtures"],
+                  "seed.sha256": _mapping(first["seed"], "seed")["sha256"],
+                  "config": first["config"]}
+    for run in runs[1:]:
+        candidate = {"gate_version": run.report["gate_version"],
+                     "fixtures": run.report["fixtures"],
+                     "seed.sha256": _mapping(run.report["seed"], "seed")["sha256"],
+                     "config": run.report["config"]}
+        for field, reference in comparable.items():
+            if _canonical_bytes(candidate[field]) != _canonical_bytes(reference):
+                _refuse(f"{field} mismatch across reports")
+
+    arm_metadata = {}
+    for arm, reports in by_arm.items():
+        reference = {"engine": reports[0]["engine"], "host": reports[0]["host"]}
+        for report in reports[1:]:
+            candidate = {"engine": report["engine"], "host": report["host"]}
+            if _canonical_bytes(candidate) != _canonical_bytes(reference):
+                _refuse(f"{arm} engine/host metadata changed across rounds")
+        arm_metadata[arm] = reference
+
+    signature_sets = {arm: _collect_signatures(reports) for arm, reports in by_arm.items()}
+    baseline_keys, candidate_keys = set(signature_sets["baseline"]), set(signature_sets["candidate"])
+
+    def partition(keys: set[bytes], *, shared: bool = False) -> list[dict[str, Any]]:
+        output = []
+        for key in sorted(keys):
+            baseline, candidate = signature_sets["baseline"].get(key), signature_sets["candidate"].get(key)
+            source = baseline or candidate
+            item = {"ordering_rids": source["ordering_rids"],
+                    "ordering_texts": source["ordering_texts"]}
+            if shared:
+                item.update(baseline_count=baseline["count"], candidate_count=candidate["count"])
+            elif baseline:
+                item["baseline_count"] = baseline["count"]
+            else:
+                item["candidate_count"] = candidate["count"]
+            output.append(item)
+        return output
+
+    metric_names = set(_mapping(first["metrics"], "metrics"))
+    for run in runs[1:]:
+        if set(_mapping(run.report["metrics"], "metrics")) != metric_names:
+            _refuse("metric names mismatch across reports")
+    metric_ranges = {}
+    for name in sorted(metric_names):
+        metric_ranges[name] = {}
+        for arm, reports in by_arm.items():
+            values = [float(value) for report in reports for value in
+                      _mapping(_mapping(report["metrics"], "metrics")[name],
+                               f"metrics.{name}")["values"]]
+            metric_ranges[name][arm] = _range(values)
+
+    paired_runs = []
+    for index, (round_number, pair) in enumerate(sorted(by_round.items())):
+        baseline_times = _stability_timestamps(pair["baseline"])
+        candidate_times = _stability_timestamps(pair["candidate"])
+        if len(baseline_times) != len(candidate_times):
+            _refuse(f"round {round_number} stability timestamp counts differ")
+        skews = [round(abs(candidate - baseline), 6)
+                 for baseline, candidate in zip(baseline_times, candidate_times, strict=True)]
+        paired_runs.append({"round": round_number, "process_order": list(process_orders[index]),
+                            "stability_timestamp_skew_s": skews,
+                            "max_stability_timestamp_skew_s": max(skews),
+                            "mean_stability_timestamp_skew_s": round(statistics.mean(skews), 6)})
+
+    return {
+        "comparator": COMPARATOR_VERSION, "gate": GATE_NAME, "gate_version": GATE_VERSION,
+        "rounds": len(by_round), "fixtures": dict(_mapping(first["fixtures"], "fixtures")),
+        "seed_sha256": _mapping(first["seed"], "seed")["sha256"],
+        "config": dict(_mapping(first["config"], "config")), "arms": arm_metadata,
+        "ordering_signatures": {
+            "baseline_only": partition(baseline_keys - candidate_keys),
+            "candidate_only": partition(candidate_keys - baseline_keys),
+            "shared": partition(baseline_keys & candidate_keys, shared=True)},
+        "paired_runs": paired_runs, "metric_ranges": metric_ranges,
+    }
+
+
+def _run_gate(python_executable: str, gate_path: Path, db_path: Path,
+              config: GateConfig) -> Mapping[str, Any]:
+    command = [python_executable, str(gate_path), "--db", str(db_path),
+               "--repeats", str(config.metric_repeats),
+               "--determinism-runs", str(config.stability_runs),
+               "--drift-probe-seconds", str(config.drift_probe_seconds)]
+    completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    try:
+        report = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        _refuse(f"gate under {python_executable!r} did not emit one JSON object: {error}")
+    return _mapping(report, f"gate output from {python_executable}")
+
+
+def _assert_seed(path: Path, expected: str, moment: str, hasher: Hasher) -> None:
+    actual = hasher(path)
+    if actual != expected:
+        _refuse(f"seed changed {moment}: expected fingerprint {expected}, got {actual}")
+
+
+def run_comparison(*, baseline_python: str, candidate_python: str, db_path: Path,
+                   gate_path: Path, rounds: int, config: GateConfig,
+                   runner: Runner = _run_gate,
+                   hasher: Hasher = _seed_fingerprint) -> dict[str, Any]:
+    if rounds < 2:
+        _refuse("--rounds must be at least 2")
+    if not db_path.is_file():
+        _refuse(f"--db must name an existing preseeded file: {db_path}")
+    if config.metric_repeats < 1 or config.stability_runs < 2:
+        _refuse("repeats must be positive and determinism-runs must be at least 2")
+    if config.drift_probe_seconds < 0:
+        _refuse("drift-probe-seconds must not be negative")
+
+    fingerprint = hasher(db_path)
+    executables = {"baseline": baseline_python, "candidate": candidate_python}
+    runs, process_orders = [], []
+    for round_index in range(rounds):
+        round_number = round_index + 1
+        order = ["baseline", "candidate"] if round_index % 2 == 0 else ["candidate", "baseline"]
+        process_orders.append(order)
+        for position, arm in enumerate(order):
+            _assert_seed(db_path, fingerprint, f"before round {round_number} {arm}", hasher)
+            report = runner(executables[arm], gate_path, db_path, config)
+            _assert_seed(db_path, fingerprint, f"after round {round_number} {arm}", hasher)
+            report_seed = _mapping(report.get("seed"), f"{arm} round {round_number}.seed")
+            if report_seed.get("sha256") != fingerprint:
+                _refuse(
+                    f"{arm} round {round_number} reported seed SHA "
+                    f"{report_seed.get('sha256')!r}, but the pre-launch bytes hash to {fingerprint}"
+                )
+            if position == 0:
+                _assert_seed(db_path, fingerprint,
+                             f"between processes in round {round_number}", hasher)
+            runs.append(ArmRun(arm, round_number, report))
+    _assert_seed(db_path, fingerprint, "after all processes", hasher)
+    result = compare_reports(runs, expected_config=config, process_orders=process_orders)
+    result["arms"]["baseline"]["python_executable"] = baseline_python
+    result["arms"]["candidate"]["python_executable"] = candidate_python
+    result["local_seed_fingerprint_sha256"] = fingerprint
+    return result
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-python", required=True)
+    parser.add_argument("--candidate-python", required=True)
+    parser.add_argument("--db", type=Path, required=True, help="preseeded gate database")
+    parser.add_argument("--gate", type=Path, default=Path(__file__).with_name("gate_4k.py"))
+    parser.add_argument("--rounds", type=int, default=2)
+    parser.add_argument("--repeats", type=int, default=7)
+    parser.add_argument("--determinism-runs", type=int, default=6)
+    parser.add_argument("--drift-probe-seconds", type=int, default=8)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    config = GateConfig(args.repeats, args.determinism_runs, args.drift_probe_seconds)
+    try:
+        result = run_comparison(
+            baseline_python=args.baseline_python, candidate_python=args.candidate_python,
+            db_path=args.db.resolve(), gate_path=args.gate.resolve(), rounds=args.rounds,
+            config=config)
+    except (ComparisonRefusal, subprocess.CalledProcessError) as error:
+        print(f"comparison refused: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/comparison/compare_gate_4k.py
+++ b/tests/comparison/compare_gate_4k.py
@@ -264,6 +264,9 @@ def compare_reports(runs: Sequence[ArmRun], *, expected_config: GateConfig,
             _refuse(f"round {round_number} does not contain both arms")
 
     first = runs[0].report
+    # FTS5 is supplied by each interpreter's SQLite build. Requiring the exact
+    # degeneracy object can conservatively refuse unlike Python environments;
+    # it can never silently bless different lexical behavior as comparable.
     comparable = {"gate_version": first["gate_version"], "fixtures": first["fixtures"],
                   "seed.sha256": _mapping(first["seed"], "seed")["sha256"],
                   "config": first["config"],
@@ -420,9 +423,6 @@ def run_comparison(*, baseline_python: str, candidate_python: str, db_path: Path
                     f"{arm} round {round_number} reported seed SHA "
                     f"{report_seed.get('sha256')!r}, but the pre-launch bytes hash to {fingerprint}"
                 )
-            if position == 0:
-                _assert_seed(db_path, fingerprint,
-                             f"between processes in round {round_number}", hasher)
             runs.append(ArmRun(arm, round_number, report))
     _assert_seed(db_path, fingerprint, "after all processes", hasher)
     result = compare_reports(runs, expected_config=config, process_orders=process_orders)

--- a/tests/comparison/compare_gate_4k.py
+++ b/tests/comparison/compare_gate_4k.py
@@ -277,6 +277,19 @@ def compare_reports(runs: Sequence[ArmRun], *, expected_config: GateConfig,
                 _refuse(f"{arm} engine/host metadata changed across rounds")
         arm_metadata[arm] = reference
 
+    baseline_engine = _mapping(arm_metadata["baseline"]["engine"], "baseline.engine")
+    candidate_engine = _mapping(arm_metadata["candidate"]["engine"], "candidate.engine")
+    same_version = (
+        baseline_engine["distribution_version"] == candidate_engine["distribution_version"])
+    baseline_extension = baseline_engine.get("extension_sha256")
+    candidate_extension = candidate_engine.get("extension_sha256")
+    same_native_bytes = (
+        baseline_extension == candidate_extension
+        if baseline_extension is not None and candidate_extension is not None else None)
+    artifact_warning = (
+        "SAME_VERSION_DIFFERENT_NATIVE_BYTES"
+        if same_version and same_native_bytes is False else None)
+
     signature_sets = {arm: _collect_signatures(reports) for arm, reports in by_arm.items()}
     baseline_keys, candidate_keys = set(signature_sets["baseline"]), set(signature_sets["candidate"])
 
@@ -327,6 +340,11 @@ def compare_reports(runs: Sequence[ArmRun], *, expected_config: GateConfig,
         "rounds": len(by_round), "fixtures": dict(_mapping(first["fixtures"], "fixtures")),
         "seed_sha256": _mapping(first["seed"], "seed")["sha256"],
         "config": dict(_mapping(first["config"], "config")), "arms": arm_metadata,
+        "artifact_identity": {
+            "same_distribution_version": same_version,
+            "same_native_extension_bytes": same_native_bytes,
+            "warning": artifact_warning,
+        },
         "ordering_signatures": {
             "baseline_only": partition(baseline_keys - candidate_keys),
             "candidate_only": partition(candidate_keys - baseline_keys),

--- a/tests/comparison/compare_gate_4k.py
+++ b/tests/comparison/compare_gate_4k.py
@@ -19,7 +19,10 @@ COMPARATOR_VERSION = "1.4.0"
 DEFAULT_TOP_K = 5
 DEFAULT_STABILITY_QUERY = "What is Taylor's role?"
 
-_ENGINE_KEYS = {"distribution_version", "module_file", "import_source", "wheel_sha256"}
+_ENGINE_KEYS = {
+    "distribution_version", "module_file", "import_source", "wheel_sha256",
+    "module_sha256", "extension_file", "extension_sha256",
+}
 _HOST_KEYS = {"platform", "python"}
 _FIXTURE_KEYS = {"corpus_sha256", "queries_sha256", "probes_sha256"}
 _SEED_KEYS = {"path", "sha256", "bytes", "mtime_unix", "created_at_min",
@@ -89,11 +92,14 @@ def _canonical_bytes(value: Any) -> bytes:
 
 
 def _seed_fingerprint(db_path: Path) -> str:
-    """Use the runner's exact name+NUL+bytes digest over the whole seed bundle."""
-    files = sorted(
-        (path for path in db_path.parent.glob(db_path.name + "*") if path.is_file()),
-        key=lambda path: path.name,
-    )
+    """Use the runner's exact name+NUL+bytes digest over one stable main file."""
+    for suffix in ("-wal", "-journal"):
+        sidecar = Path(f"{db_path}{suffix}")
+        if sidecar.is_file() and sidecar.stat().st_size > 0:
+            _refuse(
+                f"seed has a non-empty {suffix} sidecar; checkpoint it or use VACUUM INTO "
+                "before comparing builds")
+    files = [db_path]
     digest = hashlib.sha256()
     for path in files:
         digest.update(path.name.encode("utf-8"))
@@ -152,6 +158,8 @@ def _validate_report(report: Mapping[str, Any], label: str, expected: GateConfig
     if _canonical_bytes(config) != _canonical_bytes(expected.as_dict()):
         _refuse(f"{label} config mismatch: expected {expected.as_dict()!r}, "
                 f"got {dict(config)!r}")
+    if engine["import_source"] not in {"site-packages", "editable", "other"}:
+        _refuse(f"{label}.engine.import_source is not canonical: {engine['import_source']!r}")
     started = _number(observed["started_unix"], f"{label}.observed.started_unix")
     finished = _number(observed["finished_unix"], f"{label}.observed.finished_unix")
     if finished < started:
@@ -258,12 +266,14 @@ def compare_reports(runs: Sequence[ArmRun], *, expected_config: GateConfig,
     first = runs[0].report
     comparable = {"gate_version": first["gate_version"], "fixtures": first["fixtures"],
                   "seed.sha256": _mapping(first["seed"], "seed")["sha256"],
-                  "config": first["config"]}
+                  "config": first["config"],
+                  "lexical_degeneracy": first["lexical_degeneracy"]}
     for run in runs[1:]:
         candidate = {"gate_version": run.report["gate_version"],
                      "fixtures": run.report["fixtures"],
                      "seed.sha256": _mapping(run.report["seed"], "seed")["sha256"],
-                     "config": run.report["config"]}
+                     "config": run.report["config"],
+                     "lexical_degeneracy": run.report["lexical_degeneracy"]}
         for field, reference in comparable.items():
             if _canonical_bytes(candidate[field]) != _canonical_bytes(reference):
                 _refuse(f"{field} mismatch across reports")
@@ -277,6 +287,9 @@ def compare_reports(runs: Sequence[ArmRun], *, expected_config: GateConfig,
                 _refuse(f"{arm} engine/host metadata changed across rounds")
         arm_metadata[arm] = reference
 
+    if arm_metadata["baseline"]["host"]["platform"] != arm_metadata["candidate"]["host"]["platform"]:
+        _refuse("baseline and candidate host.platform differ")
+
     baseline_engine = _mapping(arm_metadata["baseline"]["engine"], "baseline.engine")
     candidate_engine = _mapping(arm_metadata["candidate"]["engine"], "candidate.engine")
     same_version = (
@@ -286,6 +299,10 @@ def compare_reports(runs: Sequence[ArmRun], *, expected_config: GateConfig,
     same_native_bytes = (
         baseline_extension == candidate_extension
         if baseline_extension is not None and candidate_extension is not None else None)
+    if same_native_bytes is True:
+        _refuse(
+            "baseline and candidate use the same native extension bytes; "
+            "this is a self-comparison, not an engine comparison")
     artifact_warning = (
         "SAME_VERSION_DIFFERENT_NATIVE_BYTES"
         if same_version and same_native_bytes is False else None)
@@ -436,8 +453,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             baseline_python=args.baseline_python, candidate_python=args.candidate_python,
             db_path=args.db.resolve(), gate_path=args.gate.resolve(), rounds=args.rounds,
             config=config)
-    except (ComparisonRefusal, subprocess.CalledProcessError) as error:
+    except ComparisonRefusal as error:
         print(f"comparison refused: {error}", file=sys.stderr)
+        return 2
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or "").strip()
+        print(f"comparison refused: {error}", file=sys.stderr)
+        if detail:
+            print(detail, file=sys.stderr)
+        return 2
+    except OSError as error:
+        print(f"comparison refused: could not launch gate process: {error}", file=sys.stderr)
         return 2
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0

--- a/tests/comparison/gate_4k.py
+++ b/tests/comparison/gate_4k.py
@@ -72,6 +72,8 @@ import tempfile
 import time
 from importlib import metadata as importlib_metadata
 from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 FIXTURES = Path(__file__).parent / "fixtures"
 CORPUS = FIXTURES / "corpus_4353_gate_v1.json"
@@ -128,8 +130,22 @@ def _load() -> tuple[list[dict], list[dict], list[dict]]:
 
 
 def _seed_bytes(base: Path) -> dict:
-    """Hash the complete database bundle without opening it."""
-    files = sorted(p for p in base.parent.glob(base.name + "*") if p.is_file())
+    """Hash a stable SQLite seed without opening it.
+
+    A non-empty WAL or rollback journal contains authoritative state outside
+    the main file. Immutable reads ignore WAL content, while ordinary reads
+    create or alter sidecars, so neither can produce a reproducible comparison.
+    Require callers to checkpoint/VACUUM INTO one stable database first.
+    """
+    if not base.is_file():
+        raise SystemExit(f"seed database does not exist: {base}")
+    for suffix in ("-wal", "-journal"):
+        sidecar = Path(f"{base}{suffix}")
+        if sidecar.is_file() and sidecar.stat().st_size > 0:
+            raise SystemExit(
+                f"seed has a non-empty {suffix} sidecar; checkpoint it or use VACUUM INTO "
+                "before comparing builds")
+    files = [base]
     bundle = hashlib.sha256()
     entries = []
     for path in files:
@@ -163,15 +179,12 @@ def _sha256_file(path: Path) -> str:
 
 def _seed_snapshot(base: Path) -> dict:
     """Content identity and clock origin for the immutable seed bundle."""
-    if not base.is_file():
-        raise SystemExit(f"seed database does not exist: {base}")
-
     # This digest is deliberately BEFORE the first SQLite open. Even a
     # metadata-only connection can touch WAL/SHM state; a report that hashes
     # afterward cannot prove both candidate processes started from the bytes
     # the comparator supplied.
     snapshot = _seed_bytes(base)
-    uri = f"file:{base.resolve().as_posix()}?mode=ro"
+    uri = f"{base.resolve().as_uri()}?mode=ro&immutable=1"
     con = sqlite3.connect(uri, uri=True)
     try:
         created_min, created_max, record_count = con.execute(
@@ -213,6 +226,15 @@ def _import_metadata(yantrikdb) -> dict:
     archive_hash = direct_url.get("archive_info", {}).get("hash")
     wheel_sha256 = archive_hash.removeprefix("sha256=") if (
         isinstance(archive_hash, str) and archive_hash.startswith("sha256=")) else None
+    if editable:
+        parsed = urlparse(direct_url.get("url", ""))
+        distribution_root = Path(url2pathname(parsed.path)).resolve()
+    else:
+        distribution_root = Path(dist.locate_file("")).resolve()
+    if not module_path.is_relative_to(distribution_root):
+        raise SystemExit(
+            "import metadata mismatch: imported yantrikdb module is outside the "
+            f"distribution root ({module_path} vs {distribution_root})")
     return {
         "distribution_version": dist.version,
         "module_file": str(module_path),
@@ -263,6 +285,13 @@ def _seed(facts: list[dict], db_path: str):
     time.sleep(DRAIN_SECONDS)
     del db
     gc.collect()
+    # The comparator consumes one immutable main file. YantrikDB uses WAL by
+    # default, so checkpoint a seed created by this runner before hashing it.
+    con = sqlite3.connect(db_path)
+    try:
+        con.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        con.close()
 
 
 def _fresh_copy(base: Path, into: Path) -> Path:
@@ -503,7 +532,8 @@ def _degeneracy(db_path: str, term: str = "taylor") -> dict:
     Hence the long name. A metric whose denominator is ambiguous will be
     compared against a metric it does not measure.
     """
-    con = sqlite3.connect(db_path)
+    uri = f"{Path(db_path).resolve().as_uri()}?mode=ro&immutable=1"
+    con = sqlite3.connect(uri, uri=True)
     rows = con.execute(
         "SELECT memories_fts.rank FROM memories m "
         "JOIN memories_fts ON memories_fts.rowid = m.rowid "
@@ -526,30 +556,8 @@ def _degeneracy(db_path: str, term: str = "taylor") -> dict:
             "fraction_ordered_by_cosine_alone": round(tied / len(rows), 4)}
 
 
-def _determinism(base: Path, runs: int = 6, seed_mtime_ns: int = 0,
-                 query: str = STABILITY_QUERY) -> dict:
-    """Identical query, identical starting state, fresh copy each time.
-
-    A build that answers differently on the same bytes cannot be measured at
-    all, so this runs FIRST and the report says so loudly.
-    """
-    from yantrikdb._yantrikdb_rust import YantrikDB
-    seen, observations, root = [], [], Path(tempfile.mkdtemp())
-    for i in range(runs):
-        d = root / f"r{i}"
-        d.mkdir()
-        db = YantrikDB.with_default(str(_fresh_copy(base, d)))
-        trace: list[dict] = []
-        texts = _texts(db, query, TOP_K, trace)
-        seen.append(tuple(texts))
-        item = trace[0]
-        item["seed_age_s"] = round(
-            max(0.0, item["observed_at_unix"] - seed_mtime_ns / 1e9), 6)
-        observations.append(item)
-        del db
-        gc.collect()
-    shutil.rmtree(root, ignore_errors=True)
-    n = len(set(seen))
+def _group_stability_observations(observations: list[dict]) -> list[dict]:
+    """Group identical RID+text orderings while preserving observation times."""
     grouped: dict[tuple[tuple[str, ...], tuple[str, ...]], dict] = {}
     for item in observations:
         key = (tuple(item["ordering_rids"]), tuple(item["ordering_texts"]))
@@ -562,8 +570,35 @@ def _determinism(base: Path, runs: int = 6, seed_mtime_ns: int = 0,
             }
         grouped[key]["count"] += 1
         grouped[key]["observed_at_unix"].append(item["observed_at_unix"])
+    return list(grouped.values())
+
+
+def _determinism(base: Path, runs: int = 6, seed_mtime_ns: int = 0,
+                 query: str = STABILITY_QUERY) -> dict:
+    """Identical query, identical starting state, fresh copy each time.
+
+    A build that answers differently on the same bytes cannot be measured at
+    all, so this runs FIRST and the report says so loudly.
+    """
+    from yantrikdb._yantrikdb_rust import YantrikDB
+    observations, root = [], Path(tempfile.mkdtemp())
+    for i in range(runs):
+        d = root / f"r{i}"
+        d.mkdir()
+        db = YantrikDB.with_default(str(_fresh_copy(base, d)))
+        trace: list[dict] = []
+        _texts(db, query, TOP_K, trace)
+        item = trace[0]
+        item["seed_age_s"] = round(
+            max(0.0, item["observed_at_unix"] - seed_mtime_ns / 1e9), 6)
+        observations.append(item)
+        del db
+        gc.collect()
+    shutil.rmtree(root, ignore_errors=True)
+    grouped = _group_stability_observations(observations)
+    n = len(grouped)
     return {"query": query, "runs": runs, "distinct": n,
-            "signatures": list(grouped.values()),
+            "signatures": grouped,
             "deterministic": n == 1, "raw_observations": observations,
             "note": ("identical inputs produced different answers — every "
                      "metric below is unreliable" if n > 1 else
@@ -636,12 +671,11 @@ def main() -> int:
 
     determinism = _determinism(
         base, args.stability_runs, seed["latest_mtime_ns"])
-    seed_after = _seed_snapshot(base)
+    lexical_degeneracy = _degeneracy(str(base))
+    seed_after = _seed_bytes(base)
     if seed_after["sha256"] != seed["sha256"]:
         raise SystemExit(
             "seed hash changed during measurement — the gate did not run on immutable bytes")
-
-    lexical_degeneracy = _degeneracy(str(base))
     run_finished_at = time.time()
     out = {
         "gate": GATE_NAME,

--- a/tests/comparison/gate_4k.py
+++ b/tests/comparison/gate_4k.py
@@ -153,6 +153,14 @@ def _seed_bytes(base: Path) -> dict:
     }
 
 
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def _seed_snapshot(base: Path) -> dict:
     """Content identity and clock origin for the immutable seed bundle."""
     if not base.is_file():
@@ -185,7 +193,10 @@ def _seed_snapshot(base: Path) -> dict:
 
 def _import_metadata(yantrikdb) -> dict:
     """Prove which interpreter, package, and native extension produced a run."""
+    from yantrikdb import _yantrikdb_rust
+
     module_path = Path(yantrikdb.__file__).resolve()
+    extension_path = Path(_yantrikdb_rust.__file__).resolve()
     dist = importlib_metadata.distribution("yantrikdb")
     direct_url = {}
     if raw := dist.read_text("direct_url.json"):
@@ -207,6 +218,9 @@ def _import_metadata(yantrikdb) -> dict:
         "module_file": str(module_path),
         "import_source": import_source,
         "wheel_sha256": wheel_sha256,
+        "module_sha256": _sha256_file(module_path),
+        "extension_file": str(extension_path),
+        "extension_sha256": _sha256_file(extension_path),
     }
 
 
@@ -636,6 +650,7 @@ def main() -> int:
         "host": {
             "platform": platform.platform(),
             "python": platform.python_version(),
+            "executable": str(Path(sys.executable).resolve()),
         },
         "fixtures": FIXTURE_HASHES,
         "seed": seed,

--- a/tests/comparison/gate_4k.py
+++ b/tests/comparison/gate_4k.py
@@ -44,6 +44,13 @@ check fails the gate refuses to run rather than quietly reporting numbers from
 a different corpus. NOTE: v1.2.0 changes only SCORING — the fixtures and their
 hashes are unchanged from v1.1.0.
 
+WHAT v1.4.0 ADDS. A comparison now carries its proof of identity: all three
+fixture hashes, the complete seed bundle hash before its first database open,
+seed age for every metric window, import provenance, raw metric values, and
+cold-open ordering signatures with observation times. The companion comparator
+runs both interpreters in alternating order against those exact seed bytes and
+refuses mismatched reports before calculating a delta.
+
 Run:
     python tests/comparison/gate_4k.py --repeats 7 --direction
     python tests/comparison/gate_4k.py --db <seeded.db> --repeats 7
@@ -55,6 +62,7 @@ import argparse
 import gc
 import hashlib
 import json
+import platform
 import re
 import shutil
 import sqlite3
@@ -62,6 +70,7 @@ import statistics
 import sys
 import tempfile
 import time
+from importlib import metadata as importlib_metadata
 from pathlib import Path
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -69,23 +78,41 @@ CORPUS = FIXTURES / "corpus_4353_gate_v1.json"
 QUERIES = FIXTURES / "queries_1k.json"
 PROBES = FIXTURES / "direction_probes_v1_1.json"
 
+GATE_NAME = "hermes-plugin/competing-distractors"
+GATE_VERSION = "1.4.0"
+
 # Pinned at gate v1.0.0 and unchanged since. A candidate build must be measured
 # against the same bytes the previous candidate was measured against.
 CORPUS_SHA256 = "2d2d039094644ce5b2a1d8de5047daa5b4a183e98919bdae3a57a67962df4fc9"
 QUERIES_SHA256 = "a4b866a5bdeccfb103b25d2cf1a66a1ca50af9096ccb55bf73579f676f4b407f"
+PROBES_SHA256 = "dfe0242e72fa575c5d45bf7afc8e2e153dde279fc45be2b049da15f6e0383a3d"
+FIXTURE_HASHES = {
+    "corpus_sha256": CORPUS_SHA256,
+    "queries_sha256": QUERIES_SHA256,
+    "probes_sha256": PROBES_SHA256,
+}
 
 # Seeding is async; measuring before the write queue drains reports compaction
 # noise as retrieval quality.
 DRAIN_SECONDS = 30
+TOP_K = 5
+STABILITY_QUERY = "What is Taylor's role?"
 
 _REPORTS_TO = re.compile(r"^([A-Z][a-z]+) reports to ([A-Z][a-z]+)\.$")
 
 
-def _load() -> tuple[list[dict], list[dict]]:
-    cblob = CORPUS.read_text(encoding="utf-8")
-    qblob = QUERIES.read_text(encoding="utf-8")
-    for name, blob, want in (("corpus", cblob, CORPUS_SHA256),
-                             ("queries", qblob, QUERIES_SHA256)):
+def _load() -> tuple[list[dict], list[dict], list[dict]]:
+    blobs = {
+        CORPUS.name: CORPUS.read_text(encoding="utf-8"),
+        QUERIES.name: QUERIES.read_text(encoding="utf-8"),
+        PROBES.name: PROBES.read_text(encoding="utf-8"),
+    }
+    for name, blob in blobs.items():
+        want = {
+            CORPUS.name: CORPUS_SHA256,
+            QUERIES.name: QUERIES_SHA256,
+            PROBES.name: PROBES_SHA256,
+        }[name]
         got = hashlib.sha256(blob.encode("utf-8")).hexdigest()
         if got != want:
             raise SystemExit(
@@ -93,7 +120,94 @@ def _load() -> tuple[list[dict], list[dict]]:
                 f"  expected {want}\n  actual   {got}\n"
                 "Numbers from a drifted corpus are not comparable to prior runs."
             )
-    return json.loads(cblob)["facts"], json.loads(qblob)["queries"]
+    return (
+        json.loads(blobs[CORPUS.name])["facts"],
+        json.loads(blobs[QUERIES.name])["queries"],
+        json.loads(blobs[PROBES.name])["probes"],
+    )
+
+
+def _seed_bytes(base: Path) -> dict:
+    """Hash the complete database bundle without opening it."""
+    files = sorted(p for p in base.parent.glob(base.name + "*") if p.is_file())
+    bundle = hashlib.sha256()
+    entries = []
+    for path in files:
+        blob = path.read_bytes()
+        bundle.update(path.name.encode("utf-8"))
+        bundle.update(b"\0")
+        bundle.update(blob)
+        stat = path.stat()
+        entries.append({
+            "name": path.name,
+            "sha256": hashlib.sha256(blob).hexdigest(),
+            "bytes": len(blob),
+            "mtime_ns": stat.st_mtime_ns,
+        })
+    return {
+        "sha256": bundle.hexdigest(),
+        "bytes": sum(f["bytes"] for f in entries),
+        "mtime_unix": max(f["mtime_ns"] for f in entries) / 1e9,
+        "latest_mtime_ns": max(f["mtime_ns"] for f in entries),
+        "files": entries,
+    }
+
+
+def _seed_snapshot(base: Path) -> dict:
+    """Content identity and clock origin for the immutable seed bundle."""
+    if not base.is_file():
+        raise SystemExit(f"seed database does not exist: {base}")
+
+    # This digest is deliberately BEFORE the first SQLite open. Even a
+    # metadata-only connection can touch WAL/SHM state; a report that hashes
+    # afterward cannot prove both candidate processes started from the bytes
+    # the comparator supplied.
+    snapshot = _seed_bytes(base)
+    uri = f"file:{base.resolve().as_posix()}?mode=ro"
+    con = sqlite3.connect(uri, uri=True)
+    try:
+        created_min, created_max, record_count = con.execute(
+            "SELECT MIN(created_at), MAX(created_at), COUNT(*) FROM memories"
+        ).fetchone()
+    finally:
+        con.close()
+    if _seed_bytes(base)["sha256"] != snapshot["sha256"]:
+        raise SystemExit(
+            "seed hash changed during metadata read — use a stable, checkpointed seed")
+    return {
+        "path": str(base.resolve()),
+        **snapshot,
+        "created_at_min": created_min,
+        "created_at_max": created_max,
+        "record_count": record_count,
+    }
+
+
+def _import_metadata(yantrikdb) -> dict:
+    """Prove which interpreter, package, and native extension produced a run."""
+    module_path = Path(yantrikdb.__file__).resolve()
+    dist = importlib_metadata.distribution("yantrikdb")
+    direct_url = {}
+    if raw := dist.read_text("direct_url.json"):
+        try:
+            direct_url = json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+    editable = bool(direct_url.get("dir_info", {}).get("editable"))
+    import_source = (
+        "editable" if editable else
+        "site-packages" if "site-packages" in {p.lower() for p in module_path.parts} else
+        "other"
+    )
+    archive_hash = direct_url.get("archive_info", {}).get("hash")
+    wheel_sha256 = archive_hash.removeprefix("sha256=") if (
+        isinstance(archive_hash, str) and archive_hash.startswith("sha256=")) else None
+    return {
+        "distribution_version": dist.version,
+        "module_file": str(module_path),
+        "import_source": import_source,
+        "wheel_sha256": wheel_sha256,
+    }
 
 
 def _partition_queries(facts: list[dict], queries: list[dict]) -> tuple[list, list]:
@@ -133,7 +247,8 @@ def _seed(facts: list[dict], db_path: str):
                     continue
                 raise
     time.sleep(DRAIN_SECONDS)
-    return db
+    del db
+    gc.collect()
 
 
 def _fresh_copy(base: Path, into: Path) -> Path:
@@ -143,9 +258,24 @@ def _fresh_copy(base: Path, into: Path) -> Path:
     return into / base.name
 
 
-def _texts(db, q, k=5):
-    return [(h.get("text") or "").strip()
-            for h in db.recall_text(q, top_k=k, namespace="g")]
+def _texts(db, q, k=5, trace: list[dict] | None = None):
+    observed_at = time.time()
+    hits = db.recall_text(q, top_k=k, namespace="g")
+    texts = [(h.get("text") or "").strip() for h in hits]
+    rids = [(h.get("rid") or "").strip() for h in hits]
+    if trace is not None:
+        payload = json.dumps(
+            {"rids": rids, "texts": texts}, ensure_ascii=True, separators=(",", ":"))
+        trace.append({
+            "query": q,
+            "top_k": k,
+            "count": len(texts),
+            "ordering_rids": rids,
+            "ordering_texts": texts,
+            "ordering_signature": hashlib.sha256(payload.encode("utf-8")).hexdigest(),
+            "observed_at_unix": observed_at,
+        })
+    return texts
 
 
 # --- v1.3.0: one function per metric, so the runner can transpose the loop ---
@@ -155,17 +285,17 @@ def _texts(db, q, k=5):
 # cross-instance comparison inside its own tight window instead of smearing it
 # across the whole suite. See _measure_transposed for why that matters.
 
-def _m_precision(db, unique, ambiguous, probes) -> float:
+def _m_precision(db, unique, ambiguous, probes, trace=None) -> float:
     hits = 0
     for q in unique:
-        got = _texts(db, q["query"], q.get("top_k", 5))
+        got = _texts(db, q["query"], q.get("top_k", 5), trace)
         t = (q.get("target_text") or "").strip()
         if t and any(t in g or g in t for g in got):
             hits += 1
     return hits / len(unique) if unique else 0.0
 
 
-def _m_role_share(db, unique, ambiguous, probes) -> float:
+def _m_role_share(db, unique, ambiguous, probes, trace=None) -> float:
     """Ambiguous role queries: what fraction of returned relation records put
     the queried entity in SUBJECT position? Independent of which valid answer
     was designated, so a mechanism promoting any correct answer scores."""
@@ -175,31 +305,32 @@ def _m_role_share(db, unique, ambiguous, probes) -> float:
         if not m:
             continue
         subj = m.group(1)
-        rel = [t for t in _texts(db, q["query"]) if " reports to " in t]
+        rel = [t for t in _texts(db, q["query"], trace=trace) if " reports to " in t]
         if rel:
             shares.append(sum(1 for t in rel if t.startswith(f"{subj} reports to "))
                           / len(rel))
     return statistics.mean(shares) if shares else 0.0
 
 
-def _m_possessive_top1(db, unique, ambiguous, probes) -> float:
+def _m_possessive_top1(db, unique, ambiguous, probes, trace=None) -> float:
     vals = []
     for p in probes:
-        a, b = _texts(db, p["query_possessive"]), _texts(db, p["query_plain"])
+        a = _texts(db, p["query_possessive"], trace=trace)
+        b = _texts(db, p["query_plain"], trace=trace)
         vals.append(1.0 if (a and b and a[0] == b[0]) else 0.0)
     return statistics.mean(vals) if vals else 0.0
 
 
-def _m_possessive_jaccard(db, unique, ambiguous, probes) -> float:
+def _m_possessive_jaccard(db, unique, ambiguous, probes, trace=None) -> float:
     vals = []
     for p in probes:
-        a = set(_texts(db, p["query_possessive"]))
-        b = set(_texts(db, p["query_plain"]))
+        a = set(_texts(db, p["query_possessive"], trace=trace))
+        b = set(_texts(db, p["query_plain"], trace=trace))
         vals.append(len(a & b) / len(a | b) if (a | b) else 1.0)
     return statistics.mean(vals) if vals else 0.0
 
 
-def _m_direction_separation(db, unique, ambiguous, probes) -> float:
+def _m_direction_separation(db, unique, ambiguous, probes, trace=None) -> float:
     seps = []
     for p in probes:
         e = p["entity"]
@@ -209,8 +340,8 @@ def _m_direction_separation(db, unique, ambiguous, probes) -> float:
             rel = [t for t in ts if _sp in t or _op in t]
             return None if not rel else sum(1 for t in rel if t.startswith(_sp)) / len(rel)
 
-        s = share(_texts(db, p["query_subject"]))
-        o = share(_texts(db, p["query_object"]))
+        s = share(_texts(db, p["query_subject"], trace=trace))
+        o = share(_texts(db, p["query_object"], trace=trace))
         if s is not None and o is not None:
             seps.append(s - o)
     return statistics.mean(seps) if seps else 0.0
@@ -236,13 +367,40 @@ METRICS = {
 def _one_pass(db, unique: list[dict], ambiguous: list[dict],
               probes: list[dict]) -> dict:
     """Retained for callers wanting a single instance's full reading."""
-    return {name: fn(db, unique, ambiguous, probes)
+    return {name: fn(db, unique, ambiguous, probes, None)
             for name, fn in METRICS.items()}
+
+
+def _metric_observation(fn, db, unique, ambiguous, probes,
+                        seed_mtime_ns: int) -> tuple[float, dict]:
+    """One raw metric reading plus a signature of every ordering it consumed."""
+    started = time.time_ns()
+    trace: list[dict] = []
+    value = fn(db, unique, ambiguous, probes, trace)
+    finished = time.time_ns()
+    stable_trace = [
+        {k: item[k] for k in ("query", "top_k", "count", "ordering_signature")}
+        for item in trace
+    ]
+    signature = hashlib.sha256(
+        json.dumps(stable_trace, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return value, {
+        "value": round(value, 8),
+        "ordering_signature": signature,
+        "query_count": len(trace),
+        "result_count": sum(item["count"] for item in trace),
+        "observed_at_unix": started / 1e9,
+        "finished_at_unix": finished / 1e9,
+        "seed_age_start_s": round(max(0, started - seed_mtime_ns) / 1e9, 6),
+        "seed_age_end_s": round(max(0, finished - seed_mtime_ns) / 1e9, 6),
+    }
 
 
 def _measure_transposed(instances, unique, ambiguous, probes,
                         decay_per_second: float = 5e-8,
-                        drift_probe_seconds: int = 8) -> dict:
+                        drift_probe_seconds: float = 8,
+                        seed_mtime_ns: int = 0) -> dict:
     """Measure each metric across ALL instances back-to-back, not each instance
     across all metrics.
 
@@ -260,32 +418,53 @@ def _measure_transposed(instances, unique, ambiguous, probes,
     """
     out = {}
     for name, fn in METRICS.items():
-        t0 = time.time()
-        vals = [fn(db, unique, ambiguous, probes) for db in instances]
-        span = time.time() - t0
+        observations = [
+            _metric_observation(fn, db, unique, ambiguous, probes, seed_mtime_ns)
+            for db in instances
+        ]
+        vals = [value for value, _ in observations]
+        raw = [observation for _, observation in observations]
+        span = raw[-1]["finished_at_unix"] - raw[0]["observed_at_unix"]
 
         # Measure drift sensitivity instead of asserting it: read the metric on
         # ONE fixed instance, wait, read it again. Any movement is the clock,
         # because the instance and its data are identical.
-        before = fn(instances[0], unique, ambiguous, probes)
+        before, before_observation = _metric_observation(
+            fn, instances[0], unique, ambiguous, probes, seed_mtime_ns)
         time.sleep(drift_probe_seconds)
-        after = fn(instances[0], unique, ambiguous, probes)
+        after, after_observation = _metric_observation(
+            fn, instances[0], unique, ambiguous, probes, seed_mtime_ns)
         moved = abs(after - before)
 
         sd = statistics.stdev(vals) if len(vals) > 1 else 0.0
         out[name] = {
             "mean": round(statistics.mean(vals), 4),
+            "values": [round(v, 8) for v in vals],
             "stdev": round(sd, 4),
             "spread": round(max(vals) - min(vals), 4),
             "burst_span_s": round(span, 3),
             "drift_budget_in_burst": f"{span * decay_per_second:.2e}",
             "measured_drift_move": round(moved, 4),
             "drift_probe_seconds": drift_probe_seconds,
+            "window": {
+                "t_start_unix": raw[0]["observed_at_unix"],
+                "t_end_unix": raw[-1]["finished_at_unix"],
+                "seed_age_s": raw[0]["seed_age_start_s"],
+            },
+            "raw_observations": raw,
+            "drift_probe": {
+                "before": round(before, 8),
+                "after": round(after, 8),
+                "moved": round(moved, 8),
+                "seconds": drift_probe_seconds,
+                "before_observation": before_observation,
+                "after_observation": after_observation,
+            },
             "reading": (
                 f"MOVED {moved:.4f} on a fixed instance over "
                 f"{drift_probe_seconds}s with no other change — spread here may "
-                "be the clock, not the engine; confirm against "
-                "determinism_burst before calling a change a result"
+                "be the clock, not the engine; compare the raw ordering "
+                "signatures before calling a change a result"
                 if moved > 0 else
                 "held exactly on a fixed instance across the drift probe — "
                 "spread here is not decay, so a change larger than it is real"),
@@ -333,26 +512,45 @@ def _degeneracy(db_path: str, term: str = "taylor") -> dict:
             "fraction_ordered_by_cosine_alone": round(tied / len(rows), 4)}
 
 
-def _determinism(base: Path, runs: int = 6) -> dict:
+def _determinism(base: Path, runs: int = 6, seed_mtime_ns: int = 0,
+                 query: str = STABILITY_QUERY) -> dict:
     """Identical query, identical starting state, fresh copy each time.
 
     A build that answers differently on the same bytes cannot be measured at
     all, so this runs FIRST and the report says so loudly.
     """
     from yantrikdb._yantrikdb_rust import YantrikDB
-    seen, root = [], Path(tempfile.mkdtemp())
+    seen, observations, root = [], [], Path(tempfile.mkdtemp())
     for i in range(runs):
         d = root / f"r{i}"
         d.mkdir()
         db = YantrikDB.with_default(str(_fresh_copy(base, d)))
-        seen.append(tuple((h.get("text") or "").strip()
-                          for h in db.recall_text("What is Taylor's role?",
-                                                  top_k=5, namespace="g")))
+        trace: list[dict] = []
+        texts = _texts(db, query, TOP_K, trace)
+        seen.append(tuple(texts))
+        item = trace[0]
+        item["seed_age_s"] = round(
+            max(0.0, item["observed_at_unix"] - seed_mtime_ns / 1e9), 6)
+        observations.append(item)
         del db
         gc.collect()
     shutil.rmtree(root, ignore_errors=True)
     n = len(set(seen))
-    return {"runs": runs, "distinct_orderings": n, "deterministic": n == 1,
+    grouped: dict[tuple[tuple[str, ...], tuple[str, ...]], dict] = {}
+    for item in observations:
+        key = (tuple(item["ordering_rids"]), tuple(item["ordering_texts"]))
+        if key not in grouped:
+            grouped[key] = {
+                "ordering_rids": item["ordering_rids"],
+                "ordering_texts": item["ordering_texts"],
+                "count": 0,
+                "observed_at_unix": [],
+            }
+        grouped[key]["count"] += 1
+        grouped[key]["observed_at_unix"].append(item["observed_at_unix"])
+    return {"query": query, "runs": runs, "distinct": n,
+            "signatures": list(grouped.values()),
+            "deterministic": n == 1, "raw_observations": observations,
             "note": ("identical inputs produced different answers — every "
                      "metric below is unreliable" if n > 1 else
                      "identical inputs produced identical answers")}
@@ -363,9 +561,20 @@ def main() -> int:
     ap.add_argument("--db", default=None, help="reuse an already-seeded gate db")
     ap.add_argument("--repeats", type=int, default=7,
                     help="isolated repeats; each runs against a fresh db copy")
+    ap.add_argument("--stability-runs", "--determinism-runs",
+                    dest="stability_runs", type=int, default=6,
+                    help="fresh-copy runs for the byte-identical ordering check")
+    ap.add_argument("--drift-probe-seconds", type=int, default=8,
+                    help="delay between fixed-instance drift observations")
     ap.add_argument("--direction", action="store_true",
                     help="(retained for compatibility; the subset always runs)")
     args = ap.parse_args()
+    if args.repeats < 1:
+        ap.error("--repeats must be at least 1")
+    if args.stability_runs < 2:
+        ap.error("--stability-runs must be at least 2")
+    if args.drift_probe_seconds < 0:
+        ap.error("--drift-probe-seconds cannot be negative")
 
     sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarks"))
     from _bootstrap import _pin_engine_import
@@ -374,8 +583,7 @@ def main() -> int:
 
     import yantrikdb
 
-    facts, queries = _load()
-    probes = json.loads(PROBES.read_text(encoding="utf-8"))["probes"]
+    facts, queries, probes = _load()
     unique, ambiguous = _partition_queries(facts, queries)
 
     if args.db:
@@ -385,6 +593,9 @@ def main() -> int:
         print(f"seeding {len(facts)} records, draining {DRAIN_SECONDS}s…",
               file=sys.stderr)
         _seed(facts, str(base))
+
+    seed = _seed_snapshot(base)
+    run_started_at = time.time()
 
     # Stage and OPEN every instance before measuring anything. Opening is the
     # slow part; doing it up front is what lets each metric be read across all
@@ -396,17 +607,52 @@ def main() -> int:
         d.mkdir()
         instances.append(YantrikDB.with_default(str(_fresh_copy(base, d))))
 
-    metrics = _measure_transposed(instances, unique, ambiguous, probes)
+    metrics = _measure_transposed(
+        instances,
+        unique,
+        ambiguous,
+        probes,
+        drift_probe_seconds=args.drift_probe_seconds,
+        seed_mtime_ns=seed["latest_mtime_ns"],
+    )
 
     del instances
     gc.collect()
     shutil.rmtree(root, ignore_errors=True)
 
+    determinism = _determinism(
+        base, args.stability_runs, seed["latest_mtime_ns"])
+    seed_after = _seed_snapshot(base)
+    if seed_after["sha256"] != seed["sha256"]:
+        raise SystemExit(
+            "seed hash changed during measurement — the gate did not run on immutable bytes")
+
+    lexical_degeneracy = _degeneracy(str(base))
+    run_finished_at = time.time()
     out = {
-        "gate": "hermes-plugin/competing-distractors v1.3.0",
-        "engine": yantrikdb.__version__,
+        "gate": GATE_NAME,
+        "gate_version": GATE_VERSION,
+        "engine": _import_metadata(yantrikdb),
+        "host": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+        },
+        "fixtures": FIXTURE_HASHES,
+        "seed": seed,
+        "config": {
+            "metric_repeats": args.repeats,
+            "stability_runs": args.stability_runs,
+            "drift_probe_seconds": args.drift_probe_seconds,
+            "top_k": TOP_K,
+            "stability_query": STABILITY_QUERY,
+        },
+        "observed": {
+            "started_unix": run_started_at,
+            "finished_unix": run_finished_at,
+            "seed_age_s_at_start": max(0.0, run_started_at - seed["mtime_unix"]),
+        },
         "corpus": len(facts),
-        "determinism": _determinism(base),
+        "stability": determinism,
         "query_partition": {
             "scored_by_record_identity": len(unique),
             "scored_by_role_share": len(ambiguous),
@@ -418,13 +664,7 @@ def main() -> int:
         },
         "instances": args.repeats,
         "metrics": metrics,
-        "reading_deltas": (
-            "Two different cautions. On a metric marked drift_sensitive=false, "
-            "spread is real and a change larger than it is a result. On "
-            "drift_sensitive=true, spread may be ties crossing under recency "
-            "decay rather than nondeterminism — check determinism_burst before "
-            "calling any such change a result."),
-        "lexical_degeneracy": _degeneracy(str(base)),
+        "lexical_degeneracy": lexical_degeneracy,
     }
     print(json.dumps(out, indent=2))
     return 0

--- a/tests/comparison/gate_4k.py
+++ b/tests/comparison/gate_4k.py
@@ -47,13 +47,15 @@ hashes are unchanged from v1.1.0.
 WHAT v1.4.0 ADDS. A comparison now carries its proof of identity: all three
 fixture hashes, the complete seed bundle hash before its first database open,
 seed age for every metric window, import provenance, raw metric values, and
-cold-open ordering signatures with observation times. The companion comparator
+fresh-copy in-process ordering signatures with observation times. The companion comparator
 runs both interpreters in alternating order against those exact seed bytes and
 refuses mismatched reports before calculating a delta.
 
 Run:
-    python tests/comparison/gate_4k.py --repeats 7 --direction
-    python tests/comparison/gate_4k.py --db <seeded.db> --repeats 7
+    python tests/comparison/gate_4k.py --repeats 7 --stability-runs 6 --drift-probe-seconds 8
+    python tests/comparison/gate_4k.py --db <checkpointed.db> --repeats 7
+    python tests/comparison/compare_gate_4k.py --baseline-python <python> \
+        --candidate-python <python> --db <checkpointed.db>
 """
 
 from __future__ import annotations
@@ -287,11 +289,25 @@ def _seed(facts: list[dict], db_path: str):
     gc.collect()
     # The comparator consumes one immutable main file. YantrikDB uses WAL by
     # default, so checkpoint a seed created by this runner before hashing it.
-    con = sqlite3.connect(db_path)
-    try:
-        con.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-    finally:
-        con.close()
+    _checkpoint_seed(Path(db_path))
+
+
+def _checkpoint_seed(db_path: Path, retries: int = 5) -> None:
+    """Checkpoint self-seeded WAL state, verifying SQLite did not report busy."""
+    busy = 1
+    for attempt in range(retries):
+        con = sqlite3.connect(db_path)
+        try:
+            row = con.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        finally:
+            con.close()
+        busy = int(row[0]) if row else 1
+        if busy == 0:
+            return
+        time.sleep(0.05 * (attempt + 1))
+    raise RuntimeError(
+        f"could not checkpoint self-seeded gate database after {retries} attempts "
+        f"(SQLite busy={busy}); close remaining engine handles and retry")
 
 
 def _fresh_copy(base: Path, into: Path) -> Path:
@@ -405,13 +421,6 @@ METRICS = {
     "possessive_jaccard_secondary": _m_possessive_jaccard,
     "direction_separation": _m_direction_separation,
 }
-
-
-def _one_pass(db, unique: list[dict], ambiguous: list[dict],
-              probes: list[dict]) -> dict:
-    """Retained for callers wanting a single instance's full reading."""
-    return {name: fn(db, unique, ambiguous, probes, None)
-            for name, fn in METRICS.items()}
 
 
 def _metric_observation(fn, db, unique, ambiguous, probes,
@@ -578,7 +587,8 @@ def _determinism(base: Path, runs: int = 6, seed_mtime_ns: int = 0,
     """Identical query, identical starting state, fresh copy each time.
 
     A build that answers differently on the same bytes cannot be measured at
-    all, so this runs FIRST and the report says so loudly.
+    all, so the report carries every ordering and the comparator refuses to
+    treat unstable readings as a trustworthy change.
     """
     from yantrikdb._yantrikdb_rust import YantrikDB
     observations, root = [], Path(tempfile.mkdtemp())

--- a/tests/test_comparison_gate_v14_comparator.py
+++ b/tests/test_comparison_gate_v14_comparator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import importlib.util
 import json
+import sqlite3
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -18,6 +19,12 @@ assert _SPEC and _SPEC.loader
 comparator = importlib.util.module_from_spec(_SPEC)
 sys.modules[_SPEC.name] = comparator
 _SPEC.loader.exec_module(comparator)
+
+_GATE_PATH = _ROOT / "tests" / "comparison" / "gate_4k.py"
+_GATE_SPEC = importlib.util.spec_from_file_location("gate_4k_hash_contract", _GATE_PATH)
+assert _GATE_SPEC and _GATE_SPEC.loader
+gate = importlib.util.module_from_spec(_GATE_SPEC)
+_GATE_SPEC.loader.exec_module(gate)
 
 
 def _config():
@@ -44,7 +51,7 @@ def _report(*, arm, seed_sha, signatures, timestamp_offset=0.0):
         "engine": {
             "distribution_version": arm,
             "module_file": f"/{arm}/yantrikdb/__init__.py",
-            "import_source": "wheel",
+            "import_source": "site-packages",
             "wheel_sha256": arm * 8,
             "module_sha256": arm * 16,
             "extension_file": f"/{arm}/yantrikdb/_yantrikdb_rust.so",
@@ -173,6 +180,21 @@ def test_flags_same_version_with_different_native_bytes_without_refusing():
     }
 
 
+def test_refuses_a_same_native_artifact_self_comparison():
+    runs = _paired("a" * 64)
+    for run in runs:
+        run.report["engine"]["extension_sha256"] = "e" * 64
+    with pytest.raises(comparator.ComparisonRefusal, match="self-comparison"):
+        _compare(runs)
+
+
+def test_refuses_a_noncanonical_import_source():
+    runs = _paired("a" * 64)
+    runs[0].report["engine"]["import_source"] = "wheel"
+    with pytest.raises(comparator.ComparisonRefusal, match="import_source is not canonical"):
+        _compare(runs)
+
+
 def test_refuses_bad_signature_counts_and_metric_value_counts():
     runs = _paired("a" * 64)
     runs[0].report["stability"]["signatures"][0]["count"] = 2
@@ -202,7 +224,17 @@ def test_orchestration_alternates_and_guards_the_same_seed(tmp_path):
         db_path=db, gate_path=tmp_path / "gate.py", rounds=2,
         config=_config(), runner=runner)
     assert calls == ["base-python", "candidate-python", "candidate-python", "base-python"]
-    assert result["local_seed_fingerprint_sha256"]
+    assert result["local_seed_fingerprint_sha256"] == seed_sha
+
+
+def test_runner_and_comparator_use_the_same_seed_digest(tmp_path):
+    db = tmp_path / "seed.db"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE memories (created_at REAL)")
+    con.execute("INSERT INTO memories VALUES (1.0)")
+    con.commit()
+    con.close()
+    assert comparator._seed_fingerprint(db) == gate._seed_bytes(db)["sha256"]
 
 
 def test_orchestration_refuses_seed_sidecar_mutation(tmp_path):
@@ -215,8 +247,7 @@ def test_orchestration_refuses_seed_sidecar_mutation(tmp_path):
         return _report(arm=executable, seed_sha=seed_sha,
                        signatures=[_signature("one", [1000.0, 1001.0])])
 
-    with pytest.raises(comparator.ComparisonRefusal,
-                       match="seed changed after round 1 baseline"):
+    with pytest.raises(comparator.ComparisonRefusal, match="non-empty -wal sidecar"):
         comparator.run_comparison(
             baseline_python="baseline", candidate_python="candidate", db_path=db,
             gate_path=tmp_path / "gate.py", rounds=2, config=_config(), runner=runner)
@@ -250,6 +281,24 @@ def test_subprocess_command_forwards_config(monkeypatch, tmp_path):
         "candidate-python", str(gate), "--db", str(db), "--repeats", "3",
         "--determinism-runs", "2", "--drift-probe-seconds", "0"]
     assert captured["kwargs"] == {"check": True, "capture_output": True, "text": True}
+
+
+def test_main_surfaces_the_failed_runners_stderr(monkeypatch, tmp_path, capsys):
+    db = tmp_path / "seed.db"
+    db.write_bytes(b"seed")
+
+    def fail(**kwargs):
+        raise comparator.subprocess.CalledProcessError(
+            2, ["candidate-python", "gate_4k.py"], stderr="checkpoint the WAL first")
+
+    monkeypatch.setattr(comparator, "run_comparison", fail)
+    code = comparator.main([
+        "--baseline-python", "baseline-python",
+        "--candidate-python", "candidate-python",
+        "--db", str(db),
+    ])
+    assert code == 2
+    assert "checkpoint the WAL first" in capsys.readouterr().err
 
 
 def test_at_least_two_rounds_are_required(tmp_path):

--- a/tests/test_comparison_gate_v14_comparator.py
+++ b/tests/test_comparison_gate_v14_comparator.py
@@ -46,6 +46,9 @@ def _report(*, arm, seed_sha, signatures, timestamp_offset=0.0):
             "module_file": f"/{arm}/yantrikdb/__init__.py",
             "import_source": "wheel",
             "wheel_sha256": arm * 8,
+            "module_sha256": arm * 16,
+            "extension_file": f"/{arm}/yantrikdb/_yantrikdb_rust.so",
+            "extension_sha256": arm * 32,
         },
         "host": {"platform": "test", "python": f"python-{arm}"},
         "fixtures": {
@@ -156,6 +159,18 @@ def test_refuses_engine_or_host_instability_within_an_arm():
     with pytest.raises(comparator.ComparisonRefusal,
                        match="baseline engine/host metadata changed"):
         _compare(runs)
+
+
+def test_flags_same_version_with_different_native_bytes_without_refusing():
+    runs = _paired("a" * 64)
+    for run in runs:
+        run.report["engine"]["distribution_version"] = "0.17.1"
+    result = _compare(runs)
+    assert result["artifact_identity"] == {
+        "same_distribution_version": True,
+        "same_native_extension_bytes": False,
+        "warning": "SAME_VERSION_DIFFERENT_NATIVE_BYTES",
+    }
 
 
 def test_refuses_bad_signature_counts_and_metric_value_counts():

--- a/tests/test_comparison_gate_v14_comparator.py
+++ b/tests/test_comparison_gate_v14_comparator.py
@@ -1,0 +1,247 @@
+"""Fast, engine-free tests for the canonical gate v1.4 comparator."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_PATH = _ROOT / "tests" / "comparison" / "compare_gate_4k.py"
+_SPEC = importlib.util.spec_from_file_location("compare_gate_4k_under_test", _PATH)
+assert _SPEC and _SPEC.loader
+comparator = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = comparator
+_SPEC.loader.exec_module(comparator)
+
+
+def _config():
+    return comparator.GateConfig(3, 2, 0)
+
+
+def _signature(name, timestamps):
+    return {
+        "ordering_rids": [f"{name}-rid"],
+        "ordering_texts": [f"{name} text"],
+        "count": len(timestamps),
+        "observed_at_unix": timestamps,
+    }
+
+
+def _report(*, arm, seed_sha, signatures, timestamp_offset=0.0):
+    config = _config()
+    shifted = [{**signature, "observed_at_unix": [value + timestamp_offset
+                                                   for value in signature["observed_at_unix"]]}
+               for signature in signatures]
+    return {
+        "gate": comparator.GATE_NAME,
+        "gate_version": comparator.GATE_VERSION,
+        "engine": {
+            "distribution_version": arm,
+            "module_file": f"/{arm}/yantrikdb/__init__.py",
+            "import_source": "wheel",
+            "wheel_sha256": arm * 8,
+        },
+        "host": {"platform": "test", "python": f"python-{arm}"},
+        "fixtures": {
+            "corpus_sha256": "c" * 64,
+            "queries_sha256": "q" * 64,
+            "probes_sha256": "p" * 64,
+        },
+        "seed": {
+            "path": "/seed.db",
+            "sha256": seed_sha,
+            "bytes": 4,
+            "mtime_unix": 900.0,
+            "created_at_min": 1.0,
+            "created_at_max": 2.0,
+            "record_count": 4353,
+        },
+        "config": config.as_dict(),
+        "observed": {
+            "started_unix": 999.0 + timestamp_offset,
+            "finished_unix": 1005.0 + timestamp_offset,
+            "seed_age_s_at_start": 99.0 + timestamp_offset,
+        },
+        "metrics": {
+            "precision": {
+                "values": [0.1, 0.2, 0.3],
+                "mean": 0.2,
+                "stdev": 0.1,
+                "spread": 0.2,
+                "window": {"t_start_unix": 1000.0, "t_end_unix": 1001.0,
+                           "seed_age_s": 100.0},
+                "burst_span_s": 1.0,
+                "drift_probe": {"before": 0.2, "after": 0.2, "moved": 0.0,
+                                "seconds": 0.0},
+            }
+        },
+        "stability": {
+            "query": config.stability_query,
+            "runs": config.stability_runs,
+            "distinct": len(shifted),
+            "signatures": shifted,
+        },
+        "lexical_degeneracy": {"term": "taylor"},
+    }
+
+
+def _paired(seed_sha):
+    baseline = _report(
+        arm="baseline", seed_sha=seed_sha,
+        signatures=[_signature("shared", [1000.0]), _signature("base", [1001.0])])
+    candidate = _report(
+        arm="candidate", seed_sha=seed_sha,
+        signatures=[_signature("shared", [1000.0]), _signature("candidate", [1001.0])],
+        timestamp_offset=2.5)
+    return [
+        comparator.ArmRun("baseline", 1, baseline),
+        comparator.ArmRun("candidate", 1, candidate),
+        comparator.ArmRun("candidate", 2, copy.deepcopy(candidate)),
+        comparator.ArmRun("baseline", 2, copy.deepcopy(baseline)),
+    ]
+
+
+def _compare(runs):
+    return comparator.compare_reports(
+        runs, expected_config=_config(),
+        process_orders=(("baseline", "candidate"), ("candidate", "baseline")))
+
+
+def test_reports_signature_counts_timestamp_skew_and_metric_ranges():
+    result = _compare(_paired("a" * 64))
+    signatures = result["ordering_signatures"]
+    assert signatures["baseline_only"][0]["baseline_count"] == 2
+    assert signatures["candidate_only"][0]["candidate_count"] == 2
+    assert signatures["shared"][0]["baseline_count"] == 2
+    assert signatures["shared"][0]["candidate_count"] == 2
+    assert [pair["process_order"] for pair in result["paired_runs"]] == [
+        ["baseline", "candidate"], ["candidate", "baseline"]]
+    assert result["paired_runs"][0]["stability_timestamp_skew_s"] == [2.5, 2.5]
+    assert result["metric_ranges"]["precision"] == {
+        "baseline": {"count": 6, "min": 0.1, "max": 0.3,
+                     "range": pytest.approx(0.2)},
+        "candidate": {"count": 6, "min": 0.1, "max": 0.3,
+                      "range": pytest.approx(0.2)},
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda report: report.update(gate_version="1.3.0"), "gate version mismatch"),
+        (lambda report: report["fixtures"].update(corpus_sha256="different"),
+         "fixtures mismatch"),
+        (lambda report: report["seed"].update(sha256="different"),
+         "seed.sha256 mismatch"),
+        (lambda report: report["config"].update(top_k=99), "config mismatch"),
+    ],
+)
+def test_refuses_nonidentical_cross_arm_contract_fields(mutation, message):
+    runs = _paired("a" * 64)
+    mutation(runs[1].report)
+    with pytest.raises(comparator.ComparisonRefusal, match=message):
+        _compare(runs)
+
+
+def test_refuses_engine_or_host_instability_within_an_arm():
+    runs = _paired("a" * 64)
+    runs[-1].report["engine"] = {**runs[-1].report["engine"],
+                                  "module_file": "/changed/yantrikdb/__init__.py"}
+    with pytest.raises(comparator.ComparisonRefusal,
+                       match="baseline engine/host metadata changed"):
+        _compare(runs)
+
+
+def test_refuses_bad_signature_counts_and_metric_value_counts():
+    runs = _paired("a" * 64)
+    runs[0].report["stability"]["signatures"][0]["count"] = 2
+    with pytest.raises(comparator.ComparisonRefusal, match="count does not match"):
+        _compare(runs)
+
+    runs = _paired("a" * 64)
+    runs[0].report["metrics"]["precision"]["values"].pop()
+    with pytest.raises(comparator.ComparisonRefusal, match="values count mismatch"):
+        _compare(runs)
+
+
+def test_orchestration_alternates_and_guards_the_same_seed(tmp_path):
+    db = tmp_path / "seed.db"
+    db.write_bytes(b"seed")
+    seed_sha = comparator._seed_fingerprint(db)
+    calls = []
+
+    def runner(executable, gate_path, db_path, config):
+        calls.append(executable)
+        arm = "baseline" if executable == "base-python" else "candidate"
+        return _report(arm=arm, seed_sha=seed_sha,
+                       signatures=[_signature("one", [1000.0, 1001.0])])
+
+    result = comparator.run_comparison(
+        baseline_python="base-python", candidate_python="candidate-python",
+        db_path=db, gate_path=tmp_path / "gate.py", rounds=2,
+        config=_config(), runner=runner)
+    assert calls == ["base-python", "candidate-python", "candidate-python", "base-python"]
+    assert result["local_seed_fingerprint_sha256"]
+
+
+def test_orchestration_refuses_seed_sidecar_mutation(tmp_path):
+    db = tmp_path / "seed.db"
+    db.write_bytes(b"seed")
+    seed_sha = comparator._seed_fingerprint(db)
+
+    def runner(executable, gate_path, db_path, config):
+        Path(f"{db_path}-wal").write_bytes(b"new WAL")
+        return _report(arm=executable, seed_sha=seed_sha,
+                       signatures=[_signature("one", [1000.0, 1001.0])])
+
+    with pytest.raises(comparator.ComparisonRefusal,
+                       match="seed changed after round 1 baseline"):
+        comparator.run_comparison(
+            baseline_python="baseline", candidate_python="candidate", db_path=db,
+            gate_path=tmp_path / "gate.py", rounds=2, config=_config(), runner=runner)
+
+
+def test_orchestration_refuses_a_report_not_bound_to_the_prelaunch_seed(tmp_path):
+    db = tmp_path / "seed.db"
+    db.write_bytes(b"seed")
+
+    def runner(executable, gate_path, db_path, config):
+        return _report(arm=executable, seed_sha="0" * 64,
+                       signatures=[_signature("one", [1000.0, 1001.0])])
+
+    with pytest.raises(comparator.ComparisonRefusal, match="reported seed SHA"):
+        comparator.run_comparison(
+            baseline_python="baseline", candidate_python="candidate", db_path=db,
+            gate_path=tmp_path / "gate.py", rounds=2, config=_config(), runner=runner)
+
+
+def test_subprocess_command_forwards_config(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured.update(command=command, kwargs=kwargs)
+        return SimpleNamespace(stdout=json.dumps({"gate": comparator.GATE_NAME}))
+
+    monkeypatch.setattr(comparator.subprocess, "run", fake_run)
+    gate, db = tmp_path / "gate.py", tmp_path / "seed.db"
+    comparator._run_gate("candidate-python", gate, db, _config())
+    assert captured["command"] == [
+        "candidate-python", str(gate), "--db", str(db), "--repeats", "3",
+        "--determinism-runs", "2", "--drift-probe-seconds", "0"]
+    assert captured["kwargs"] == {"check": True, "capture_output": True, "text": True}
+
+
+def test_at_least_two_rounds_are_required(tmp_path):
+    db = tmp_path / "seed.db"
+    db.write_bytes(b"seed")
+    with pytest.raises(comparator.ComparisonRefusal, match="at least 2"):
+        comparator.run_comparison(
+            baseline_python="baseline", candidate_python="candidate", db_path=db,
+            gate_path=tmp_path / "gate.py", rounds=1, config=_config(),
+            runner=lambda *args: {})

--- a/tests/test_comparison_gate_v14_runner.py
+++ b/tests/test_comparison_gate_v14_runner.py
@@ -1,0 +1,127 @@
+"""Fast contract tests for the v1.4 comparison-gate evidence envelope."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_RUNNER = _ROOT / "tests" / "comparison" / "gate_4k.py"
+
+
+def _runner_module():
+    spec = importlib.util.spec_from_file_location("gate_4k_v14", _RUNNER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_v14_pins_and_reports_all_three_fixture_hashes():
+    gate = _runner_module()
+    assert gate.GATE_NAME == "hermes-plugin/competing-distractors"
+    assert gate.GATE_VERSION == "1.4.0"
+    assert set(gate.FIXTURE_HASHES) == {
+        "corpus_sha256",
+        "queries_sha256",
+        "probes_sha256",
+    }
+    facts, queries, probes = gate._load()
+    assert facts and queries and probes
+
+
+def test_seed_snapshot_covers_every_sidecar_and_detects_mutation(tmp_path):
+    gate = _runner_module()
+    base = tmp_path / "gate.db"
+    con = sqlite3.connect(base)
+    con.execute("CREATE TABLE memories (created_at REAL)")
+    con.executemany("INSERT INTO memories VALUES (?)", [(1.0,), (2.0,)])
+    con.commit()
+    con.close()
+    (tmp_path / "gate.db-extra").write_bytes(b"aux")
+
+    before = gate._seed_snapshot(base)
+    assert before["bytes"] == base.stat().st_size + 3
+    assert before["record_count"] == 2
+    assert before["created_at_min"] == 1.0
+    assert before["created_at_max"] == 2.0
+    assert {f["name"] for f in before["files"]} == {"gate.db", "gate.db-extra"}
+
+    (tmp_path / "gate.db-extra").write_bytes(b"changed")
+    after = gate._seed_snapshot(base)
+    assert after["sha256"] != before["sha256"]
+
+
+def test_metric_observation_carries_raw_ordering_and_seed_age():
+    gate = _runner_module()
+
+    def metric(_db, _unique, _ambiguous, _probes, trace):
+        trace.extend([
+            {
+                "query": "q",
+                "top_k": 5,
+                "count": 2,
+                "ordering_signature": "a" * 64,
+                "observed_at_unix": 1,
+            },
+            {
+                "query": "q2",
+                "top_k": 3,
+                "count": 1,
+                "ordering_signature": "b" * 64,
+                "observed_at_unix": 2,
+            },
+        ])
+        return 0.5
+
+    value, observation = gate._metric_observation(metric, None, [], [], [], 0)
+    assert value == 0.5
+    assert observation["query_count"] == 2
+    assert observation["result_count"] == 3
+    assert len(observation["ordering_signature"]) == 64
+    assert observation["observed_at_unix"] <= observation["finished_at_unix"]
+    assert observation["seed_age_start_s"] <= observation["seed_age_end_s"]
+
+
+def test_metric_report_contains_the_canonical_v14_fields():
+    gate = _runner_module()
+
+    class FakeDB:
+        def recall_text(self, _query, top_k, namespace):
+            assert namespace == "g"
+            return [{"rid": "r1", "text": "Taylor reports to Carol."}][:top_k]
+
+    unique = [{"query": "Taylor", "target_text": "Taylor reports to Carol."}]
+    probes = [{
+        "entity": "Taylor",
+        "query_possessive": "What is Taylor's role?",
+        "query_plain": "What is Taylor s role?",
+        "query_subject": "Taylor as subject",
+        "query_object": "Taylor as object",
+    }]
+    report = gate._measure_transposed(
+        [FakeDB(), FakeDB()], unique, [], probes,
+        drift_probe_seconds=0, seed_mtime_ns=0)
+    for metric in report.values():
+        assert len(metric["values"]) == 2
+        assert set(metric["window"]) == {"t_start_unix", "t_end_unix", "seed_age_s"}
+        assert {"before", "after", "moved", "seconds"} <= set(metric["drift_probe"])
+        assert len(metric["raw_observations"]) == 2
+        assert all(len(row["ordering_signature"]) == 64
+                   for row in metric["raw_observations"])
+
+
+def test_runner_exposes_reproducibility_knobs_and_drops_stale_v13_advice():
+    src = _RUNNER.read_text(encoding="utf-8")
+    assert "--repeats" in src
+    assert "--stability-runs" in src
+    assert "--determinism-runs" in src
+    assert "--drift-probe-seconds" in src
+    assert "raw_observations" in src
+    assert "seed_age_start_s" in src
+    assert '"gate_version": GATE_VERSION' in src
+    assert '"config": {' in src
+    assert '"stability": determinism' in src
+    assert "drift_sensitive=false" not in src
+    assert "determinism_burst" not in src

--- a/tests/test_comparison_gate_v14_runner.py
+++ b/tests/test_comparison_gate_v14_runner.py
@@ -123,5 +123,8 @@ def test_runner_exposes_reproducibility_knobs_and_drops_stale_v13_advice():
     assert '"gate_version": GATE_VERSION' in src
     assert '"config": {' in src
     assert '"stability": determinism' in src
+    assert '"module_sha256"' in src
+    assert '"extension_sha256"' in src
+    assert '"executable"' in src
     assert "drift_sensitive=false" not in src
     assert "determinism_burst" not in src

--- a/tests/test_comparison_gate_v14_runner.py
+++ b/tests/test_comparison_gate_v14_runner.py
@@ -6,6 +6,8 @@ import importlib.util
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 _ROOT = Path(__file__).resolve().parent.parent
 _RUNNER = _ROOT / "tests" / "comparison" / "gate_4k.py"
 
@@ -31,7 +33,7 @@ def test_v14_pins_and_reports_all_three_fixture_hashes():
     assert facts and queries and probes
 
 
-def test_seed_snapshot_covers_every_sidecar_and_detects_mutation(tmp_path):
+def test_seed_snapshot_hashes_the_checkpointed_main_file_and_detects_mutation(tmp_path):
     gate = _runner_module()
     base = tmp_path / "gate.db"
     con = sqlite3.connect(base)
@@ -39,18 +41,34 @@ def test_seed_snapshot_covers_every_sidecar_and_detects_mutation(tmp_path):
     con.executemany("INSERT INTO memories VALUES (?)", [(1.0,), (2.0,)])
     con.commit()
     con.close()
-    (tmp_path / "gate.db-extra").write_bytes(b"aux")
-
     before = gate._seed_snapshot(base)
-    assert before["bytes"] == base.stat().st_size + 3
+    assert before["bytes"] == base.stat().st_size
     assert before["record_count"] == 2
     assert before["created_at_min"] == 1.0
     assert before["created_at_max"] == 2.0
-    assert {f["name"] for f in before["files"]} == {"gate.db", "gate.db-extra"}
+    assert [f["name"] for f in before["files"]] == ["gate.db"]
 
-    (tmp_path / "gate.db-extra").write_bytes(b"changed")
+    con = sqlite3.connect(base)
+    con.execute("INSERT INTO memories VALUES (3.0)")
+    con.commit()
+    con.close()
     after = gate._seed_snapshot(base)
     assert after["sha256"] != before["sha256"]
+
+
+def test_seed_snapshot_refuses_authoritative_wal_bytes(tmp_path):
+    gate = _runner_module()
+    base = tmp_path / "gate.db"
+    con = sqlite3.connect(base)
+    assert con.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+    con.execute("CREATE TABLE memories (created_at REAL)")
+    con.execute("INSERT INTO memories VALUES (1.0)")
+    con.commit()
+    wal = Path(f"{base}-wal")
+    assert wal.stat().st_size > 0
+    with pytest.raises(SystemExit, match="checkpoint it or use VACUUM INTO"):
+        gate._seed_snapshot(base)
+    con.close()
 
 
 def test_metric_observation_carries_raw_ordering_and_seed_age():
@@ -110,6 +128,19 @@ def test_metric_report_contains_the_canonical_v14_fields():
         assert len(metric["raw_observations"]) == 2
         assert all(len(row["ordering_signature"]) == 64
                    for row in metric["raw_observations"])
+
+
+def test_stability_identity_includes_rids_not_only_duplicate_text():
+    gate = _runner_module()
+    observations = [
+        {"ordering_rids": ["r1"], "ordering_texts": ["same text"],
+         "observed_at_unix": 1.0},
+        {"ordering_rids": ["r2"], "ordering_texts": ["same text"],
+         "observed_at_unix": 2.0},
+    ]
+    grouped = gate._group_stability_observations(observations)
+    assert len(grouped) == 2
+    assert {tuple(row["ordering_rids"]) for row in grouped} == {("r1",), ("r2",)}
 
 
 def test_runner_exposes_reproducibility_knobs_and_drops_stale_v13_advice():

--- a/tests/test_comparison_gate_v14_runner.py
+++ b/tests/test_comparison_gate_v14_runner.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import importlib.util
 import sqlite3
+import sys
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -69,6 +71,79 @@ def test_seed_snapshot_refuses_authoritative_wal_bytes(tmp_path):
     with pytest.raises(SystemExit, match="checkpoint it or use VACUUM INTO"):
         gate._seed_snapshot(base)
     con.close()
+
+
+def test_self_seed_checkpoint_retries_busy_and_requires_success(monkeypatch, tmp_path):
+    gate = _runner_module()
+    rows = iter([(1, 3, 2), (0, 0, 0)])
+    sleeps = []
+
+    class Connection:
+        def __init__(self, row):
+            self.row = row
+
+        def execute(self, statement):
+            assert statement == "PRAGMA wal_checkpoint(TRUNCATE)"
+            return self
+
+        def fetchone(self):
+            return self.row
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(gate.sqlite3, "connect", lambda _path: Connection(next(rows)))
+    monkeypatch.setattr(gate.time, "sleep", sleeps.append)
+    gate._checkpoint_seed(tmp_path / "gate.db", retries=2)
+    assert sleeps == [0.05]
+
+
+def test_self_seed_checkpoint_refuses_permanent_busy(monkeypatch, tmp_path):
+    gate = _runner_module()
+
+    class BusyConnection:
+        def execute(self, _statement):
+            return self
+
+        def fetchone(self):
+            return (1, 3, 0)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(gate.sqlite3, "connect", lambda _path: BusyConnection())
+    monkeypatch.setattr(gate.time, "sleep", lambda _seconds: None)
+    with pytest.raises(RuntimeError, match="SQLite busy=1"):
+        gate._checkpoint_seed(tmp_path / "gate.db", retries=2)
+
+
+def test_import_metadata_must_describe_the_imported_module(monkeypatch, tmp_path):
+    gate = _runner_module()
+    imported = tmp_path / "imported" / "yantrikdb"
+    imported.mkdir(parents=True)
+    module_file = imported / "__init__.py"
+    extension_file = imported / "_yantrikdb_rust.pyd"
+    module_file.write_text("", encoding="utf-8")
+    extension_file.write_bytes(b"native")
+
+    module = ModuleType("yantrikdb")
+    module.__file__ = str(module_file)
+    module._yantrikdb_rust = SimpleNamespace(__file__=str(extension_file))
+    monkeypatch.setitem(sys.modules, "yantrikdb", module)
+
+    class WrongDistribution:
+        version = "0.17.1"
+
+        def read_text(self, _name):
+            return None
+
+        def locate_file(self, _name):
+            return tmp_path / "different-install"
+
+    monkeypatch.setattr(
+        gate.importlib_metadata, "distribution", lambda _name: WrongDistribution())
+    with pytest.raises(SystemExit, match="imported yantrikdb module is outside"):
+        gate._import_metadata(module)
 
 
 def test_metric_observation_carries_raw_ordering_and_seed_age():


### PR DESCRIPTION
## Summary
- upgrade the competing-distractor runner to canonical gate v1.4 with pinned fixture identity, checkpointed seed identity, artifact provenance, raw metric windows, drift observations, and RID+text stability signatures
- add an alternating two-process comparator that refuses incomparable reports before calculating ranges or ordering deltas
- bind every report to the comparator's pre-launch seed bytes and refuse baseline-vs-itself native artifacts

## Review trail
- initial implementation: `353315e`
- additive native artifact identity: `d951039`
- independent review fixes: `7d140c6` (real WAL seeds, stderr propagation, self-comparison refusal, distribution/import cross-check, RID+text grouping, digest equivalence)
- final fold: `5a5f8f5` (verified checkpoint busy handling and distribution-root regression)

Independent review reproduced the original WAL failure against a real engine-style seed, then verified the fixed path accepts a checkpointed seed without creating sidecars and refuses a dirty WAL with actionable guidance.

## Verification
- `41 passed` across the existing gate contract and new v1.4 runner/comparator tests
- Ruff clean
- `git diff --check` clean
- no live benchmark or external model calls

Gate-only change; no plugin release required.