### PR TITLE
release: v0.20.0 — engine 0.18.x admitted, and the gate that admits it no longer measures the clock

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: yantrikdb
-version: 0.19.0
+version: 0.20.0
 # Note: plugin.yaml lives at both the repo root AND yantrikdb/ subfolder. The
 # root copy is the manifest Hermes' user-installed plugin loader reads when a
 # user does `hermes plugins install yantrikos/yantrikdb-hermes-plugin`; the
@@ -7,7 +7,7 @@ version: 0.19.0
 # `yantrikdb-hermes install <hermes>`. Both should declare the same version.
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.18.0
+  - yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.19.0
   - requests>=2.31,<3.0.0
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yantrikdb-hermes-plugin"
-version = "0.19.0"
+version = "0.20.0"
 description = "Self-maintaining memory plugin for Hermes Agent — embedded YantrikDB engine, ~10 MB, no server, no token, no GPU. Canonicalizes duplicates, surfaces contradictions, ranks with recency awareness, and explains recall."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -42,7 +42,7 @@ classifiers = [
 # shipped 2.0.0 against an unbounded pin. tests/test_dependency_pins.py enforces
 # this; raise a ceiling only after testing against the new major.
 dependencies = [
-  "yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.18.0",
+  "yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.19.0",
   "requests>=2.31,<3.0.0",
 ]
 
@@ -156,7 +156,7 @@ exclude = ["reference/", "tests/", "^__init__\\.py$"]
 # matching `## [X.Y.Z] — YYYY-MM-DD — Summary` header. The CI `version-sync`
 # job blocks merge if the three sources drift.
 [tool.bumpversion]
-current_version = "0.19.0"
+current_version = "0.20.0"
 commit = false       # let the human author the commit message + body
 tag = false          # tag via `gh release create`, not on bump
 allow_dirty = true

--- a/tests/comparison/compare_gate_4k.py
+++ b/tests/comparison/compare_gate_4k.py
@@ -28,7 +28,13 @@ _FIXTURE_KEYS = {"corpus_sha256", "queries_sha256", "probes_sha256"}
 _SEED_KEYS = {"path", "sha256", "bytes", "mtime_unix", "created_at_min",
               "created_at_max", "record_count"}
 _CONFIG_KEYS = {"metric_repeats", "stability_runs", "drift_probe_seconds",
-                "top_k", "stability_query"}
+                "top_k", "stability_query", "seed_created_at"}
+
+# v1.5: the instant every seeded row is written at. Both arms must agree on
+# it, because it is what removes the clock from the comparison — see
+# gate_4k.SEED_CREATED_AT. A report that omits it is a v1.4 report and is
+# refused by the key check above rather than silently compared.
+DEFAULT_SEED_CREATED_AT = 1_600_000_000.0
 
 
 class ComparisonRefusal(ValueError):
@@ -42,6 +48,7 @@ class GateConfig:
     drift_probe_seconds: int
     top_k: int = DEFAULT_TOP_K
     stability_query: str = DEFAULT_STABILITY_QUERY
+    seed_created_at: float = DEFAULT_SEED_CREATED_AT
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -50,6 +57,7 @@ class GateConfig:
             "drift_probe_seconds": self.drift_probe_seconds,
             "top_k": self.top_k,
             "stability_query": self.stability_query,
+            "seed_created_at": self.seed_created_at,
         }
 
 
@@ -342,6 +350,35 @@ def compare_reports(runs: Sequence[ArmRun], *, expected_config: GateConfig,
                                f"metrics.{name}")["values"]]
             metric_ranges[name][arm] = _range(values)
 
+    # Per-round, per-repeat-index paired readings.
+    #
+    # `metric_ranges` above aggregates every reading from both rounds, which is
+    # enough to describe a spread but NOT enough to decide an admission: a rule
+    # of the form "candidate >= baseline at every paired repeat index in every
+    # round" cannot be evaluated from a min/max envelope. Emitting the paired
+    # values makes the decision rule computable from the report alone, and
+    # auditable afterwards by someone who was not there.
+    paired_metrics: dict[str, Any] = {}
+    for round_number, pair in sorted(by_round.items()):
+        per_round: dict[str, Any] = {}
+        for name in sorted(metric_names):
+            arm_values = {
+                arm: [float(value) for value in
+                      _mapping(_mapping(pair[arm]["metrics"], "metrics")[name],
+                               f"metrics.{name}")["values"]]
+                for arm in ("baseline", "candidate")
+            }
+            if len(arm_values["baseline"]) != len(arm_values["candidate"]):
+                _refuse(f"round {round_number} metric {name} repeat counts differ: "
+                        f"{len(arm_values['baseline'])} vs {len(arm_values['candidate'])}")
+            deltas = [round(c - b, 12) for b, c in
+                      zip(arm_values["baseline"], arm_values["candidate"], strict=True)]
+            per_round[name] = {"baseline": arm_values["baseline"],
+                               "candidate": arm_values["candidate"],
+                               "delta": deltas,
+                               "min_delta": min(deltas) if deltas else None}
+        paired_metrics[str(round_number)] = per_round
+
     paired_runs = []
     for index, (round_number, pair) in enumerate(sorted(by_round.items())):
         baseline_times = _stability_timestamps(pair["baseline"])
@@ -370,6 +407,7 @@ def compare_reports(runs: Sequence[ArmRun], *, expected_config: GateConfig,
             "candidate_only": partition(candidate_keys - baseline_keys),
             "shared": partition(baseline_keys & candidate_keys, shared=True)},
         "paired_runs": paired_runs, "metric_ranges": metric_ranges,
+        "paired_metrics": paired_metrics,
     }
 
 

--- a/tests/comparison/compare_gate_4k.py
+++ b/tests/comparison/compare_gate_4k.py
@@ -14,8 +14,13 @@ from pathlib import Path
 from typing import Any
 
 GATE_NAME = "hermes-plugin/competing-distractors"
-GATE_VERSION = "1.4.0"
-COMPARATOR_VERSION = "1.4.0"
+# Kept in lockstep with gate_4k.GATE_VERSION on purpose: a report from a
+# different gate version is refused, not compared. The deciding run of the
+# 0.18.0 admission was voided by exactly that check firing on a half-bumped
+# pair, which is the check working — so these two are asserted equal by the
+# gate's own test suite rather than left to be remembered.
+GATE_VERSION = "1.5.0"
+COMPARATOR_VERSION = "1.5.0"
 DEFAULT_TOP_K = 5
 DEFAULT_STABILITY_QUERY = "What is Taylor's role?"
 

--- a/tests/comparison/gate_4k.py
+++ b/tests/comparison/gate_4k.py
@@ -83,7 +83,27 @@ QUERIES = FIXTURES / "queries_1k.json"
 PROBES = FIXTURES / "direction_probes_v1_1.json"
 
 GATE_NAME = "hermes-plugin/competing-distractors"
-GATE_VERSION = "1.4.0"
+GATE_VERSION = "1.5.0"
+
+# Every seeded record is written at ONE fixed historical instant.
+#
+# v1.4 measured a candidate against a baseline and could not tell a real
+# ranking change from the clock: three comparator runs over the SAME seed
+# bytes with the SAME two wheels disagreed with themselves — the baseline
+# alone read direction_separation 0.0625-0.1042, then 0.0347-0.0458, then
+# 0.0458-0.0625. The share metrics are computed over near-tied directional
+# pairs, so one flipped tie moves them by 1/len(rel); and the pair flips
+# because `now()` advances between reads while the two rows sit seconds
+# apart in created_at, which makes their recency terms cross at a
+# sub-epsilon difference in the composite.
+#
+# Writing every row at the same instant removes the term that moves:
+# recency and decay are then identical across candidates at any `now`, so
+# ranking is decided by the geometry the gate exists to measure. The value
+# is far enough in the past that the decay curve is flat there, and it is
+# FIXED so two runs a day apart see the same corpus age relative to each
+# other.
+SEED_CREATED_AT = 1_600_000_000.0  # 2020-09-13T12:26:40Z
 
 # Pinned at gate v1.0.0 and unchanged since. A candidate build must be measured
 # against the same bytes the previous candidate was measured against.
@@ -277,7 +297,15 @@ def _seed(facts: list[dict], db_path: str):
     for f in facts:
         while True:
             try:
-                db.record_text(f["text"], memory_type="semantic", namespace="g")
+                db.record_text(
+                    f["text"],
+                    memory_type="semantic",
+                    namespace="g",
+                    # See SEED_CREATED_AT: identical for every row, so the
+                    # recency and decay terms cannot decide a near-tie and
+                    # the comparison stops depending on when it ran.
+                    created_at=SEED_CREATED_AT,
+                )
                 break
             except Exception as e:  # noqa: BLE001 — backpressure is expected at this rate
                 if "queue full" in str(e) or "Backpressure" in type(e).__name__:
@@ -704,6 +732,7 @@ def main() -> int:
             "drift_probe_seconds": args.drift_probe_seconds,
             "top_k": TOP_K,
             "stability_query": STABILITY_QUERY,
+            "seed_created_at": SEED_CREATED_AT,
         },
         "observed": {
             "started_unix": run_started_at,

--- a/tests/test_comparison_gate_v14_comparator.py
+++ b/tests/test_comparison_gate_v14_comparator.py
@@ -123,6 +123,67 @@ def _compare(runs):
         process_orders=(("baseline", "candidate"), ("candidate", "baseline")))
 
 
+def test_a_complete_1_5_0_report_pair_is_accepted_and_paired_metrics_computable():
+    """The version the runner now emits must actually be consumable.
+
+    The voided 0.18.0 run proved the refusal path works and left the accept
+    path unproven. This pins it: a complete 1.5.0 pair compares, and the
+    per-round, per-index deltas the decision rule reads are present and
+    correctly signed.
+    """
+    result = _compare(_paired("seed-15"))
+    assert result["gate_version"] == "1.5.0"
+    assert set(result["paired_metrics"]) == {"1", "2"}
+    for round_key in ("1", "2"):
+        precision = result["paired_metrics"][round_key]["precision"]
+        assert precision["baseline"] == [0.1, 0.2, 0.3]
+        assert precision["candidate"] == [0.1, 0.2, 0.3]
+        assert precision["delta"] == [0.0, 0.0, 0.0]
+        assert precision["min_delta"] == 0.0
+
+
+def test_paired_metrics_reports_a_per_index_shortfall():
+    """A candidate that is worse at ONE repeat index must show up as such.
+
+    The decision rule is `candidate >= baseline` at every index, so a single
+    low reading has to survive into the report rather than being averaged
+    away by a mean or hidden inside a min/max envelope.
+    """
+    runs = _paired("seed-15")
+    for run in runs:
+        if run.arm == "candidate":
+            run.report["metrics"]["precision"]["values"] = [0.1, 0.05, 0.3]
+    result = _compare(runs)
+    precision = result["paired_metrics"]["1"]["precision"]
+    assert precision["delta"] == [0.0, -0.15, 0.0]
+    assert precision["min_delta"] == -0.15
+    # the envelope alone would not have shown it
+    assert result["metric_ranges"]["precision"]["candidate"]["min"] == 0.05
+
+
+def test_a_1_4_0_report_is_refused_not_compared():
+    runs = _paired("seed-15")
+    runs[0].report["gate_version"] = "1.4.0"
+    with pytest.raises(comparator.ComparisonRefusal, match="gate version mismatch"):
+        _compare(runs)
+
+
+def test_mixed_gate_versions_across_rounds_are_refused():
+    """Round 1 on one gate version and round 2 on another is not a comparison."""
+    runs = _paired("seed-15")
+    runs[3].report["gate_version"] = "1.4.0"
+    with pytest.raises(comparator.ComparisonRefusal, match="gate version mismatch"):
+        _compare(runs)
+
+
+def test_a_report_without_seed_created_at_is_refused():
+    """A v1.4-shaped config cannot be silently compared against v1.5."""
+    runs = _paired("seed-15")
+    del runs[1].report["config"]["seed_created_at"]
+    with pytest.raises(comparator.ComparisonRefusal):
+        _compare(runs)
+
+
 def test_comparator_and_runner_pin_the_same_gate_version():
     """A half-bumped pair refuses every report instead of comparing.
 

--- a/tests/test_comparison_gate_v14_comparator.py
+++ b/tests/test_comparison_gate_v14_comparator.py
@@ -123,6 +123,17 @@ def _compare(runs):
         process_orders=(("baseline", "candidate"), ("candidate", "baseline")))
 
 
+def test_comparator_and_runner_pin_the_same_gate_version():
+    """A half-bumped pair refuses every report instead of comparing.
+
+    The 0.18.0 deciding run was voided this way: the runner said 1.5.0 while
+    the comparator still expected 1.4.0. The check was right; nothing was
+    keeping the two constants together.
+    """
+    assert comparator.GATE_VERSION == gate.GATE_VERSION
+    assert comparator.COMPARATOR_VERSION == gate.GATE_VERSION
+
+
 def test_reports_signature_counts_timestamp_skew_and_metric_ranges():
     result = _compare(_paired("a" * 64))
     signatures = result["ordering_signatures"]

--- a/tests/test_comparison_gate_v14_runner.py
+++ b/tests/test_comparison_gate_v14_runner.py
@@ -25,7 +25,7 @@ def _runner_module():
 def test_v14_pins_and_reports_all_three_fixture_hashes():
     gate = _runner_module()
     assert gate.GATE_NAME == "hermes-plugin/competing-distractors"
-    assert gate.GATE_VERSION == "1.4.0"
+    assert gate.GATE_VERSION == "1.5.0"
     assert set(gate.FIXTURE_HASHES) == {
         "corpus_sha256",
         "queries_sha256",

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+### Gate v1.5.0 — the 4k comparison gate no longer measures the clock
+
+v1.4 could not tell a ranking change from the time of day. Three comparator runs over the same
+seed bytes with the same two wheels disagreed with themselves: the baseline alone read
+`direction_separation` 0.06250–0.10417, then 0.03472–0.04583, then 0.04583–0.06250. Both
+affected metrics are share statistics over near-tied directional pairs, so one flipped tie
+moves them by `1/len(rel)` — and the pair flips because two rows sit seconds apart in
+`created_at` while `now()` advances between reads.
+
+Every seeded row is now written at one fixed historical instant, which removes the term that
+moved. Validated: the same engine, three runs, one seed → all five metrics byte-identical, and
+`stability.distinct` 2 → 1. The comparator additionally emits `paired_metrics` (per round, per
+metric, per-index deltas), because a rule of the form "candidate ≥ baseline at every paired
+index" cannot be evaluated from a min/max envelope, and a rule that cannot be evaluated is not
+a rule. `seed_created_at` joins the canonical config, so a v1.4 report is refused rather than
+silently compared, and the runner and comparator versions are now asserted equal by the suite.
+
 ## [0.20.0] — 2026-08-26 — engine 0.18.x admitted
 Pin: `yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.19.0` (was `<0.18.0`). No plugin code change.
 
@@ -10,23 +27,24 @@ Engine 0.18.0 is additive (pack substrate: structured `hit["pack"]` provenance, 
 settings on `mounted_packs()`, `pack_context_for`, `recall_from_packs_for`, `PackNotMounted`).
 The plugin does not use the new surfaces yet.
 
-Admission by gate v1.4 (`tests/comparison/compare_gate_4k.py`, LXC hermes-lab, one
-checkpointed seed `58e3725f…`, baseline PyPI 0.17.1 vs candidate 0.18.0 wheel
-`f50eebb4…`, 2 rounds × 7 repeats, alternating process order, 6 stability opens per arm
-per round; comparator exit 0, no identity refusal, distinct native bytes):
+Admission by **gate v1.5.0** under a preregistration frozen before the data were opened
+(criterion, frozen inputs, tolerance and decision rule reviewed by the engine reviewer in
+advance). Baseline PyPI 0.17.1 vs the 0.18.0 release wheel `9052a0d1…`, one checkpointed
+seed built by the baseline engine, 2 rounds × 7 repeats, alternating process order, 6
+stability opens per arm per round, comparator exit 0, no identity refusal, distinct native
+bytes:
 
-| metric (14 readings/arm) | 0.17.1 | 0.18.0 |
-|---|---|---|
-| precision@5 (unique answers) | 0.5 / 0.5 | 0.5 / 0.5 |
-| possessive top-1 agreement | 0.9167 | 0.9167 |
-| possessive Jaccard (secondary) | 0.9444 | 0.9444 |
-| direction separation (min–max) | 0.025–0.0625 | 0.0347–0.0625 |
-| role share, ambiguous queries (min–max) | 0.5625–0.625 | 0.5625–0.625 |
+Every one of the five metrics was **exactly equal** across the arms at every paired repeat
+index in both rounds — `min_delta = +0.0` for all 5 × 7 × 2 readings, no violations. Ordering
+signatures: candidate-only = ∅, baseline-only = ∅, and a **single** shared ordering (baseline
+12 / candidate 12), i.e. every cold open in both arms returned the same order. Plugin suite on
+the candidate engine: 494 passed, 3 skipped, 2 xfailed — identical to the baseline reference
+recorded in the same environment.
 
-Ordering signatures: candidate-only = ∅, baseline-only = ∅; both arms produce the same two
-known orderings (the "Taylor reports to Pat." / "Pat reports to Taylor." recency tie-crossing,
-baseline 9/3, candidate 8/4 of 12 opens). No category negative. Plugin suite on the candidate
-engine: 488 passed, 3 skipped, 2 xfailed.
+**Scope of that result.** Gate v1.5 seeds every row at one fixed historical instant, so decay
+and recency contribute identically to every candidate. It measures retrieval geometry and
+ordering containment **with recency held constant**, and is not evidence that time-sensitive
+ranking is stable; that needs its own clock-controlled test.
 
 ## [0.19.0] — 2026-08-25 — engine 0.16.x and 0.17.x admitted
 

--- a/yantrikdb/CHANGELOG.md
+++ b/yantrikdb/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to the YantrikDB Hermes memory plugin.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); semantic versioning. Distributed standalone per Hermes maintainer guidance (PR #9989 closed 2026-05-13).
 
+## [0.20.0] — 2026-08-26 — engine 0.18.x admitted
+Pin: `yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.19.0` (was `<0.18.0`). No plugin code change.
+
+Engine 0.18.0 is additive (pack substrate: structured `hit["pack"]` provenance, signed
+settings on `mounted_packs()`, `pack_context_for`, `recall_from_packs_for`, `PackNotMounted`).
+The plugin does not use the new surfaces yet.
+
+Admission by gate v1.4 (`tests/comparison/compare_gate_4k.py`, LXC hermes-lab, one
+checkpointed seed `58e3725f…`, baseline PyPI 0.17.1 vs candidate 0.18.0 wheel
+`f50eebb4…`, 2 rounds × 7 repeats, alternating process order, 6 stability opens per arm
+per round; comparator exit 0, no identity refusal, distinct native bytes):
+
+| metric (14 readings/arm) | 0.17.1 | 0.18.0 |
+|---|---|---|
+| precision@5 (unique answers) | 0.5 / 0.5 | 0.5 / 0.5 |
+| possessive top-1 agreement | 0.9167 | 0.9167 |
+| possessive Jaccard (secondary) | 0.9444 | 0.9444 |
+| direction separation (min–max) | 0.025–0.0625 | 0.0347–0.0625 |
+| role share, ambiguous queries (min–max) | 0.5625–0.625 | 0.5625–0.625 |
+
+Ordering signatures: candidate-only = ∅, baseline-only = ∅; both arms produce the same two
+known orderings (the "Taylor reports to Pat." / "Pat reports to Taylor." recency tie-crossing,
+baseline 9/3, candidate 8/4 of 12 opens). No category negative. Plugin suite on the candidate
+engine: 488 passed, 3 skipped, 2 xfailed.
+
 ## [0.19.0] — 2026-08-25 — engine 0.16.x and 0.17.x admitted
 
 Pin: `yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.18.0` (was `<0.16.0`). Same change in

--- a/yantrikdb/plugin.yaml
+++ b/yantrikdb/plugin.yaml
@@ -1,8 +1,8 @@
 name: yantrikdb
-version: 0.19.0
+version: 0.20.0
 description: "YantrikDB — self-maintaining memory for Hermes with canonicalization, contradiction tracking, recency-aware ranking, explainable recall, and pluggable embedders (bundled potion-2M default; first-class loaders for the model2vec family and the HF sentence-transformers ecosystem; custom Python embedder class as escape hatch). As of v0.2.0 the default backend is in-process (`pip install` and go); HTTP-to-server is optional for HA cluster setups."
 pip_dependencies:
-  - yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.18.0
+  - yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.19.0
   - requests>=2.31,<3.0.0
 hooks:
   - on_session_end


### PR DESCRIPTION
Two things that belong together: the engine 0.18.x pin lift, and the gate fix that made its admission mean something.

## The gate could not tell a ranking change from the time of day

Three comparator runs over the **same seed bytes** with the **same two wheels** disagreed with themselves — the baseline alone read `direction_separation` 0.06250–0.10417, then 0.03472–0.04583, then 0.04583–0.06250, and a candidate `role_share` dip appeared twice and vanished once.

`_m_role_share` and `_m_direction_separation` are share statistics over the returned "X reports to Y" set, so one flipped near-tie moves them by `1/len(rel)`. The pair flips because two rows sit seconds apart in `created_at` while `now()` advances between reads, crossing them sub-epsilon in the composite. A metric that contradicts itself on identical inputs cannot support an admission **or** a rejection.

**v1.5.0**: every seeded row is written at one fixed historical instant, so decay and recency contribute identically to every candidate. Validated — the same engine, three runs, one seed → all five metrics byte-identical, and `stability.distinct` 2 → 1.

Also: the comparator emits `paired_metrics` (per round, per metric, per-index deltas), because "candidate ≥ baseline at every paired index" cannot be evaluated from a min/max envelope; `seed_created_at` joins the canonical config so a v1.4 report is refused rather than silently compared; and the runner/comparator versions are asserted equal by the suite after a half-bumped pair voided a release gate run.

**Scope, which must travel with any citation:** this measures retrieval geometry and ordering containment **with recency held constant**. It is not evidence that time-sensitive ranking is stable — that needs its own clock-controlled test.

## Engine 0.18.x admitted

Pin `yantrikdb>=0.12.1,!=0.15.0,!=0.15.1,!=0.15.2,<0.19.0` (was `<0.18.0`). No plugin code change; the plugin does not use the new pack surfaces yet.

Admission ran under a preregistration frozen before the data were opened, reviewed in advance. Result: every metric **exactly equal** at every paired repeat index in both rounds (`min_delta = +0.0` across 5 × 7 × 2, no violations); ordering signatures candidate-only ∅, baseline-only ∅, a **single** shared ordering (baseline 12 / candidate 12); plugin suite 494 passed / 3 skipped / 2 xfailed on the candidate engine, identical to the baseline reference recorded in the same environment.

Gate suite 494 passed, ruff clean.